### PR TITLE
fix(ci): replace sync-v1-tag with sync-v2-tag and fix stale Landfall inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
         uses: misty-step/landfall@v1
         with:
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
-          moonshot-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/sync-v2-tag.yml
+++ b/.github/workflows/sync-v2-tag.yml
@@ -1,4 +1,4 @@
-name: Sync v1 Tag
+name: Sync v2 Tag
 
 on:
   workflow_run:
@@ -9,11 +9,11 @@ permissions:
   contents: write
 
 concurrency:
-  group: sync-v1-tag
+  group: sync-v2-tag
   cancel-in-progress: true
 
 jobs:
-  sync-v1:
+  sync-v2:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
@@ -25,21 +25,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Move v1 to latest green default-branch commit
+      - name: Move v2 to latest green default-branch commit
         env:
           TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
           git fetch origin --tags --force
 
-          current_tag_sha="$(git rev-parse -q --verify refs/tags/v1 || true)"
+          current_tag_sha="$(git rev-parse -q --verify refs/tags/v2 || true)"
           if [[ "$current_tag_sha" == "$TARGET_SHA" ]]; then
-            echo "v1 already points to ${TARGET_SHA}"
+            echo "v2 already points to ${TARGET_SHA}"
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git tag -fa v1 "$TARGET_SHA" -m "Move v1 to ${TARGET_SHA}"
-          git push origin refs/tags/v1 --force
+          git tag -fa v2 "$TARGET_SHA" -m "Move v2 to ${TARGET_SHA}"
+          git push origin refs/tags/v2 --force


### PR DESCRIPTION
## Summary

- **Replace `sync-v1-tag.yml` → `sync-v2-tag.yml`**: The old workflow was moving `v1` to v2 code, silently breaking consumers pinned to `@v1`. New workflow maintains the `v2` floating tag on each green CI push to master.
- **Fix `release.yml` stale input**: Updated `moonshot-api-key` (KimiCode era) to `llm-api-key` with `OPENROUTER_API_KEY` secret, matching Landfall's current action inputs.

The `v2` tag itself was already created and pushed manually at `b60a7d9`.

## Test plan

- [ ] Verify `sync-v2-tag.yml` triggers after CI passes on master and moves `v2` tag
- [ ] Verify `release.yml` Landfall step picks up `llm-api-key` input correctly
- [ ] Confirm no remaining references to `moonshot-api-key` or `sync-v1-tag`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to integrate with a different API provider.
  * Added version 2 tagging workflow for improved release management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->