### PR TITLE
fix: pass API key via input, bump timeout to 600s

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: misty-step/cerberus@v1
-        env:
-          CERBERUS_API_KEY: ${{ secrets.CERBERUS_API_KEY || secrets.ANTHROPIC_API_KEY }}
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          timeout: '120'
+          kimi-api-key: ${{ secrets.CERBERUS_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          timeout: '600'
 
   verdict:
     name: "Council Verdict"
@@ -103,7 +102,7 @@ Use `templates/triage-workflow.yml` to enable:
 | `kimi-base-url` | no | `https://api.moonshot.ai/v1` | API base URL |
 | `model` | no | `kimi-k2.5` | Model name |
 | `max-steps` | no | `25` | Max agentic steps |
-| `timeout` | no | `120` | Review timeout in seconds (per reviewer job) |
+| `timeout` | no | `600` | Review timeout in seconds (per reviewer job) |
 | `kimi-cli-version` | no | `1.8.0` | KimiCode CLI version |
 | `post-comment` | no | `true` | Post review comment |
 

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: '25'
   timeout:
     description: 'Review timeout in seconds'
-    default: '120'
+    default: '600'
   kimi-cli-version:
     description: 'KimiCode CLI version to install'
     default: '1.8.0'

--- a/scripts/validate-inputs.sh
+++ b/scripts/validate-inputs.sh
@@ -13,14 +13,17 @@ if [[ -z "$resolved_key" ]]; then
   cat >&2 <<'EOF'
 ::error::Missing API key for Cerberus review.
 Provide one of:
-1) with: kimi-api-key
-2) env: CERBERUS_API_KEY
-3) env: ANTHROPIC_API_KEY
+1) with: kimi-api-key  (recommended)
+2) env: CERBERUS_API_KEY  (job-level env only)
+3) env: ANTHROPIC_API_KEY  (job-level env only)
 
-One-file workflow example:
+Note: step-level env: does NOT propagate into composite actions.
+Use 'with: kimi-api-key' or set env at the job level.
+
+Example:
 - uses: misty-step/cerberus@v1
-  env:
-    CERBERUS_API_KEY: ${{ secrets.CERBERUS_API_KEY || secrets.ANTHROPIC_API_KEY }}
+  with:
+    kimi-api-key: ${{ secrets.CERBERUS_API_KEY }}
 EOF
   exit 1
 fi

--- a/templates/consumer-workflow.yml
+++ b/templates/consumer-workflow.yml
@@ -33,12 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: misty-step/cerberus@v1
-        env:
-          CERBERUS_API_KEY: ${{ secrets.CERBERUS_API_KEY || secrets.ANTHROPIC_API_KEY }}
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          timeout: '120'
+          kimi-api-key: ${{ secrets.CERBERUS_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          timeout: '600'
 
   verdict:
     name: "Council Verdict"

--- a/templates/triage-workflow.yml
+++ b/templates/triage-workflow.yml
@@ -34,12 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: misty-step/cerberus@v1
-        env:
-          CERBERUS_API_KEY: ${{ secrets.CERBERUS_API_KEY || secrets.ANTHROPIC_API_KEY }}
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          timeout: '120'
+          kimi-api-key: ${{ secrets.CERBERUS_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          timeout: '600'
 
   verdict:
     name: "Council Verdict"

--- a/tests/test_verdict_action.py
+++ b/tests/test_verdict_action.py
@@ -42,11 +42,10 @@ def test_action_uses_api_key_fallback_validator() -> None:
     assert "required: false" in match.group(0)
 
 
-def test_consumer_template_uses_single_secret_env_fallback() -> None:
+def test_consumer_template_passes_key_via_input() -> None:
     content = CONSUMER_WORKFLOW_TEMPLATE.read_text()
 
-    assert "CERBERUS_API_KEY: ${{ secrets.CERBERUS_API_KEY || secrets.ANTHROPIC_API_KEY }}" in content
-    assert "kimi-api-key:" not in content
+    assert "kimi-api-key: ${{ secrets.CERBERUS_API_KEY || secrets.ANTHROPIC_API_KEY }}" in content
 
 
 def test_readme_quick_start_uses_cerberus_secret_name() -> None:


### PR DESCRIPTION
## Summary
- Step-level `env:` on composite action consumers doesn't propagate into the action's `${{ env.X }}` context. All templates and docs now use `with: kimi-api-key` instead.
- Default timeout bumped from 120s to 600s — matches what `run-reviewer.sh` and `defaults/config.yml` already use.
- Error message in `validate-inputs.sh` now explains the step-level env gotcha.

## Test plan
- [x] 187/187 tests pass
- [ ] Verify landfall PR triggers Cerberus successfully with API key resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `kimi-api-key` input parameter for GitHub Action workflows, replacing environment variable configuration for API key management.

* **Improvements**
  * Increased reviewer job timeout from 120 to 600 seconds, providing extended time for review operations.
  * Updated workflow templates and documentation to reflect the new API key configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->