### PR TITLE
refactor: extract duplicated PR comment upsert into shared module

### DIFF
--- a/scripts/lib/github.py
+++ b/scripts/lib/github.py
@@ -1,0 +1,119 @@
+"""GitHub PR comment utilities.
+
+Provides idempotent comment upsert using HTML markers for identification.
+Used by per-reviewer comments, council verdict, and triage diagnosis.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+class CommentPermissionError(Exception):
+    """Token lacks pull-requests: write permission."""
+
+
+def _run_gh(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a gh CLI command."""
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    if check and result.returncode != 0:
+        stderr = (result.stderr or "").lower()
+        if any(s in stderr for s in ("403", "resource not accessible", "insufficient")):
+            raise CommentPermissionError(
+                "Unable to post PR comment: token lacks pull-requests: write permission.\n"
+                "Add this to your workflow:\n"
+                "permissions:\n"
+                "  contents: read\n"
+                "  pull-requests: write"
+            )
+        raise subprocess.CalledProcessError(
+            result.returncode, result.args, result.stdout, result.stderr
+        )
+    return result
+
+
+def fetch_comments(repo: str, pr_number: int) -> list[dict]:
+    """Fetch all comments on a PR."""
+    result = _run_gh(["api", f"repos/{repo}/issues/{pr_number}/comments?per_page=100"])
+    return json.loads(result.stdout)
+
+
+def find_comment_by_marker(comments: list[dict], marker: str) -> int | None:
+    """Find the first comment containing the marker, return its numeric ID."""
+    for comment in comments:
+        body = str(comment.get("body", ""))
+        if marker in body:
+            comment_id = comment.get("id")
+            if isinstance(comment_id, int):
+                return comment_id
+    return None
+
+
+def upsert_pr_comment(
+    *,
+    repo: str,
+    pr_number: int,
+    marker: str,
+    body_file: str,
+    comments: list[dict] | None = None,
+) -> None:
+    """Find existing PR comment by HTML marker, update or create.
+
+    If comments is provided, searches that list instead of fetching from API.
+
+    Raises:
+        CommentPermissionError: Token lacks pull-requests: write permission.
+        subprocess.CalledProcessError: Other gh CLI failures.
+    """
+    if comments is None:
+        comments = fetch_comments(repo, pr_number)
+
+    existing_id = find_comment_by_marker(comments, marker)
+
+    if existing_id is not None:
+        _run_gh([
+            "api",
+            f"repos/{repo}/issues/comments/{existing_id}",
+            "-X", "PATCH",
+            "-F", f"body=@{body_file}",
+        ])
+    else:
+        _run_gh([
+            "api",
+            f"repos/{repo}/issues/{pr_number}/comments",
+            "-F", f"body=@{body_file}",
+        ])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Upsert PR comment by HTML marker.")
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--pr", type=int, required=True, help="PR number")
+    parser.add_argument("--marker", required=True, help="HTML comment marker")
+    parser.add_argument("--body-file", required=True, help="Path to comment body markdown")
+    args = parser.parse_args()
+
+    if not Path(args.body_file).exists():
+        print(f"body file not found: {args.body_file}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        upsert_pr_comment(
+            repo=args.repo,
+            pr_number=args.pr,
+            marker=args.marker,
+            body_file=args.body_file,
+        )
+    except CommentPermissionError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.CalledProcessError as exc:
+        print(f"gh command failed: {exc.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/post-comment.sh
+++ b/scripts/post-comment.sh
@@ -24,16 +24,6 @@ if [[ -z "${PR_NUMBER:-}" ]]; then
   exit 2
 fi
 
-print_permissions_help() {
-  cat >&2 <<'EOF'
-::error::Unable to post Cerberus PR comment: token lacks pull request write permission.
-Add this to your workflow:
-permissions:
-  contents: read
-  pull-requests: write
-EOF
-}
-
 marker="<!-- cerberus:${perspective} -->"
 
 reviewer_info="$(
@@ -158,33 +148,8 @@ comment_file="/tmp/${perspective}-comment.md"
   printf '%s\n' "${marker}"
 } > "$comment_file"
 
