### PR TITLE
feat(council): redesign verdict comment format for scannability

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
 2. KimiCode CLI (Kimi K2.5) analyzes the PR diff from each perspective
 3. Reviewer runtime retries transient provider failures (429, 5xx, network) up to 3 times with 2s/4s/8s backoff and honors `Retry-After` when present
 4. Each reviewer posts a structured comment with findings
-5. The verdict job aggregates all reviews into a council decision
+5. The verdict job aggregates all reviews into a verdict-first council comment with collapsible reviewer sections, severity-tagged findings, file/line references, review scope, and per-reviewer timing
 6. Council verdict: **FAIL** on critical fail or 2+ fails, **WARN** on warnings or a single non-critical fail, **PASS** otherwise
 
 ## Auto-Triage (v1.1)

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,14 @@ runs:
         GH_PR_CONTEXT: /tmp/pr-context.json
       run: |
         chmod +x "$CERBERUS_ROOT/scripts/run-reviewer.sh"
+        review_started_at=$(date +%s)
+        set +e
         "$CERBERUS_ROOT/scripts/run-reviewer.sh" "$PERSPECTIVE"
+        review_exit=$?
+        review_finished_at=$(date +%s)
+        runtime_seconds=$((review_finished_at - review_started_at))
+        printf '%s\n' "$runtime_seconds" > "/tmp/${PERSPECTIVE}-runtime-seconds"
+        exit "$review_exit"
 
     - name: Parse review output
       if: always()
@@ -142,6 +149,15 @@ runs:
           PARSE_INPUT="$(cat "/tmp/${PERSPECTIVE}-parse-input")"
         fi
         python3 "$CERBERUS_ROOT/scripts/parse-review.py" "$PARSE_INPUT" > "/tmp/${PERSPECTIVE}-verdict.json"
+        RUNTIME_FILE="/tmp/${PERSPECTIVE}-runtime-seconds"
+        if [[ -f "$RUNTIME_FILE" ]]; then
+          runtime_seconds="$(cat "$RUNTIME_FILE")"
+          if [[ "$runtime_seconds" =~ ^[0-9]+$ ]]; then
+            tmp_json="/tmp/${PERSPECTIVE}-verdict.runtime.json"
+            jq --argjson runtime_seconds "$runtime_seconds" '.runtime_seconds = $runtime_seconds' "/tmp/${PERSPECTIVE}-verdict.json" > "$tmp_json"
+            mv "$tmp_json" "/tmp/${PERSPECTIVE}-verdict.json"
+          fi
+        fi
         VERDICT=$(jq -r .verdict "/tmp/${PERSPECTIVE}-verdict.json")
         if [[ ! "$VERDICT" =~ ^(PASS|WARN|FAIL|SKIP)$ ]]; then
           echo "::error::Invalid verdict value from parser: $VERDICT"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,11 +97,11 @@ Cerberus is agentic DevOps composed from distinct, focused modules. Each module 
 - [ ] Rate limit handling: respect GitHub API secondary rate limits
 
 ### Phase 2: Report Quality (P0)
-- [ ] Redesign PR comment format: clear verdict header, collapsible sections, severity indicators
-- [ ] Per-reviewer summary with pass/fail/skip status and key findings
-- [ ] Actionable findings: file + line references, suggested fixes
-- [ ] Diff size context: show what was reviewed (files changed, lines)
-- [ ] Timing info: how long each reviewer took
+- [x] Redesign PR comment format: clear verdict header, collapsible sections, severity indicators
+- [x] Per-reviewer summary with pass/fail/skip status and key findings
+- [x] Actionable findings: file + line references, suggested fixes
+- [x] Diff size context: show what was reviewed (files changed, lines)
+- [x] Timing info: how long each reviewer took
 
 ### Phase 3: Installation & DX (P1)
 - [ ] One-file installation: single workflow YAML, one secret

--- a/scripts/aggregate-verdict.py
+++ b/scripts/aggregate-verdict.py
@@ -219,6 +219,7 @@ def main() -> None:
                 "summary": data.get("summary", ""),
                 "findings": data.get("findings"),
                 "stats": data.get("stats"),
+                "runtime_seconds": data.get("runtime_seconds"),
             }
         )
 

