### PR TITLE
fix: prevent shell metacharacter injection in council verdict comment

### DIFF
--- a/scripts/post-comment.sh
+++ b/scripts/post-comment.sh
@@ -130,7 +130,7 @@ existing_id="$(
 )"
 
 if [[ -n "$existing_id" ]]; then
-  gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" -X PATCH -f body="$(cat "$comment_file")" >/dev/null
+  gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" -X PATCH -F body=@"$comment_file" >/dev/null
 else
   gh pr comment "$PR_NUMBER" --body-file "$comment_file" >/dev/null
 fi

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -97,7 +97,7 @@ runs:
 
         EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '.[] | select(.body | contains("cerberus:council")) | .id' 2>/dev/null | head -1) || true
         if [ -n "$EXISTING" ]; then
-          gh api "repos/${REPO}/issues/comments/${EXISTING}" -X PATCH -f body="$(cat /tmp/council-comment.md)" >/dev/null
+          gh api "repos/${REPO}/issues/comments/${EXISTING}" -X PATCH -F body=@/tmp/council-comment.md >/dev/null
         else
           gh pr comment "$PR_NUMBER" --body-file /tmp/council-comment.md >/dev/null
         fi


### PR DESCRIPTION
## Summary

Fixes shell metacharacter injection vulnerability in the council verdict comment posting.

### Problem
The `gh api` command was using `-f body="$(cat /tmp/council-comment.md)"` which expands shell metacharacters through command substitution. If the LLM summary contains backticks or `$()`, they would be executed during command substitution.

### Fix
Changed to use `-F body=@/tmp/council-comment.md` which reads the file content safely without shell expansion.

### Files Changed
- `verdict/action.yml`: Fixed the council verdict comment update
- `scripts/post-comment.sh`: Fixed the individual reviewer comment update (same issue)

### Security Impact
This prevents arbitrary code execution if LLM-generated content contains malicious shell metacharacters.