-comments_query=".[] | select(.body | contains(\"$marker\")) | .id"
-if ! existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --jq "$comments_query" 2>/tmp/cerberus-comment.err | head -1)"; then
-  err_output="$(cat /tmp/cerberus-comment.err)"
-  echo "$err_output" >&2
-  if echo "$err_output" | grep -qiE "403|resource not accessible by integration|insufficient"; then
-    print_permissions_help
-  fi
-  exit 1
-fi
-
-if [[ -n "$existing_id" ]]; then
-  # Pass body via gh's @file reader to avoid shell interpolation of comment content.
-  if ! gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" -X PATCH -F body=@"$comment_file" >/tmp/cerberus-comment.out 2>/tmp/cerberus-comment.err; then
-    err_output="$(cat /tmp/cerberus-comment.err)"
-    echo "$err_output" >&2
-    if echo "$err_output" | grep -qiE "403|resource not accessible by integration|insufficient"; then
-      print_permissions_help
-    fi
-    exit 1
-  fi
-else
-  if ! gh pr comment "$PR_NUMBER" --body-file "$comment_file" >/tmp/cerberus-comment.out 2>/tmp/cerberus-comment.err; then
-    err_output="$(cat /tmp/cerberus-comment.err)"
-    echo "$err_output" >&2
-    if echo "$err_output" | grep -qiE "403|resource not accessible by integration|insufficient"; then
-      print_permissions_help
-    fi
-    exit 1
-  fi
-fi
+python3 "$CERBERUS_ROOT/scripts/lib/github.py" \
+  --repo "$GITHUB_REPOSITORY" \
+  --pr "$PR_NUMBER" \
+  --marker "$marker" \
+  --body-file "$comment_file"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,279 @@
+"""Tests for lib.github PR comment upsert."""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from lib.github import (
+    CommentPermissionError,
+    find_comment_by_marker,
+    upsert_pr_comment,
+)
+
+
+class TestFindCommentByMarker:
+    def test_finds_matching_comment(self):
+        comments = [
+            {"id": 100, "body": "unrelated comment"},
+            {"id": 200, "body": "<!-- cerberus:council -->\nCouncil verdict"},
+            {"id": 300, "body": "another comment"},
+        ]
+        assert find_comment_by_marker(comments, "<!-- cerberus:council -->") == 200
+
+    def test_returns_none_when_no_match(self):
+        comments = [
+            {"id": 100, "body": "unrelated"},
+            {"id": 200, "body": "also unrelated"},
+        ]
+        assert find_comment_by_marker(comments, "<!-- cerberus:council -->") is None
+
+    def test_returns_none_for_empty_list(self):
+        assert find_comment_by_marker([], "<!-- cerberus:council -->") is None
+
+    def test_different_markers_dont_conflict(self):
+        comments = [
+            {"id": 100, "body": "<!-- cerberus:correctness -->\nReview"},
+            {"id": 200, "body": "<!-- cerberus:council -->\nCouncil verdict"},
+        ]
+        assert find_comment_by_marker(comments, "<!-- cerberus:correctness -->") == 100
+        assert find_comment_by_marker(comments, "<!-- cerberus:council -->") == 200
+        assert find_comment_by_marker(comments, "<!-- cerberus:security -->") is None
+
+    def test_skips_non_integer_ids(self):
+        comments = [
+            {"id": "IC_abc123", "body": "<!-- cerberus:council -->\nContent"},
+        ]
+        assert find_comment_by_marker(comments, "<!-- cerberus:council -->") is None
+
+    def test_first_match_wins(self):
+        comments = [
+            {"id": 100, "body": "<!-- cerberus:council -->\nFirst"},
+            {"id": 200, "body": "<!-- cerberus:council -->\nSecond"},
+        ]
+        assert find_comment_by_marker(comments, "<!-- cerberus:council -->") == 100
+
+
+class TestUpsertPrComment:
+    def test_creates_comment_when_none_exists(self, monkeypatch, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text("Test body")
+
+        calls = []
+
+        def mock_run_gh(args, *, check=True):
+            calls.append(args)
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod, "_run_gh", mock_run_gh)
+
+        upsert_pr_comment(
+            repo="owner/repo",
+            pr_number=42,
+            marker="<!-- test -->",
+            body_file=str(body_file),
+            comments=[],
+        )
+
+        assert len(calls) == 1
+        assert calls[0] == [
+            "api",
+            "repos/owner/repo/issues/42/comments",
+            "-F",
+            f"body=@{body_file}",
+        ]
+
+    def test_updates_existing_comment(self, monkeypatch, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text("Updated body")
+
+        calls = []
+
+        def mock_run_gh(args, *, check=True):
+            calls.append(args)
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod, "_run_gh", mock_run_gh)
+
+        comments = [
+            {"id": 555, "body": "<!-- test -->\nOld body"},
+        ]
+
+        upsert_pr_comment(
+            repo="owner/repo",
+            pr_number=42,
+            marker="<!-- test -->",
+            body_file=str(body_file),
+            comments=comments,
+        )
+
+        assert len(calls) == 1
+        assert calls[0] == [
+            "api",
+            "repos/owner/repo/issues/comments/555",
+            "-X",
+            "PATCH",
+            "-F",
+            f"body=@{body_file}",
+        ]
+
+    def test_fetches_comments_when_not_provided(self, monkeypatch, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text("Body")
+
+        calls = []
+
+        def mock_run_gh(args, *, check=True):
+            calls.append(args)
+            if args[1].endswith("per_page=100") and "-F" not in args:
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=0,
+                    stdout='[{"id": 999, "body": "<!-- test -->\\nContent"}]',
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod, "_run_gh", mock_run_gh)
+
+        upsert_pr_comment(
+            repo="owner/repo",
+            pr_number=42,
+            marker="<!-- test -->",
+            body_file=str(body_file),
+        )
+
+        assert len(calls) == 2
+        assert calls[1] == [
+            "api",
+            "repos/owner/repo/issues/comments/999",
+            "-X",
+            "PATCH",
+            "-F",
+            f"body=@{body_file}",
+        ]
+
+    def test_multiple_markers_dont_conflict(self, monkeypatch, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text("Body for council")
+
+        calls = []
+
+        def mock_run_gh(args, *, check=True):
+            calls.append(args)
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod, "_run_gh", mock_run_gh)
+
+        comments = [
+            {"id": 100, "body": "<!-- cerberus:correctness -->\nReview"},
+            {"id": 200, "body": "<!-- cerberus:council -->\nVerdict"},
+        ]
+
+        upsert_pr_comment(
+            repo="owner/repo",
+            pr_number=42,
+            marker="<!-- cerberus:council -->",
+            body_file=str(body_file),
+            comments=comments,
+        )
+
+        assert calls[0] == [
+            "api",
+            "repos/owner/repo/issues/comments/200",
+            "-X",
+            "PATCH",
+            "-F",
+            f"body=@{body_file}",
+        ]
+
+    def test_permission_denied_raises(self, monkeypatch, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text("Body")
+
+        def mock_run_gh(args, *, check=True):
+            raise CommentPermissionError("no permission")
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod, "_run_gh", mock_run_gh)
+
+        with pytest.raises(CommentPermissionError):
+            upsert_pr_comment(
+                repo="owner/repo",
+                pr_number=42,
+                marker="<!-- test -->",
+                body_file=str(body_file),
+                comments=[],
+            )
+
+
+class TestRunGhErrorHandling:
+    def test_403_raises_permission_error(self, monkeypatch):
+        def mock_subprocess_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="HTTP 403: Resource not accessible by integration",
+            )
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+
+        with pytest.raises(CommentPermissionError, match="pull-requests: write"):
+            mod._run_gh(["api", "repos/x/y/issues/1/comments"])
+
+    def test_insufficient_permission_raises(self, monkeypatch):
+        def mock_subprocess_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="insufficient permissions for this resource",
+            )
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+
+        with pytest.raises(CommentPermissionError):
+            mod._run_gh(["api", "repos/x/y/issues/1/comments"])
+
+    def test_other_errors_raise_called_process_error(self, monkeypatch):
+        def mock_subprocess_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                stderr="rate limit exceeded",
+            )
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            mod._run_gh(["api", "repos/x/y/issues/1/comments"])
+
+    def test_success_returns_result(self, monkeypatch):
+        def mock_subprocess_run(args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="ok", stderr=""
+            )
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod.subprocess, "run", mock_subprocess_run)
+
+        result = mod._run_gh(["api", "repos/x/y/issues/1/comments"])
+        assert result.stdout == "ok"

