### PR TITLE
fix(release): add semantic-release config for non-Node project

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,26 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": []
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Fixes Landfall release workflow failure caused by missing package.json. Adds .releaserc.json that excludes @semantic-release/npm plugin since this is not a Node.js project.