### PR TITLE
fix: graceful reviewer timeout handling with explicit SKIP verdicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          timeout: '600'
+          timeout: '120'
 
   verdict:
     name: "Council Verdict"
@@ -103,7 +103,7 @@ Use `templates/triage-workflow.yml` to enable:
 | `kimi-base-url` | no | `https://api.moonshot.ai/v1` | API base URL |
 | `model` | no | `kimi-k2.5` | Model name |
 | `max-steps` | no | `25` | Max agentic steps |
-| `timeout` | no | `600` | Review timeout in seconds |
+| `timeout` | no | `120` | Review timeout in seconds (per reviewer job) |
 | `kimi-cli-version` | no | `1.8.0` | KimiCode CLI version |
 | `post-comment` | no | `true` | Post review comment |
 

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: '25'
   timeout:
     description: 'Review timeout in seconds'
-    default: '600'
+    default: '120'
   kimi-cli-version:
     description: 'KimiCode CLI version to install'
     default: '1.8.0'
@@ -191,5 +191,5 @@ runs:
           exit 1
         fi
         if [ "$VERDICT" = "SKIP" ]; then
-          echo "::warning::${PERSPECTIVE} review verdict: SKIP (API error)"
+          echo "::warning::${PERSPECTIVE} review verdict: SKIP (timeout/API error)"
         fi

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@ Cerberus is agentic DevOps composed from distinct, focused modules. Each module 
 ## v1.0 Game Plan (Council Review Polish)
 
 ### Phase 1: Resilience (P0)
-- [ ] Timeout handling: per-reviewer timeouts with graceful degradation
+- [x] Timeout handling: per-reviewer timeouts with graceful degradation
 - [ ] API failure handling: retry with backoff, skip reviewer on persistent failure
 - [ ] Credit/token exhaustion: detect 402/429 errors, degrade gracefully, alert
 - [ ] Multi-provider fallback: if primary API fails, try secondary

--- a/templates/consumer-workflow.yml
+++ b/templates/consumer-workflow.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          timeout: '600'
+          timeout: '120'
 
   verdict:
     name: "Council Verdict"

--- a/templates/triage-workflow.yml
+++ b/templates/triage-workflow.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          timeout: '600'
+          timeout: '120'
 
   verdict:
     name: "Council Verdict"

--- a/tests/test_aggregate_verdict.py
+++ b/tests/test_aggregate_verdict.py
@@ -1012,6 +1012,25 @@ class TestSkipVerdicts:
         data = json.loads(Path("/tmp/council-verdict.json").read_text())
         assert "skipped: 1" in data["summary"]
 
+    def test_timeout_skips_are_named_in_summary(self, tmp_path):
+        (tmp_path / "apollo.json").write_text(
+            json.dumps(
+                {
+                    "reviewer": "APOLLO",
+                    "perspective": "correctness",
+                    "verdict": "SKIP",
+                    "summary": "Review skipped due to timeout after 120s.",
+                }
+            )
+        )
+        (tmp_path / "athena.json").write_text(
+            json.dumps({"reviewer": "ATHENA", "perspective": "architecture", "verdict": "PASS", "summary": "Good."})
+        )
+        code, out, _ = run_aggregate(str(tmp_path))
+        assert code == 0
+        data = json.loads(Path("/tmp/council-verdict.json").read_text())
+        assert "Timed out reviewers: APOLLO." in data["summary"]
+
     def test_all_four_verdict_types_in_stats(self, tmp_path):
         """Stats should include all four verdict types."""
         (tmp_path / "pass.json").write_text(

--- a/tests/test_parse_review.py
+++ b/tests/test_parse_review.py
@@ -793,6 +793,19 @@ Please retry after some time.
         assert data["verdict"] == "SKIP"
         assert "RATE_LIMIT" in data["summary"]
 
+    def test_detects_timeout_marker(self):
+        timeout_text = """Review Timeout: timeout after 120s
+
+APOLLO (correctness) exceeded the configured timeout.
+"""
+        code, out, err = run_parse(timeout_text, env_extra={"REVIEWER_NAME": "APOLLO"})
+        assert code == 0
+        data = json.loads(out)
+        assert data["verdict"] == "SKIP"
+        assert data["reviewer"] == "APOLLO"
+        assert "timeout after 120s" in data["summary"]
+        assert data["findings"][0]["category"] == "timeout"
+
     def test_skip_stats_are_zero(self):
         error_text = """API Error: API_ERROR
 

--- a/tests/test_run_reviewer_runtime.py
+++ b/tests/test_run_reviewer_runtime.py
@@ -61,7 +61,7 @@ def write_simple_diff(path: Path) -> None:
 @pytest.fixture(autouse=True)
 def cleanup_tmp_outputs() -> None:
     """Keep /tmp artifacts from one test from leaking into others."""
-    suffixes = ("parse-input", "output.txt", "stderr.log", "exitcode", "review.md")
+    suffixes = ("parse-input", "output.txt", "stderr.log", "exitcode", "review.md", "timeout-marker.txt")
     for perspective in PERSPECTIVES:
         for suffix in suffixes:
             Path(f"/tmp/{perspective}-{suffix}").unlink(missing_ok=True)
@@ -239,4 +239,9 @@ def test_timeout_with_partial_output_exits_zero(tmp_path: Path) -> None:
         timeout=30,
     )
     assert result.returncode == 0
-    assert "timeout: content available, proceeding to parse" in result.stdout
+    assert "timeout: forcing SKIP parse path" in result.stdout
+    parse_input_ref = Path("/tmp/security-parse-input")
+    assert parse_input_ref.exists()
+    parse_file = Path(parse_input_ref.read_text().strip())
+    content = parse_file.read_text()
+    assert "Review Timeout: timeout after 5s" in content

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -135,6 +135,6 @@ runs:
           exit 1
         fi
         if [ "$VERDICT" = "SKIP" ]; then
-          echo "::notice::Council Verdict: SKIP (all reviews skipped due to API errors)"
+          echo "::notice::Council Verdict: SKIP (all reviews skipped due to timeout/API errors)"
           exit 0
         fi


### PR DESCRIPTION
## Summary
- convert reviewer runtime timeouts into deterministic SKIP parse input markers instead of partial PASS/WARN parsing
- parse timeout markers in `parse-review.py` and emit `SKIP` with reason `timeout after <seconds>s`
- include timed-out reviewer names in council summary so PR comments show who timed out
- reduce default review timeout to 120 seconds across action defaults and workflow/docs templates
- add regression tests for runtime timeout marker emission, timeout parser behavior, and council timeout summary

## Validation
- python3 -m pytest tests/test_run_reviewer_runtime.py tests/test_parse_review.py tests/test_aggregate_verdict.py -q
- python3 -m pytest tests -q
- shellcheck scripts/run-reviewer.sh scripts/post-comment.sh
- python3 -m py_compile scripts/parse-review.py scripts/aggregate-verdict.py

Closes #37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added explicit timeout detection and tracking for reviewer jobs, now reporting timed-out reviewers in verdict summaries.

* **Bug Fixes**
  * Improved timeout handling reliability with clearer messaging distinguishing between timeout and API errors.

* **Documentation**
  * Updated timeout configuration from 600 to 120 seconds across workflows and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->