--- a/tests/test_verdict_action.py
+++ b/tests/test_verdict_action.py
@@ -18,18 +18,20 @@ def test_override_query_uses_rest_user_login() -> None:
     assert re.search(r"actor:\s*\.user\.login", content)
 
 
-def test_verdict_action_updates_comment_with_typed_file_field() -> None:
+def test_verdict_action_uses_shared_upsert() -> None:
     content = VERDICT_ACTION_FILE.read_text()
 
-    assert "-X PATCH -F body=@/tmp/council-comment.md" in content
-    assert "-X PATCH -f body=\"$(cat /tmp/council-comment.md)\"" not in content
+    assert "scripts/lib/github.py" in content
+    assert "--body-file /tmp/council-comment.md" in content
+    assert "--marker" in content
 
 
-def test_post_comment_updates_comment_with_typed_file_field() -> None:
+def test_post_comment_uses_shared_upsert() -> None:
     content = POST_COMMENT_SCRIPT.read_text()
 
-    assert "-X PATCH -F body=@\"$comment_file\"" in content
-    assert "-X PATCH -f body=\"$(cat \"$comment_file\")\"" not in content
+    assert "scripts/lib/github.py" in content
+    assert "--body-file" in content
+    assert "--marker" in content
 
 
 def test_action_uses_api_key_fallback_validator() -> None:
