### PR TITLE
fix: disable setup-node auto-cache to prevent post-run failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,7 @@ runs:
       uses: actions/setup-node@v5
       with:
         node-version: '22'
+        package-manager-cache: false
 
     - name: Install OpenCode CLI
       shell: bash

--- a/tests/test_action_cache_settings.py
+++ b/tests/test_action_cache_settings.py
@@ -1,0 +1,51 @@
+"""Regression test for #110: setup-node cache must be disabled.
+
+actions/setup-node@v5 defaults package-manager-cache to true, which
+auto-detects the consumer repo's package manager (pnpm, yarn, etc.) and
+tries to cache its store.  Since cerberus only does `npm i -g`, no store
+directory exists and the post-run save fails — marking PASS jobs as failed.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ACTION_YML = Path(__file__).parent.parent / "action.yml"
+
+
+def _load_action():
+    return yaml.safe_load(ACTION_YML.read_text())
+
+
+def _find_step(steps, name_pattern):
+    for step in steps:
+        if re.search(name_pattern, step.get("name", ""), re.IGNORECASE):
+            return step
+    return None
+
+
+def test_setup_node_disables_package_manager_cache():
+    action = _load_action()
+    steps = action["runs"]["steps"]
+    node_step = _find_step(steps, r"setup node|node\.js")
+    assert node_step is not None, "setup-node step not found in action.yml"
+
+    with_block = node_step.get("with", {})
+    assert with_block.get("package-manager-cache") is False, (
+        "setup-node must set package-manager-cache: false to prevent "
+        "post-run cache failures when consumer repos use pnpm/yarn (#110)"
+    )
+
+
+def test_setup_python_does_not_enable_cache():
+    action = _load_action()
+    steps = action["runs"]["steps"]
+    python_step = _find_step(steps, r"setup python|python")
+    assert python_step is not None, "setup-python step not found in action.yml"
+
+    with_block = python_step.get("with", {})
+    assert "cache" not in with_block or with_block["cache"] in (None, "", False), (
+        "setup-python should not enable pip caching — cerberus has no "
+        "pip dependencies to cache"
+    )


### PR DESCRIPTION
## Summary

- Disables `package-manager-cache` on `actions/setup-node@v5` in the review action
- Adds regression tests asserting cache is disabled for both setup-node and setup-python

## Root Cause

`actions/setup-node@v5` defaults `package-manager-cache: true`, which auto-detects the consumer repo's package manager (e.g. pnpm from `packageManager` field in `package.json`). It then tries to cache the pnpm/yarn store directory in a post-run step. Since cerberus only runs `npm i -g opencode-ai`, no store directory exists, and the post-run cache save fails with:

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

This marks the entire job as failed, even when the review verdict is PASS.

## Evidence

From [moneta PR #105](https://github.com/misty-step/moneta/actions/runs/21874876236): 4/5 reviewer jobs showed red X despite PASS verdicts. The moneta workflow includes `pnpm/action-setup@v4` before cerberus, triggering the auto-detection.

## Test plan

- [x] `test_setup_node_disables_package_manager_cache` — asserts `package-manager-cache: false`
- [x] `test_setup_python_does_not_enable_cache` — guards against similar issue on Python side
- [x] Full suite: 342 passed

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled package manager caching in the Node.js setup step within the GitHub Actions workflow configuration.

* **Tests**
  * Added regression tests to validate GitHub Actions caching behavior, verifying that package manager caches are properly disabled for Node.js and not enabled for Python to prevent CI pipeline failures and improve overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->