### PR TITLE
fix(prompts): APOLLO consumer/producer data-flow checklist

### DIFF
--- a/.opencode/agents/correctness.md
+++ b/.opencode/agents/correctness.md
@@ -59,6 +59,13 @@ Secondary Focus (check if relevant)
 - Migrations that can lose or corrupt data
 - Defaults changes that activate untested code paths: when a diff switches which implementation runs by default, trace the newly-defaulted path for correctness even if its lines are unchanged
 
+Consumer/Producer Data-Flow (mandatory when PR changes a consumer of shared data)
+If the diff adds/changes code that READS shared data (DB rows, shared types, artifacts, caches, event payloads):
+1) Identify what fields/invariants the consumer REQUIRES (explicit + implicit).
+2) Enumerate producers that WRITE the same data (including unchanged code).
+3) Verify each producer satisfies the consumer; if not, show the failing path.
+4) Treat silent-failure amplifiers as severity multipliers: swallowed errors, fallbacks, partial writes.
+
 Anti-Patterns (Do Not Flag)
 - Naming, formatting, style, lint rules
 - Documentation or comments unless they hide a bug

--- a/tests/test_defaults_change_awareness.py
+++ b/tests/test_defaults_change_awareness.py
@@ -54,6 +54,12 @@ class TestAgentDefaultsAwareness:
         text = (AGENTS_DIR / "correctness.md").read_text()
         assert "newly-defaulted path" in text
 
+    def test_apollo_has_consumer_producer_checklist(self):
+        text = (AGENTS_DIR / "correctness.md").read_text()
+        assert "Consumer/Producer Data-Flow" in text
+        assert "Identify what fields/invariants the consumer REQUIRES" in text
+        assert "Enumerate producers that WRITE the same data" in text
+
     def test_vulcan_mentions_defaults_changes(self):
         text = (AGENTS_DIR / "performance.md").read_text()
         assert "defaults change" in text.lower()


### PR DESCRIPTION
Closes #104

Adds a mandatory consumer/producer compatibility checklist to APOLLO so it checks cross-module data-shape invariants when PRs change consumers of shared data.

- Updated `.opencode/agents/correctness.md`
- Added regression assertions in `tests/test_defaults_change_awareness.py`

Test: `python3 -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Consumer/Producer Data-Flow guidance for validating shared data changes, including checklist items for identifying consumer requirements and enumerating producers.
  * Expanded Anti-Patterns section with additional validation criteria.

* **Tests**
  * Added test validation for consumer/producer data-flow checklist presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->