### PR TITLE
fix: retry transient reviewer failures with bounded backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ jobs:
 ## How It Works
 1. Each reviewer runs as a parallel matrix job
 2. KimiCode CLI (Kimi K2.5) analyzes the PR diff from each perspective
-3. Each reviewer posts a structured comment with findings
-4. The verdict job aggregates all reviews into a council decision
-5. Council verdict: **FAIL** on critical fail or 2+ fails, **WARN** on warnings or a single non-critical fail, **PASS** otherwise
+3. Reviewer runtime retries transient provider failures (429, 5xx, network) up to 3 times with 2s/4s/8s backoff and honors `Retry-After` when present
+4. Each reviewer posts a structured comment with findings
+5. The verdict job aggregates all reviews into a council decision
+6. Council verdict: **FAIL** on critical fail or 2+ fails, **WARN** on warnings or a single non-critical fail, **PASS** otherwise
 
 ## Auto-Triage (v1.1)
 Cerberus ships a separate triage module for council failures:

--- a/tests/test_run_reviewer_runtime.py
+++ b/tests/test_run_reviewer_runtime.py
@@ -137,7 +137,7 @@ def test_unknown_perspective_fails_fast(tmp_path: Path) -> None:
     assert "missing agent file" in result.stderr
 
 
-def test_transient_api_error_retries_then_succeeds(tmp_path: Path) -> None:
+def test_transient_server_error_retries_then_succeeds(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     retry_counter = tmp_path / "retry-count"
@@ -151,7 +151,7 @@ def test_transient_api_error_retries_then_succeeds(tmp_path: Path) -> None:
             "count=$((count + 1))\n"
             "printf '%s' \"$count\" > '" + str(retry_counter) + "'\n"
             "if [[ \"$count\" -eq 1 ]]; then\n"
-            "  echo '429 Too Many Requests' >&2\n"
+            "  echo 'HTTP 500 Internal Server Error' >&2\n"
             "  exit 1\n"
             "fi\n"
             "cat > /dev/null\n"
@@ -178,7 +178,105 @@ def test_transient_api_error_retries_then_succeeds(tmp_path: Path) -> None:
     )
     assert result.returncode == 0
     assert retry_counter.read_text() == "2"