--- a/scripts/render-council-comment.py
+++ b/scripts/render-council-comment.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Render a scannable council PR comment from council verdict JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+VERDICT_ICON = {
+    "PASS": "✅",
+    "WARN": "⚠️",
+    "FAIL": "❌",
+    "SKIP": "⏭️",
+}
+
+SEVERITY_ORDER = {
+    "critical": 0,
+    "major": 1,
+    "minor": 2,
+    "info": 3,
+}
+
+VERDICT_ORDER = {
+    "FAIL": 0,
+    "WARN": 1,
+    "SKIP": 2,
+    "PASS": 3,
+}
+
+
+def fail(message: str, code: int = 2) -> None:
+    print(f"render-council-comment: {message}", file=sys.stderr)
+    sys.exit(code)
+
+
+def read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        fail(f"unable to read {path}: {exc}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+
+
+def as_int(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_verdict(value: object) -> str:
+    text = str(value or "").upper().strip()
+    if text in VERDICT_ICON:
+        return text
+    return "WARN"
+
+
+def normalize_severity(value: object) -> str:
+    text = str(value or "").strip().lower()
+    if text in SEVERITY_ORDER:
+        return text
+    return "info"
+
+
+def reviewer_name(reviewer: dict) -> str:
+    name = reviewer.get("reviewer") or reviewer.get("perspective")
+    return str(name or "unknown")
+
+
+def perspective_name(reviewer: dict) -> str:
+    perspective = reviewer.get("perspective")
+    return str(perspective or "unknown")
+
+
+def findings_for(reviewer: dict) -> list[dict]:
+    findings = reviewer.get("findings")
+    if isinstance(findings, list):
+        return [finding for finding in findings if isinstance(finding, dict)]
+    return []
+
+
+def format_runtime(runtime_seconds: object) -> str:
+    seconds = as_int(runtime_seconds)
+    if seconds is None or seconds < 0:
+        return "n/a"
+    minutes, remainder = divmod(seconds, 60)
+    if minutes > 0:
+        return f"{minutes}m {remainder}s"
+    return f"{seconds}s"
+
+
+def format_confidence(confidence: object) -> str:
+    if confidence is None:
+        return "n/a"
+    try:
+        value = float(confidence)
+    except (TypeError, ValueError):
+        return "n/a"
+    if value < 0 or value > 1:
+        return "n/a"
+    return f"{value:.2f}"
+
+
+def summarize_reviewers(reviewers: list[dict]) -> str:
+    total = len(reviewers)
+    if total == 0:
+        return "No reviewer verdicts available."
+
+    groups: dict[str, list[str]] = {
+        "PASS": [],
+        "WARN": [],
+        "FAIL": [],
+        "SKIP": [],
+    }
+    for reviewer in reviewers:
+        groups[normalize_verdict(reviewer.get("verdict"))].append(reviewer_name(reviewer))
+
+    parts = [f"{len(groups['PASS'])}/{total} reviewers passed"]
+    if groups["FAIL"]:
+        parts.append(f"{len(groups['FAIL'])} failed ({', '.join(groups['FAIL'])})")
+    if groups["WARN"]:
+        parts.append(f"{len(groups['WARN'])} warned ({', '.join(groups['WARN'])})")
+    if groups["SKIP"]:
+        parts.append(f"{len(groups['SKIP'])} skipped ({', '.join(groups['SKIP'])})")
+    return ". ".join(parts) + "."
+
+
+def finding_location(finding: dict) -> str:
+    path = str(finding.get("file") or "").strip()
+    line = as_int(finding.get("line"))
+    if path and line is not None and line > 0:
+        return f"{path}:{line}"
+    if path:
+        return path
+    return "location n/a"
+
+
+def truncate(text: object, *, max_len: int) -> str:
+    raw = str(text or "").strip()
+    if len(raw) <= max_len:
+        return raw
+    return raw[: max_len - 1].rstrip() + "…"
+
+
+def top_findings(reviewer: dict, *, max_findings: int) -> list[dict]:
+    findings = findings_for(reviewer)
+    return sorted(
+        findings,
+        key=lambda finding: (
+            SEVERITY_ORDER.get(normalize_severity(finding.get("severity")), 99),
+            str(finding.get("title") or ""),
+            finding_location(finding),
+        ),
+    )[:max_findings]
+
+
+def count_findings(reviewers: list[dict]) -> dict[str, int]:
+    totals = {"critical": 0, "major": 0, "minor": 0, "info": 0}
+    for reviewer in reviewers:
+        stats = reviewer.get("stats")
+        if isinstance(stats, dict):
+            used_stats = False
+            for severity in totals:
+                value = as_int(stats.get(severity))
+                if value is not None:
+                    totals[severity] += max(0, value)
+                    used_stats = True
+            if used_stats:
+                continue
+        for finding in findings_for(reviewer):
+            totals[normalize_severity(finding.get("severity"))] += 1
+    return totals
+
+
+def detect_skip_banner(reviewers: list[dict]) -> str:
+    for reviewer in reviewers:
+        if normalize_verdict(reviewer.get("verdict")) != "SKIP":
+            continue
+        findings = findings_for(reviewer)
+        category = str(findings[0].get("category") or "").strip().lower() if findings else ""
+        title = str(findings[0].get("title") or "").strip().upper() if findings else ""
+        summary = str(reviewer.get("summary") or "").lower()
+
+        if category == "api_error":
+            if re.search(r"(CREDITS_DEPLETED|QUOTA_EXCEEDED)", title):
+                return (
+                    "> **⛔ API credits depleted for one or more reviewers.** "
+                    "Some reviews were skipped because the API provider has no remaining credits."
+                )
+            if "KEY_INVALID" in title:
+                return (
+                    "> **🔑 API key error for one or more reviewers.** "
+                    "Some reviews were skipped due to authentication failures."
+                )
+            return "> **⚠️ API error for one or more reviewers.** Some reviews were skipped due to API errors."
+
+        if category == "timeout" or "timeout" in summary:
+            return (
+                "> **⏱️ One or more reviewers timed out.** "
+                "Some reviews were skipped because they exceeded the configured runtime limit."
+            )
+    return ""
+
+
+def scope_summary() -> str:
+    changed_files = as_int(os.environ.get("PR_CHANGED_FILES"))
+    additions = as_int(os.environ.get("PR_ADDITIONS"))
+    deletions = as_int(os.environ.get("PR_DELETIONS"))
+    if changed_files is None or additions is None or deletions is None:
+        return "unknown scope (missing PR diff metadata)"
+    return f"{changed_files} files changed, +{additions} / -{deletions} lines"
+
+
+def run_link() -> tuple[str, str]:
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
+    repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    run_id = os.environ.get("GITHUB_RUN_ID", "").strip()
+    if not repo or not run_id:
+        return ("n/a", "")
+    return (f"#{run_id}", f"{server}/{repo}/actions/runs/{run_id}")
+
+
+def short_sha() -> str:
+    head_sha = str(os.environ.get("GH_HEAD_SHA") or "").strip()
+    if not head_sha:
+        return "<head-sha>"
+    return head_sha[:12]
+
+
+def footer_line() -> str:
+    version = str(os.environ.get("CERBERUS_VERSION") or "dev").strip() or "dev"
+    override_policy = str(os.environ.get("GH_OVERRIDE_POLICY") or "pr_author").strip() or "pr_author"
+    fail_on_verdict = str(os.environ.get("FAIL_ON_VERDICT") or "true").strip() or "true"
+    run_label, run_url = run_link()
+    if run_url:
+        run_fragment = f"[{run_label}]({run_url})"
+    else:
+        run_fragment = run_label
+    return (
+        f"*Cerberus Council ({version}) | Run {run_fragment} | "
+        f"Override policy `{override_policy}` | Fail on verdict `{fail_on_verdict}` | "
+        f"Override command: `/council override sha={short_sha()}` (reason required)*"
+    )
+
+
+def format_reviewer_block(reviewer: dict, *, max_findings: int) -> list[str]:
+    verdict = normalize_verdict(reviewer.get("verdict"))
+    icon = VERDICT_ICON[verdict]
+    name = reviewer_name(reviewer)
+    perspective = perspective_name(reviewer)
+    runtime = format_runtime(reviewer.get("runtime_seconds"))
+    confidence = format_confidence(reviewer.get("confidence"))
+    findings = findings_for(reviewer)
+    summary = truncate(reviewer.get("summary"), max_len=300) or "No summary provided."
+
+    lines = [
+        "<details>",
+        (
+            f"<summary>{icon} <strong>{name}</strong> ({perspective}) | "
+            f"{verdict} | confidence {confidence} | runtime {runtime} | findings {len(findings)}</summary>"
+        ),
+        "",
+        f"- Verdict: `{verdict}`",
+        f"- Confidence: `{confidence}`",
+        f"- Runtime: `{runtime}`",
+        f"- Summary: {summary}",
+        "",
+    ]
+
+    if findings:
+        lines.append("**Key findings**")
+        for finding in top_findings(reviewer, max_findings=max_findings):
+            severity = normalize_severity(finding.get("severity"))
+            title = truncate(finding.get("title"), max_len=100) or "Untitled finding"
+            category = truncate(finding.get("category"), max_len=40) or "uncategorized"
+            location = finding_location(finding)
+            description = truncate(finding.get("description"), max_len=220)
+            suggestion = truncate(finding.get("suggestion"), max_len=220)
+            lines.append(
+                f"- `{severity}` **{title}** (`{category}`) at `{location}`"
+            )
+            if description:
+                lines.append(f"  - {description}")
+            if suggestion:
+                lines.append(f"  - Suggestion: {suggestion}")
+        hidden = len(findings) - max_findings
+        if hidden > 0:
+            lines.append(f"- Additional findings not shown: {hidden}")
+    else:
+        lines.append("_No findings reported._")
+
+    lines.extend(["", "</details>"])
+    return lines
+
+
+def render_comment(council: dict, *, max_findings: int, marker: str) -> str:
+    reviewers = council.get("reviewers")
+    if not isinstance(reviewers, list):
+        reviewers = []
+    reviewers = [reviewer for reviewer in reviewers if isinstance(reviewer, dict)]
+    reviewers = sorted(
+        reviewers,
+        key=lambda reviewer: (
+            VERDICT_ORDER.get(normalize_verdict(reviewer.get("verdict")), 99),
+            reviewer_name(reviewer),
+        ),
+    )
+
+    verdict = normalize_verdict(council.get("verdict"))
+    icon = VERDICT_ICON[verdict]
+    summary_line = summarize_reviewers(reviewers)
+    skip_banner = detect_skip_banner(reviewers)
+    finding_totals = count_findings(reviewers)
+    stats = council.get("stats")
+    if not isinstance(stats, dict):
+        stats = {}
+    reviewer_total = as_int(stats.get("total"))
+    reviewer_pass = as_int(stats.get("pass"))
+    reviewer_warn = as_int(stats.get("warn"))
+    reviewer_fail = as_int(stats.get("fail"))
+    reviewer_skip = as_int(stats.get("skip"))
+    if None in {reviewer_total, reviewer_pass, reviewer_warn, reviewer_fail, reviewer_skip}:
+        reviewer_total = len(reviewers)
+        reviewer_pass = len([r for r in reviewers if normalize_verdict(r.get("verdict")) == "PASS"])
+        reviewer_warn = len([r for r in reviewers if normalize_verdict(r.get("verdict")) == "WARN"])
+        reviewer_fail = len([r for r in reviewers if normalize_verdict(r.get("verdict")) == "FAIL"])
+        reviewer_skip = len([r for r in reviewers if normalize_verdict(r.get("verdict")) == "SKIP"])
+
+    lines = [
+        marker,
+        f"## {icon} Council Verdict: {verdict}",
+        "",
+        f"**Summary:** {summary_line}",
+    ]
+    if skip_banner:
+        lines.extend(["", skip_banner])
+
+    lines.extend(
+        [
+            "",
+            f"**Review Scope:** {scope_summary()}",
+            (
+                "**Reviewer Breakdown:** "
+                f"{reviewer_total} total | {reviewer_pass} pass | {reviewer_warn} warn | "
+                f"{reviewer_fail} fail | {reviewer_skip} skip"
+            ),
+            (
+                "**Findings:** "
+                f"{finding_totals['critical']} critical | {finding_totals['major']} major | "
+                f"{finding_totals['minor']} minor | {finding_totals['info']} info"
+            ),
+        ]
+    )
+
+    override = council.get("override")
+    if isinstance(override, dict) and override.get("used"):
+        actor = str(override.get("actor") or "unknown")
+        sha = str(override.get("sha") or "unknown")
+        reason = truncate(override.get("reason"), max_len=120) or "n/a"
+        lines.append(f"**Override:** active by `{actor}` on `{sha}`. Reason: {reason}")
+
+    lines.extend(["", "### Reviewer Details"])
+    for reviewer in reviewers:
+        lines.extend([""] + format_reviewer_block(reviewer, max_findings=max_findings))
+
+    lines.extend(["", "---", footer_line(), ""])
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render Cerberus council comment markdown.")
+    parser.add_argument(
+        "--council-json",
+        default="/tmp/council-verdict.json",
+        help="Path to council verdict JSON.",
+    )
+    parser.add_argument(
+        "--output",
+        default="/tmp/council-comment.md",
+        help="Output markdown file path.",
+    )
+    parser.add_argument(
+        "--marker",
+        default="<!-- cerberus:council -->",
+        help="HTML marker for idempotent comment upsert.",
+    )
+    parser.add_argument(
+        "--max-findings",
+        type=int,
+        default=3,
+        help="Maximum findings to show per reviewer section.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.max_findings < 1:
+        fail("--max-findings must be >= 1")
+
+    council_path = Path(args.council_json)
+    output_path = Path(args.output)
+
+    council = read_json(council_path)
+    markdown = render_comment(council, max_findings=args.max_findings, marker=args.marker)
+
+    try:
+        output_path.write_text(markdown, encoding="utf-8")
+    except OSError as exc:
+        fail(f"unable to write {output_path}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aggregate_verdict.py
+++ b/tests/test_aggregate_verdict.py
@@ -516,6 +516,25 @@ def test_detects_fallback_verdicts(tmp_path):
     assert "Council Verdict: FAIL" in out
 
 
+def test_preserves_reviewer_runtime_seconds(tmp_path):
+    (tmp_path / "apollo.json").write_text(
+        json.dumps(
+            {
+                "reviewer": "APOLLO",
+                "perspective": "correctness",
+                "verdict": "PASS",
+                "summary": "ok",
+                "runtime_seconds": 37,
+            }
+        )
+    )
+
+    code, out, err = run_aggregate(str(tmp_path))
+    assert code == 0
+    data = json.loads(Path("/tmp/council-verdict.json").read_text())
+    assert data["reviewers"][0]["runtime_seconds"] == 37
+
+
 # ---------------------------------------------------------------------------
 # Phase 2: Unit tests via importlib (no subprocess)
 # ---------------------------------------------------------------------------

--- a/tests/test_render_council_comment.py
+++ b/tests/test_render_council_comment.py
@@ -1,0 +1,165 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+SCRIPT = ROOT / "scripts" / "render-council-comment.py"
+
+
+def run_render(tmp_path: Path, council: dict, env_extra: dict | None = None) -> tuple[int, str, str]:
+    council_path = tmp_path / "council.json"
+    output_path = tmp_path / "comment.md"
+    council_path.write_text(json.dumps(council), encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_SERVER_URL": "https://github.com",
+            "GITHUB_REPOSITORY": "misty-step/cerberus",
+            "GITHUB_RUN_ID": "12345",
+            "GH_HEAD_SHA": "abcdef1234567890",
+            "PR_CHANGED_FILES": "7",
+            "PR_ADDITIONS": "120",
+            "PR_DELETIONS": "44",
+            "CERBERUS_VERSION": "v1-test",
+            "GH_OVERRIDE_POLICY": "pr_author",
+            "FAIL_ON_VERDICT": "true",
+        }
+    )
+    if env_extra:
+        env.update(env_extra)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--council-json",
+            str(council_path),
+            "--output",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    body = output_path.read_text(encoding="utf-8") if output_path.exists() else ""
+    return result.returncode, body, result.stderr
+
+
+def test_renders_scannable_header_and_reviewer_details(tmp_path: Path) -> None:
+    council = {
+        "verdict": "FAIL",
+        "summary": "2 reviewers. Failures: 1, warnings: 0, skipped: 0.",
+        "reviewers": [
+            {
+                "reviewer": "VULCAN",
+                "perspective": "performance",
+                "verdict": "FAIL",
+                "confidence": 0.82,
+                "summary": "N+1 query in hot path.",
+                "runtime_seconds": 65,
+                "findings": [
+                    {
+                        "severity": "major",
+                        "category": "performance",
+                        "file": "src/service.py",
+                        "line": 42,
+                        "title": "N+1 query in request loop",
+                        "description": "Loop issues one query per row.",
+                        "suggestion": "Batch load related rows.",
+                    }
+                ],
+                "stats": {"critical": 0, "major": 1, "minor": 0, "info": 0},
+            },
+            {
+                "reviewer": "APOLLO",
+                "perspective": "correctness",
+                "verdict": "PASS",
+                "confidence": 0.93,
+                "summary": "No correctness regressions.",
+                "runtime_seconds": 12,
+                "findings": [],
+                "stats": {"critical": 0, "major": 0, "minor": 0, "info": 0},
+            },
+        ],
+        "stats": {"total": 2, "pass": 1, "warn": 0, "fail": 1, "skip": 0},
+        "override": {"used": False},
+    }
+
+    code, body, err = run_render(tmp_path, council)
+
+    assert code == 0, err
+    assert "<!-- cerberus:council -->" in body
+    assert "## ❌ Council Verdict: FAIL" in body
+    assert "**Summary:** 1/2 reviewers passed. 1 failed (VULCAN)." in body
+    assert "**Review Scope:** 7 files changed, +120 / -44 lines" in body
+    assert "### Reviewer Details" in body
+    assert "<details>" in body
+    assert "`src/service.py:42`" in body
+    assert "runtime 1m 5s" in body
+    assert "/council override sha=abcdef123456" in body
+
+
+def test_renders_skip_banner_for_credit_exhaustion(tmp_path: Path) -> None:
+    council = {
+        "verdict": "WARN",
+        "summary": "2 reviewers. Failures: 0, warnings: 1, skipped: 1.",
+        "reviewers": [
+            {
+                "reviewer": "SENTINEL",
+                "perspective": "security",
+                "verdict": "SKIP",
+                "confidence": 0.0,
+                "summary": "Review skipped due to API credits depleted.",
+                "runtime_seconds": 3,
+                "findings": [
+                    {
+                        "severity": "info",
+                        "category": "api_error",
+                        "file": "",
+                        "line": 0,
+                        "title": "CREDITS_DEPLETED",
+                        "description": "",
+                        "suggestion": "",
+                    }
+                ],
+                "stats": {"critical": 0, "major": 0, "minor": 0, "info": 1},
+            },
+            {
+                "reviewer": "ATHENA",
+                "perspective": "architecture",
+                "verdict": "WARN",
+                "confidence": 0.75,
+                "summary": "One major design issue.",
+                "runtime_seconds": 41,
+                "findings": [],
+                "stats": {"critical": 0, "major": 1, "minor": 0, "info": 0},
+            },
+        ],
+        "stats": {"total": 2, "pass": 0, "warn": 1, "fail": 0, "skip": 1},
+        "override": {"used": False},
+    }
+
+    code, body, err = run_render(tmp_path, council)
+
+    assert code == 0, err
+    assert "API credits depleted for one or more reviewers" in body
+    assert "**Summary:** 0/2 reviewers passed. 1 warned (ATHENA). 1 skipped (SENTINEL)." in body
+    assert "[#12345](https://github.com/misty-step/cerberus/actions/runs/12345)" in body
+
+
+def test_renders_override_details_when_present(tmp_path: Path) -> None:
+    council = {
+        "verdict": "PASS",
+        "summary": "Override by owner for abcdef1.",
+        "reviewers": [],
+        "stats": {"total": 0, "pass": 0, "warn": 0, "fail": 0, "skip": 0},
+        "override": {"used": True, "actor": "owner", "sha": "abcdef1", "reason": "False positive"},
+    }
+
+    code, body, err = run_render(tmp_path, council)
+
+    assert code == 0, err
+    assert "**Override:** active by `owner` on `abcdef1`. Reason: False positive" in body

--- a/tests/test_verdict_action.py
+++ b/tests/test_verdict_action.py
@@ -80,6 +80,13 @@ def test_verdict_action_avoids_heredoc_in_run_block() -> None:
     assert "cat >&2 <<'EOF'" not in content
 
 
+def test_verdict_action_uses_python_renderer_for_council_comment() -> None:
+    content = VERDICT_ACTION_FILE.read_text()
+
+    assert "scripts/render-council-comment.py" in content
+    assert "--output /tmp/council-comment.md" in content
+
+
 def test_verdict_action_does_not_use_sparse_checkout_dot() -> None:
     content = VERDICT_ACTION_FILE.read_text()
 

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -69,58 +69,26 @@ runs:
       if: always() && steps.aggregate.outcome == 'success'
       shell: bash
       env:
+        CERBERUS_ROOT: ${{ github.action_path }}/..
         GH_TOKEN: ${{ inputs.github-token }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         REPO: ${{ github.repository }}
+        GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        GH_OVERRIDE_POLICY: pr_author
+        PR_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
+        PR_ADDITIONS: ${{ github.event.pull_request.additions }}
+        PR_DELETIONS: ${{ github.event.pull_request.deletions }}
+        FAIL_ON_VERDICT: ${{ inputs.fail-on-verdict }}
+        CERBERUS_VERSION: ${{ github.action_ref || 'dev' }}
       run: |
         VERDICT=$(jq -r .verdict /tmp/council-verdict.json)
-        SUMMARY=$(jq -r .summary /tmp/council-verdict.json)
         if [ "$VERDICT" = "null" ] || [ -z "$VERDICT" ]; then
           echo "::error::Council verdict JSON is malformed"
           exit 1
         fi
-        EMOJI="✅"
-        if [ "$VERDICT" = "FAIL" ]; then EMOJI="❌"; fi
-        if [ "$VERDICT" = "WARN" ]; then EMOJI="⚠️"; fi
-        if [ "$VERDICT" = "SKIP" ]; then EMOJI="⏭️"; fi
-        MARKER="<!-- cerberus:council -->"
-
-        # Detect SKIP reasons across all reviewer verdicts using structured fields
-        SKIP_BANNER=""
-        for f in ./verdicts/*.json; do
-          [ -f "$f" ] || continue
-          v_verdict=$(jq -r '.verdict // empty' "$f")
-          [ "$v_verdict" = "SKIP" ] || continue
-          v_category=$(jq -r '.findings[0].category // empty' "$f")
-          v_title=$(jq -r '.findings[0].title // empty' "$f")
-          if [ "$v_category" = "api_error" ]; then
-            if printf '%s' "$v_title" | grep -qiE "CREDITS_DEPLETED|QUOTA_EXCEEDED"; then
-              SKIP_BANNER="> **⛔ API credits depleted for one or more reviewers.** Some reviews were skipped because the API provider has no remaining credits. Top up credits or configure a fallback provider."
-            elif printf '%s' "$v_title" | grep -qiE "KEY_INVALID"; then
-              SKIP_BANNER="> **🔑 API key error for one or more reviewers.** Some reviews were skipped due to authentication failures. Check that the API key is valid."
-            else
-              SKIP_BANNER="> **⚠️ API error for one or more reviewers.** Some reviews were skipped due to API errors."
-            fi
-            break
-          elif [ "$v_category" = "timeout" ]; then
-            SKIP_BANNER="> **⏱️ One or more reviewers timed out.** Some reviews were skipped because they exceeded the configured runtime limit."
-            break
-          fi
-        done
-
-        {
-          printf '%s\n' "$MARKER"
-          printf '%s\n' "## ${EMOJI} Council Verdict: ${VERDICT}"
-          printf '\n'
-          if [ -n "$SKIP_BANNER" ]; then
-            printf '%s\n' "$SKIP_BANNER"
-            printf '\n'
-          fi
-          printf '%s\n' "$SUMMARY"
-          printf '\n'
-          printf '%s\n' "---"
-          printf '%s\n' "*Cerberus Council*"
-        } > /tmp/council-comment.md
+        python3 "$CERBERUS_ROOT/scripts/render-council-comment.py" \
+          --council-json /tmp/council-verdict.json \
+          --output /tmp/council-comment.md
 
         print_permissions_help() {
           {


### PR DESCRIPTION
## Summary
- replace inline shell markdown assembly with a dedicated Python renderer for council comments
- redesign council comment output with verdict-first header, reviewer breakdown, collapsible reviewer details, actionable finding locations, diff scope, and footer metadata
- capture per-reviewer runtime in review artifacts and pass it through council aggregation so timing appears in council comments
- add regression tests for renderer output, runtime passthrough, and verdict action wiring
- update docs to reflect the new council comment format

## Testing
- python3 -m py_compile scripts/aggregate-verdict.py scripts/render-council-comment.py scripts/triage.py scripts/parse-review.py
- python3 -m pytest tests/test_render_council_comment.py tests/test_verdict_action.py tests/test_aggregate_verdict.py -q
- python3 -m pytest tests/ -q

Closes #40