### PR TITLE
feat: confidence-aware reviewer and council verdict thresholds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,10 @@ Shell access is toggled per agent via `exclude_tools` in the YAML config.
 
 ## Verdict Logic
 
-Each reviewer emits: `FAIL` (any critical OR 2+ major) | `WARN` (1 major OR 3+ minor) | `PASS`.
+Each reviewer emits: `FAIL` (any critical OR 2+ major) | `WARN` (1 major OR 5+ minor OR 3+ minor in same category) | `PASS`.
+Only findings from reviews with confidence >= 0.7 count toward these thresholds.
 
-Council: `FAIL` if any reviewer FAILs (unless overridden) | `WARN` if any warns | `PASS` otherwise.
+Council: `FAIL` on a critical reviewer FAIL or 2+ reviewer FAILs (unless overridden) | `WARN` on any WARN or a single non-critical FAIL | `PASS` otherwise.
 
 Override: `/council override sha=<sha>` comment on PR with reason. SHA must match HEAD. Actor constraints per `defaults/config.yml`.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
 2. KimiCode CLI (Kimi K2.5) analyzes the PR diff from each perspective
 3. Each reviewer posts a structured comment with findings
 4. The verdict job aggregates all reviews into a council decision
-5. Council verdict: **FAIL** if any reviewer fails, **WARN** if any warns, **PASS** otherwise
+5. Council verdict: **FAIL** on critical fail or 2+ fails, **WARN** on warnings or a single non-critical fail, **PASS** otherwise
 
 ## Inputs
 ### Review Action (`misty-step/cerberus@v1`)
@@ -97,12 +97,13 @@ jobs:
 ## Verdict Rules
 Each reviewer emits:
 - **FAIL**: any critical finding OR 2+ major findings
-- **WARN**: exactly 1 major OR 3+ minor findings
+- **WARN**: exactly 1 major OR 5+ minor findings OR 3+ minor findings in the same category
 - **PASS**: otherwise
+- Only findings from reviews with confidence **>= 0.7** count toward verdict thresholds.
 
 Council:
-- **FAIL**: any reviewer FAILs (unless overridden)
-- **WARN**: any reviewer WARNs
+- **FAIL**: any critical reviewer FAIL OR 2+ reviewer FAILs (unless overridden)
+- **WARN**: any reviewer WARN OR a single non-critical reviewer FAIL
 - **PASS**: all reviewers pass
 
 ## Override Protocol

--- a/agents/architecture-prompt.md
+++ b/agents/architecture-prompt.md
@@ -86,8 +86,9 @@ Output Format
 - confidence is 0.0 to 1.0.
 - Apply verdict rules:
 - FAIL: any critical OR 2+ major findings
-- WARN: exactly 1 major OR 3+ minor findings
+- WARN: exactly 1 major OR 5+ minor findings OR 3+ minor findings in same category
 - PASS: everything else
+- Only findings from reviews with confidence >= 0.7 count toward verdict thresholds.
 - Do not report findings with confidence below 0.6.
 - Set confidence to your actual confidence level. Do not default to 0.85.
 

--- a/agents/correctness-prompt.md
+++ b/agents/correctness-prompt.md
@@ -83,8 +83,9 @@ Output Format
 - confidence is 0.0 to 1.0.
 - Apply verdict rules:
 - FAIL: any critical OR 2+ major findings
-- WARN: exactly 1 major OR 3+ minor findings
+- WARN: exactly 1 major OR 5+ minor findings OR 3+ minor findings in same category
 - PASS: everything else
+- Only findings from reviews with confidence >= 0.7 count toward verdict thresholds.
 - Do not report findings with confidence below 0.6.
 - Set confidence to your actual confidence level. Do not default to 0.85.
 

--- a/agents/maintainability-prompt.md
+++ b/agents/maintainability-prompt.md
@@ -91,8 +91,9 @@ Output Format
 - confidence is 0.0 to 1.0.
 - Apply verdict rules:
 - FAIL: any critical OR 2+ major findings