@@ -82,12 +84,11 @@ def test_readme_quick_start_uses_openrouter_secret_name() -> None:
     assert "MOONSHOT_API_KEY" not in content
 
 
-def test_permission_help_is_present_in_comment_scripts() -> None:
-    post_comment_content = POST_COMMENT_SCRIPT.read_text()
-    verdict_content = VERDICT_ACTION_FILE.read_text()
+def test_permission_help_is_present_in_shared_module() -> None:
+    github_module = ROOT / "scripts" / "lib" / "github.py"
+    content = github_module.read_text()
 
-    assert "pull-requests: write" in post_comment_content
-    assert "pull-requests: write" in verdict_content
+    assert "pull-requests: write" in content
 
 
 def test_verdict_action_avoids_heredoc_in_run_block() -> None:

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -156,35 +156,11 @@ runs:
           --council-json /tmp/council-verdict.json \
           --output /tmp/council-comment.md
 
-        print_permissions_help() {
-          {
-            echo "::error::Unable to post council PR comment: token lacks pull request write permission."
-            echo "Add this to your workflow:"
-            echo "permissions:"
-            echo "  contents: read"
-            echo "  pull-requests: write"
-          } >&2
-        }
-
-        EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '.[] | select(.body | contains("cerberus:council")) | .id' 2>/tmp/cerberus-council.err | head -1) || true
-        if [ -n "$EXISTING" ]; then
-          # Pass body via gh's @file reader to avoid shell interpolation of comment content.
-          if ! gh api "repos/${REPO}/issues/comments/${EXISTING}" -X PATCH -F body=@/tmp/council-comment.md >/tmp/cerberus-council.out 2>/tmp/cerberus-council.err; then
-            cat /tmp/cerberus-council.err >&2
-            if grep -qiE "403|resource not accessible by integration|insufficient" /tmp/cerberus-council.err; then
-              print_permissions_help
-            fi
-            exit 1
-          fi
-        else
-          if ! gh pr comment "$PR_NUMBER" --body-file /tmp/council-comment.md >/tmp/cerberus-council.out 2>/tmp/cerberus-council.err; then
-            cat /tmp/cerberus-council.err >&2
-            if grep -qiE "403|resource not accessible by integration|insufficient" /tmp/cerberus-council.err; then
-              print_permissions_help
-            fi
-            exit 1
-          fi
-        fi
+        python3 "$CERBERUS_ROOT/scripts/lib/github.py" \
+          --repo "$REPO" \
+          --pr "$PR_NUMBER" \
+          --marker "<!-- cerberus:council -->" \
+          --body-file /tmp/council-comment.md
 
     - name: Check verdict
       if: always() && steps.aggregate.outcome == 'success' && (inputs.fail-on-verdict == 'true' || inputs.fail-on-skip == 'true')


### PR DESCRIPTION
## Summary

- Extracts `upsert_pr_comment()` into `scripts/lib/github.py` — shared by all three comment-posting call sites
- Replaces duplicated find-by-marker + PATCH/POST logic in `post-comment.sh`, `verdict/action.yml`, and `triage.py`
- Shared module handles 403 permission errors with actionable guidance
- CLI entrypoint (`python3 scripts/lib/github.py --repo --pr --marker --body-file`) for bash callers
- Net -81 lines across the codebase

Closes #48

## Test plan

- [x] 15 new tests in `tests/test_github.py` covering:
  - Create comment when none exists
  - Update existing comment matched by marker
  - Multiple markers don't conflict
  - First match wins
  - Non-integer IDs skipped (GraphQL node IDs)
  - Permission denied (403) raises `CommentPermissionError`
  - Rate limit / other errors raise `CalledProcessError`
  - Auto-fetch comments when not pre-provided
- [x] 431/431 existing tests pass (no regressions)
- [x] `shellcheck` and `py_compile` clean
- [ ] E2E: trigger Cerberus on moonbridge PR to verify comment posting works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved GitHub PR comment management with centralized, idempotent comment handling for better reliability across the system.
  * Enhanced error handling with user-friendly messages for permission issues.

* **Tests**
  * Added comprehensive test coverage for comment management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->