### PR TITLE
feat(council): implement per-reviewer override policies

### DIFF
--- a/scripts/aggregate-verdict.py
+++ b/scripts/aggregate-verdict.py
@@ -283,9 +283,16 @@ def main() -> None:
         reviewer_policies: dict[str, str] = {}
         if reviewer_policies_raw:
             try:
-                reviewer_policies = json.loads(reviewer_policies_raw)
-            except json.JSONDecodeError:
-                pass
+                parsed = json.loads(reviewer_policies_raw)
+                if not isinstance(parsed, dict):
+                    raise ValueError("GH_REVIEWER_POLICIES must be a JSON object")
+                reviewer_policies = parsed
+            except (json.JSONDecodeError, ValueError) as exc:
+                print(
+                    f"aggregate-verdict: warning: invalid GH_REVIEWER_POLICIES ({exc}); "
+                    "falling back to global policy",
+                    file=sys.stderr,
+                )
         policy = determine_effective_policy(verdicts, reviewer_policies, global_policy)
         pr_author = os.environ.get("GH_PR_AUTHOR")
         actor_permission = os.environ.get("GH_OVERRIDE_ACTOR_PERMISSION")

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -43,19 +43,25 @@ runs:
         python3 - "$CONFIG" <<'PYEOF'
         import json, os, re, sys
         config_path = sys.argv[1]
-        text = open(config_path).read()
+        with open(config_path) as fh:
+            raw = fh.read()
+        # Strip comment-only lines to prevent matching commented-out entries.
+        text = "\n".join(
+            line for line in raw.splitlines()
+            if not line.lstrip().startswith("#")
+        )
         # Extract global override actor policy.
-        m = re.search(r'^override:\s*\n(?:.*\n)*?\s+actor:\s*(\S+)', text, re.MULTILINE)
-        global_policy = m.group(1) if m else "pr_author"
+        m = re.search(r'^\s*override:\s*\n(?:.*\n)*?^\s+actor:\s*(\S+)', text, re.MULTILINE)
+        global_policy = m.group(1).strip("\"'") if m else "pr_author"
         # Extract per-reviewer override policies from reviewers list.
         policies = {}
         for block in re.finditer(
-            r'-\s+name:\s*(\S+).*?(?=\n\s*-\s+name:|\Z)', text, re.DOTALL
+            r'^\s*-\s+name:\s*(\S+).*?(?=^\s*-\s+name:|\Z)', text, re.DOTALL | re.MULTILINE
         ):
-            name = block.group(1)
-            om = re.search(r'override:\s*(\S+)', block.group(0))
+            name = block.group(1).strip("\"'")
+            om = re.search(r'^\s*override:\s*(\S+)', block.group(0), re.MULTILINE)
             if om:
-                policies[name] = om.group(1)
+                policies[name] = om.group(1).strip("\"'")
             else:
                 policies[name] = global_policy
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:


### PR DESCRIPTION
## Summary

- Enforces per-reviewer override policies defined in `defaults/config.yml` — SENTINEL's `maintainers_only` policy now actually blocks PR author overrides
- `aggregate-verdict.py` picks the strictest policy among failing reviewers (`maintainers_only` > `write_access` > `pr_author`)
- `verdict/action.yml` reads per-reviewer policies from config and resolves override actor's repo permission via GitHub API

## Changes

**`scripts/aggregate-verdict.py`**
- New `POLICY_STRICTNESS` ranking and `determine_effective_policy()` function
- `validate_actor()` now supports `write_access` (write/maintain/admin) and `maintainers_only` (maintain/admin)
- `main()` reads `GH_REVIEWER_POLICIES` JSON map and `GH_OVERRIDE_ACTOR_PERMISSION` env vars
- Backward compatible: falls back to `GH_OVERRIDE_POLICY` when `GH_REVIEWER_POLICIES` is absent

**`verdict/action.yml`**
- New "Read reviewer policies from config" step (regex-based parser, no PyYAML dependency)
- Override check step now resolves actor's permission via `gh api repos/.../collaborators/.../permission`
- Dynamic `GH_OVERRIDE_POLICY` from config instead of hardcoded `pr_author`

**`tests/test_aggregate_verdict.py`**
- 24 new tests: `TestDetermineEffectivePolicy` (9), `TestValidateActorWriteAccess` (6), `TestValidateActorMaintainersOnly` (5), `TestPerReviewerOverrideIntegration` (4)

## Test plan

- [x] All 239 tests pass (`python3 -m pytest tests/ -v`)
- [x] Backward compatibility: existing 3-arg `validate_actor()` calls still work
- [x] Regex parser correctly extracts policies from `defaults/config.yml`
- [ ] E2E: trigger override on moonbridge PR with SENTINEL FAIL to verify `maintainers_only` blocks PR author

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic reviewer-specific policy configuration via a new workflow step that exposes global and per-reviewer policies and actor permission.
  * Policy strictness selection to pick the most restrictive policy among failing reviewers.
  * Actor-permission-aware validation to control when overrides apply.

* **Tests**
  * Expanded test coverage for per-reviewer overrides, permission scenarios, fallback handling, and end-to-end integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->