### PR TITLE
fix: P0 security — enforce override actor auth + fork PR guard

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,17 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Check fork safety
+      shell: bash
+      env:
+        HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        BASE_REPO: ${{ github.repository }}
+      run: |
+        if [[ -n "$HEAD_REPO" && "$HEAD_REPO" != "$BASE_REPO" ]]; then
+          echo "::error::Cerberus does not run on fork PRs to protect secrets. Use pull_request trigger (not pull_request_target) and gate on same-repo PRs."
+          exit 1
+        fi
+
     - name: Validate perspective
       shell: bash
       env:

--- a/scripts/aggregate-verdict.py
+++ b/scripts/aggregate-verdict.py
@@ -65,9 +65,7 @@ def parse_override(raw: str | None, head_sha: str | None) -> dict | None:
 
 def validate_actor(actor: str, policy: str, pr_author: str | None) -> bool:
     if policy == "pr_author":
-        return bool(pr_author) and actor == pr_author
-    if policy in {"write_access", "maintainers_only"}:
-        return True
+        return bool(pr_author) and actor.lower() == pr_author.lower()
     return False
 
 

--- a/templates/consumer-workflow.yml
+++ b/templates/consumer-workflow.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   review:
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: "${{ matrix.reviewer }}"
     runs-on: ubuntu-latest
     strategy:

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -42,7 +42,11 @@ runs:
           echo "::warning::Failed to fetch override comments: $OVERRIDE"
           OVERRIDE=""
         fi
-        echo "override=${OVERRIDE}" >> "$GITHUB_OUTPUT"
+        {
+          echo "override<<CERBERUS_OVERRIDE_EOF"
+          echo "$OVERRIDE"
+          echo "CERBERUS_OVERRIDE_EOF"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Aggregate verdicts
       id: aggregate


### PR DESCRIPTION
## Summary

- **Enforce override actor authorization** (#3): `aggregate-verdict.py` validates the `/council override` comment actor against the `pr_author` policy. Case-insensitive comparison. Fails closed on missing PR author or unknown policy.
- **Gate consumer workflow on same-repo PRs** (#2): Fork PRs blocked from review jobs. Guard also added to `action.yml` itself (defense-in-depth).
- **#1 already mitigated**: Composite action uses `env:` vars. No `${{ }}` in `run:` blocks.
- **Review hardening**: Removed stub `write_access`/`maintainers_only` policies that returned `True` unconditionally. Used heredoc delimiter for GITHUB_OUTPUT.

## Deferred findings (issues filed)

- #24 Per-reviewer override policies from config.yml
- #25 Override comment selector picks last match instead of first authorized
- #26 Use mktemp for temporary files instead of fixed /tmp/ paths

## Test plan

- [x] 31/31 tests pass (pytest tests/ -v)
- [x] 19 aggregate-verdict tests (10 for actor auth)
- [x] shellcheck clean, py_compile clean

Closes #1, #2, #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Policy-based authorization for verdict overrides with safer validation and warnings when an override is rejected.
  * Fork-safety gate preventing checks from running on forked PRs and restricting review jobs to same-repo PRs.

* **Tests**
  * Expanded test coverage for override authorization across policies, case-insensitive author matching, and related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->