### PR TITLE
fix(ATHENA): recognize incremental delivery patterns

### DIFF
--- a/.opencode/agents/architecture.md
+++ b/.opencode/agents/architecture.md
@@ -62,6 +62,20 @@ Secondary Focus (check if relevant)
 - Integration boundaries: external services wrapped behind stable interface
 - Evolution path: can this design survive 10x feature growth
 
+Incremental Delivery (Recognize Intentional Building Blocks)
+Some PRs intentionally deliver utilities and building blocks without full integration. This is a VALID pattern when:
+- The utility is tested and documented
+- The code is designed as a reusable building block (clear interfaces, single responsibility)
+- The PR description or context indicates follow-up integration work is planned
+- The utility solves a concrete, understood problem even if not yet wired into the full system
+
+Do NOT flag "orphan code" or "unused code" for well-designed utilities that are clearly intended as building blocks. The absence of immediate callers is not an architecture problem when the code is designed for future use.
+
+DO flag orphan code when:
+- It appears abandoned or incomplete (no tests, no docs, unclear purpose)
+- It's dead code that should have been removed
+- It's a partial implementation that doesn't stand alone
+
 Anti-Patterns (Do Not Flag)
 - Individual bugs or edge cases (Apollo's job)
 - Security issues (Sentinel's job)


### PR DESCRIPTION
## Problem
ATHENA was flagging intentional building-block PRs as architecture failures.

Example: PR #164 (bitterblossom registry-based dispatch) was flagged for:
1. ResolveSprite 'orphan code' — actually a building block with planned follow-up integration
2. --issue flag 'incomplete' — ATHENA reviewed stale SHA

The PR delivered tested, documented utilities without full integration — a valid incremental delivery pattern.

## Solution
Add explicit guidance to ATHENA for recognizing incremental delivery:

- Well-tested, documented utilities are valid building blocks even without immediate callers
- Absence of immediate integration is not an architecture problem when code is designed for future use
- Only flag orphan code when it's abandoned, dead, or incomplete

## Changes
- Added "Incremental Delivery" section to architecture reviewer agent
- Clarified when orphan code is vs isn't a problem

## Verification
- Section is properly placed before Anti-Patterns
- Guidance is specific and actionable
- Follows existing agent formatting

Fixes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architecture guidelines to clarify criteria for incremental delivery of utilities and building blocks, and expanded anti-pattern guidance for development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->