### PR TITLE
fix(release): avoid v2 tag clobber during semantic-release fetch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # `sync-v2-tag.yml` force-moves the floating `v2` tag after CI.
+      # semantic-release runs `git fetch --tags` and will fail if local `v2`
+      # exists but points elsewhere ("would clobber existing tag").
+      - name: Delete local v2 tag (avoid semantic-release fetch clobber)
+        run: |
+          set -euo pipefail
+          git tag -d v2 || true
+
       # Landfall: Automated semantic-release pipeline
       # https://github.com/misty-step/landfall
       - name: Run Landfall

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_release_workflow_deletes_local_v2_tag_before_landfall() -> None:
+    release_workflow = (
+        Path(__file__).parent.parent / ".github" / "workflows" / "release.yml"
+    )
+    text = release_workflow.read_text(encoding="utf-8")
+
+    landfall = text.find("- name: Run Landfall")
+    assert landfall != -1, "expected release workflow to run Landfall"
+
+    scrub_v2 = text.find("git tag -d v2")
+    assert scrub_v2 != -1, "expected release workflow to delete local v2 tag"
+
+    assert scrub_v2 < landfall, "v2 tag scrub must run before Landfall"
+


### PR DESCRIPTION
Closes #87

## Problem
Release workflow can fail when semantic-release runs `git fetch --tags` and the floating `v2` tag moved since checkout (`would clobber existing tag`).

## Fix
Delete local `v2` tag immediately before running Landfall/semantic-release so the internal fetch can recreate it cleanly.

## Verification
- Added regression test: `tests/test_release_workflow.py`
- `python3 -m pytest tests/`
