### PR TITLE
feat: migrate from Moonshot direct API to OpenRouter

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kimi-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          kimi-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           timeout: '600'
 
   verdict:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
         uses: misty-step/landfall@v1
         with:
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
-          moonshot-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
   kimi-base-url:
     description: 'Kimi API base URL'
-    default: 'https://api.moonshot.ai/v1'
+    default: 'https://openrouter.ai/api/v1'
   model:
     description: 'Model name'
     default: 'kimi-k2.5'

--- a/scripts/run-reviewer.sh
+++ b/scripts/run-reviewer.sh
@@ -217,19 +217,19 @@ tmp_agent="/tmp/${perspective}-agent.yaml"
 sed "s|system_prompt_path: \./|system_prompt_path: ${agent_dir}/|" "$agent_file" > "$tmp_agent"
 
 model="${KIMI_MODEL:-kimi-k2.5}"
-base_url="${KIMI_BASE_URL:-https://api.moonshot.ai/v1}"
+base_url="${KIMI_BASE_URL:-https://openrouter.ai/api/v1}"
 
 # Create temp config with model, provider, and step limit
 cat > "/tmp/${perspective}-kimi-config.toml" <<TOML
-default_model = "moonshot/${model}"
+default_model = "openrouter/moonshotai/${model}"
 
-[models."moonshot/${model}"]
-provider = "moonshot"
+[models."openrouter/moonshotai/${model}"]
+provider = "openrouter"
 model = "${model}"
 max_context_size = 262144
 capabilities = ["thinking"]
 
-[providers.moonshot]
+[providers.openrouter]
 type = "kimi"
 base_url = "${base_url}"
 api_key = "${KIMI_API_KEY}"


### PR DESCRIPTION
## Summary

Migrates Cerberus from direct Moonshot API to OpenRouter, per Phaedrus directive (Feb 8).

Closes #66

## Changes

| File | Change |
|------|--------|
| `action.yml` | Default base URL → `openrouter.ai/api/v1` |
| `cerberus.yml` | `MOONSHOT_API_KEY` → `OPENROUTER_API_KEY` |
| `release.yml` | `moonshot-api-key` → `openrouter-api-key` |
| `run-reviewer.sh` | Provider `moonshot` → `openrouter`, model path `openrouter/moonshotai/${model}` |

## Why

- Moonshot direct API has had multiple suspensions/reliability issues
- OpenRouter provides a stable proxy with the same Kimi K2.5 model
- Consistent with how all sprites are already powered

## Note

Fixed a bug from the sprite-generated migration: model path was concatenating `kimi-k2.5${model}` instead of using `${model}` correctly.

## Required

`OPENROUTER_API_KEY` must be added as a GitHub org secret (replacing `MOONSHOT_API_KEY`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated the code review automation system to use OpenRouter API provider instead of Moonshot
  * Updated API authentication credentials and base endpoint URLs across GitHub Actions workflows and action configurations
  * Updated model provider references and namespaces to align with OpenRouter API specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->