-- WARN: exactly 1 major OR 3+ minor findings
+- WARN: exactly 1 major OR 5+ minor findings OR 3+ minor findings in same category
 - PASS: everything else
+- Only findings from reviews with confidence >= 0.7 count toward verdict thresholds.
 - Do not report findings with confidence below 0.6.
 - Set confidence to your actual confidence level. Do not default to 0.85.
 

--- a/agents/performance-prompt.md
+++ b/agents/performance-prompt.md
@@ -89,8 +89,9 @@ Output Format
 - confidence is 0.0 to 1.0.
 - Apply verdict rules:
 - FAIL: any critical OR 2+ major findings
-- WARN: exactly 1 major OR 3+ minor findings
+- WARN: exactly 1 major OR 5+ minor findings OR 3+ minor findings in same category
 - PASS: everything else
+- Only findings from reviews with confidence >= 0.7 count toward verdict thresholds.
 - Do not report findings with confidence below 0.6.
 - Set confidence to your actual confidence level. Do not default to 0.85.
 

--- a/agents/security-prompt.md
+++ b/agents/security-prompt.md
@@ -91,8 +91,9 @@ Output Format
 - confidence is 0.0 to 1.0.
 - Apply verdict rules:
 - FAIL: any critical OR 2+ major findings
-- WARN: exactly 1 major OR 3+ minor findings
+- WARN: exactly 1 major OR 5+ minor findings OR 3+ minor findings in same category
 - PASS: everything else
+- Only findings from reviews with confidence >= 0.7 count toward verdict thresholds.
 - Do not report findings with confidence below 0.6.
 - Set confidence to your actual confidence level. Do not default to 0.85.
 

--- a/defaults/config.yml
+++ b/defaults/config.yml
@@ -24,7 +24,11 @@ override:
 # Verdict rules
 verdict:
   fail_on: "any_critical_or_2_major"  # any_critical | any_critical_or_2_major | any_major
-  warn_on: "any_major_or_3_minor"     # any_major | any_major_or_3_minor | any_minor
+  warn_on: "any_major_or_5_minor_or_3_minor_same_category"  # any_major | any_major_or_5_minor_or_3_minor_same_category
+  confidence_min: 0.7
+
+council_verdict:
+  fail_on: "any_critical_fail_or_2_fails"  # single non-critical FAIL is downgraded to WARN
 
 # The five heads of Cerberus.
 # Names are cosmetic — perspective determines behavior.


### PR DESCRIPTION
## Summary
Implements issue #11 by tightening reviewer verdict thresholds, adding confidence-aware gating, and reducing false-positive merge blocks at council level.

## Product Spec
- Reviewer verdict thresholds:
  - FAIL: any critical OR 2+ major findings.
  - WARN: exactly 1 major OR 5+ minor findings OR 3+ minor findings in the same category.
  - PASS: otherwise.
- Confidence gate:
  - Only findings from reviews with confidence >= 0.7 count toward verdict thresholds.
- Council verdict threshold:
  - FAIL on any critical reviewer FAIL or 2+ reviewer FAILs.
  - WARN on reviewer WARN or a single non-critical FAIL.
  - PASS otherwise.

## Technical Design
- `scripts/parse-review.py`
  - Recompute verdict with confidence gate and new minor-threshold logic.
  - Preserve SKIP verdicts from recompute.
- `scripts/aggregate-verdict.py`
  - Evaluate fail evidence from `stats/findings`.
  - Treat single explicit non-critical FAIL as WARN at council layer.
  - Keep conservative blocking behavior when fail evidence is missing.
- Sync policy docs and reviewer prompt rules in:
  - `README.md`, `CLAUDE.md`, `defaults/config.yml`, `agents/*-prompt.md`.

## Validation
- `python3 -m pytest tests/ -q`
- Result: `131 passed`

Closes #11