-    assert "Transient API error detected" in result.stdout
+    assert "Retrying after transient error (class=server_5xx)" in result.stdout
+
+
+def test_transient_network_error_retries_then_succeeds(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    retry_counter = tmp_path / "retry-count"
+    retry_counter.write_text("0")
+
+    make_executable(
+        bin_dir / "kimi",
+        (
+            "#!/usr/bin/env bash\n"
+            "count=$(cat '" + str(retry_counter) + "')\n"
+            "count=$((count + 1))\n"
+            "printf '%s' \"$count\" > '" + str(retry_counter) + "'\n"
+            "if [[ \"$count\" -eq 1 ]]; then\n"
+            "  echo 'network timeout while connecting to provider' >&2\n"
+            "  exit 1\n"
+            "fi\n"
+            "cat > /dev/null\n"
+            "cat <<'REVIEW'\n"
+            "```json\n"
+            '{"reviewer":"STUB","perspective":"security","verdict":"PASS",'
+              '"confidence":0.95,"summary":"Recovered",'
+              '"findings":[],"stats":{"files_reviewed":1,"files_with_issues":0,'
+              '"critical":0,"major":0,"minor":0,"info":0}}\n'
+            "```\n"
+            "REVIEW\n"
+        ),
+    )
+    make_executable(bin_dir / "sleep", "#!/usr/bin/env bash\nexit 0\n")
+
+    diff_file = tmp_path / "diff.patch"
+    write_simple_diff(diff_file)
+    result = subprocess.run(
+        [str(RUN_REVIEWER), "security"],
+        env=make_env(bin_dir, diff_file),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert retry_counter.read_text() == "2"
+    assert "Retrying after transient error (class=network)" in result.stdout
+
+
+def test_rate_limit_retry_after_header_overrides_default_backoff(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    retry_counter = tmp_path / "retry-count"
+    retry_counter.write_text("0")
+    sleep_arg_file = tmp_path / "sleep-arg"
+    sleep_arg_file.write_text("")
+
+    make_executable(
+        bin_dir / "kimi",
+        (
+            "#!/usr/bin/env bash\n"
+            "count=$(cat '" + str(retry_counter) + "')\n"
+            "count=$((count + 1))\n"
+            "printf '%s' \"$count\" > '" + str(retry_counter) + "'\n"
+            "if [[ \"$count\" -eq 1 ]]; then\n"
+            "  echo 'HTTP 429 Too Many Requests' >&2\n"
+            "  echo 'Retry-After: 9' >&2\n"
+            "  exit 1\n"
+            "fi\n"
+            "cat > /dev/null\n"
+            "cat <<'REVIEW'\n"
+            "```json\n"
+            '{"reviewer":"STUB","perspective":"security","verdict":"PASS",'
+              '"confidence":0.95,"summary":"Recovered",'
+              '"findings":[],"stats":{"files_reviewed":1,"files_with_issues":0,'
+              '"critical":0,"major":0,"minor":0,"info":0}}\n'
+            "```\n"
+            "REVIEW\n"
+        ),
+    )
+    make_executable(
+        bin_dir / "sleep",
+        "#!/usr/bin/env bash\n"
+        "echo \"$1\" > '" + str(sleep_arg_file) + "'\n"
+        "exit 0\n",
+    )
+
+    diff_file = tmp_path / "diff.patch"
+    write_simple_diff(diff_file)
+    result = subprocess.run(
+        [str(RUN_REVIEWER), "security"],
+        env=make_env(bin_dir, diff_file),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert retry_counter.read_text() == "2"
+    assert sleep_arg_file.read_text() == "9\n"
+    assert "Retrying after transient error (class=rate_limit)" in result.stdout
+    assert "wait=9s" in result.stdout
 
 
 def test_permanent_api_error_is_written_for_parser(tmp_path: Path) -> None:
@@ -208,6 +306,44 @@ def test_permanent_api_error_is_written_for_parser(tmp_path: Path) -> None:
     parse_file = Path(parse_input_ref.read_text().strip())
     content = parse_file.read_text()
     assert "API Error: API_KEY_INVALID" in content
+
+
+def test_non_transient_4xx_error_does_not_retry(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    attempt_counter = tmp_path / "attempt-count"
+    attempt_counter.write_text("0")
+
+    make_executable(
+        bin_dir / "kimi",
+        (
+            "#!/usr/bin/env bash\n"
+            "count=$(cat '" + str(attempt_counter) + "')\n"
+            "count=$((count + 1))\n"
+            "printf '%s' \"$count\" > '" + str(attempt_counter) + "'\n"
+            "echo 'HTTP 404 Not Found' >&2\n"
+            "exit 1\n"
+        ),
+    )
+    make_executable(bin_dir / "sleep", "#!/usr/bin/env bash\nexit 99\n")
+
+    diff_file = tmp_path / "diff.patch"
+    write_simple_diff(diff_file)
+    result = subprocess.run(
+        [str(RUN_REVIEWER), "security"],
+        env=make_env(bin_dir, diff_file),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert attempt_counter.read_text() == "1"
+    assert "Retrying after transient error" not in result.stdout
+    parse_input_ref = Path("/tmp/security-parse-input")
+    assert parse_input_ref.exists()
+    parse_file = Path(parse_input_ref.read_text().strip())
+    content = parse_file.read_text()
+    assert "API Error: API_ERROR" in content
 
 
 def test_timeout_with_partial_output_exits_zero(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- classify reviewer failures into transient (429/5xx/network) vs permanent (non-429 4xx/auth/quota)
- retry transient failures up to 3 times using 2s/4s/8s schedule
- honor Retry-After for 429 responses when provided
- keep permanent error path explicit for parser compatibility
- document retry behavior in README

## Testing
- pytest -q tests/test_run_reviewer_runtime.py
- ./tests/run-tests.sh
- shellcheck scripts/run-reviewer.sh

Closes #39


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry mechanism for transient API failures (rate limits, server errors, network issues) with exponential backoff timing (2s, 4s, 8s)
  * Integrated Retry-After header support for optimized rate limit handling

* **Documentation**
  * Expanded "How It Works" section with detailed retry workflow
  * Enhanced Auto-Triage documentation with modes, loop protection, and environment controls

* **Tests**
  * Added comprehensive test coverage for retry scenarios and error classification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->