### PR TITLE
fix: reviewer checks show red on FAIL + verdict job checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -141,3 +141,15 @@ runs:
         name: cerberus-verdict-${{ inputs.perspective }}
         path: /tmp/${{ inputs.perspective }}-verdict.json
         retention-days: 1
+
+    - name: Enforce verdict
+      if: steps.parse.outcome == 'success'
+      shell: bash
+      env:
+        VERDICT: ${{ steps.parse.outputs.verdict }}
+        PERSPECTIVE: ${{ inputs.perspective }}
+      run: |
+        if [ "$VERDICT" = "FAIL" ]; then
+          echo "::error::${PERSPECTIVE} review verdict: FAIL"
+          exit 1
+        fi

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -18,6 +18,11 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: .
+
     - name: Download verdict artifacts
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
## Problem

Two bugs in the Cerberus GitHub Action:

### Bug 1: Reviewer checks always show green ✅ even on FAIL
Individual reviewer jobs (APOLLO, SENTINEL, etc.) always showed green checkmarks in GitHub regardless of their actual verdict. A reviewer could return FAIL but the GitHub check would still show ✅.

**Cause:** The action set the verdict as an output but never exited non-zero.

**Fix:** Added an 'Enforce verdict' step that exits with code 1 when verdict is FAIL. Now:
- PASS → ✅ green check
- WARN → ✅ green check (warnings are informational, not blocking)
- FAIL → ❌ red cross

### Bug 2: Council Verdict fails with 'not a git repository'
The verdict job failed on every repo with:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

**Cause:** The `gh` CLI tries to initialize git context on startup. The verdict job had no `actions/checkout` step, so there was no git repo.

**Fix:** Added `actions/checkout@v4` with `sparse-checkout: .` (minimal checkout just for gh CLI context).

## Testing
Test on brainrot PR #321 and moneta after merging — both have active Cerberus integration PRs.