### PR TITLE
Scope findings to PR delta, not pre-existing conditions

### DIFF
--- a/.opencode/agents/maintainability.md
+++ b/.opencode/agents/maintainability.md
@@ -148,6 +148,11 @@ Bad finding (do NOT report this):
   Title: "Could add JSDoc to exported function"
   Why this is bad: The function name and types are self-documenting. Adding docs for docs' sake is noise.
 
+Bad finding (pre-existing condition, do NOT report this):
+- severity: major, category: component-complexity, file: src/pages/ChatPage.tsx, line: 1
+  Title: "ChatPage component has grown too large with mixed responsibilities — spans 800+ lines"
+  Why this is bad: The component was already ~650 lines before this PR. The PR added proportional complexity for its feature. Flag only the delta introduced by this PR, not the pre-existing total.
+
 JSON Schema
 ```json
 {

--- a/templates/review-prompt.md
+++ b/templates/review-prompt.md
@@ -22,10 +22,16 @@ Read this file to see all changes. Skip lockfiles, generated/minified files, and
 ## Scope Rules
 - ONLY flag issues in code that is ADDED or MODIFIED in this diff.
 - You MAY read surrounding code for context, but do not report issues in unchanged code.
-- If an existing bug is made worse by this change, flag it. If it was already there, skip it.
 - Do not suggest improvements to code outside the diff.
 - Prioritize: new files over modified files, application code over test code.
 - If the diff is very large, focus on the highest-risk changes and note which files you deprioritized.
+
+### Pre-Existing Conditions
+Findings must be attributable to THIS PR's changes, not the codebase's history.
+- If a file had pre-existing issues before this PR, do NOT flag them as findings.
+- If this PR makes a pre-existing issue WORSE, flag only the delta — the new complexity introduced, not the total. Example: "This PR adds 150 lines to an already-large component" is valid; "This 800-line component is too large" is not.
+- If a pre-existing condition is relevant context for a finding, mention it in the description as background, not as the finding itself.
+- Do NOT inflate severity because of accumulated pre-existing debt. Judge the PR's contribution in isolation.
 
 ## Defaults Change Awareness
 - When a diff changes DEFAULT BEHAVIOR (feature flags, env var defaults, fallback order, backend selection, default function arguments), the newly-defaulted code path is IN SCOPE for review even if its lines are unchanged.

--- a/tests/test_pre_existing_scope.py
+++ b/tests/test_pre_existing_scope.py
@@ -1,0 +1,56 @@
+"""Verify review prompt scopes findings to PR-introduced changes only.
+
+Regression test for issue #103: reviewers flagged pre-existing conditions
+(e.g., "this file is too large") that existed before the PR, creating noise
+and making authors responsible for inherited tech debt.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+REVIEW_PROMPT = ROOT / "templates" / "review-prompt.md"
+AGENTS_DIR = ROOT / ".opencode" / "agents"
+
+
+class TestReviewPromptPreExistingScope:
+    """The shared review prompt must instruct reviewers to flag only
+    the delta introduced by the PR, not pre-existing conditions."""
+
+    def test_contains_pre_existing_conditions_section(self):
+        text = REVIEW_PROMPT.read_text()
+        assert "### Pre-Existing Conditions" in text
+
+    def test_instructs_not_to_flag_pre_existing(self):
+        text = REVIEW_PROMPT.read_text()
+        assert "do NOT flag them as findings" in text
+
+    def test_instructs_delta_only(self):
+        text = REVIEW_PROMPT.read_text()
+        assert "flag only the delta" in text
+
+    def test_instructs_no_severity_inflation(self):
+        text = REVIEW_PROMPT.read_text()
+        assert "Do NOT inflate severity" in text
+
+    def test_pre_existing_section_inside_scope_rules(self):
+        """Pre-existing conditions guidance must be within scope rules,
+        before evidence rules."""
+        text = REVIEW_PROMPT.read_text()
+        scope_pos = text.index("## Scope Rules")
+        pre_existing_pos = text.index("### Pre-Existing Conditions")
+        evidence_pos = text.index("## Evidence Rules")
+        assert scope_pos < pre_existing_pos < evidence_pos
+
+
+class TestArtemisPreExistingExample:
+    """ARTEMIS (maintainability) must include a negative example for
+    pre-existing condition findings, since this reviewer is most likely
+    to flag accumulated complexity."""
+
+    def test_artemis_has_pre_existing_bad_example(self):
+        text = (AGENTS_DIR / "maintainability.md").read_text()
+        assert "pre-existing condition" in text.lower()
+
+    def test_artemis_bad_example_shows_component_size(self):
+        text = (AGENTS_DIR / "maintainability.md").read_text()
+        assert "Flag only the delta introduced by this PR" in text


### PR DESCRIPTION
## Summary
Reviewers flagged inherited tech debt (e.g. "800-line component too large") as major findings when the PR only added proportional complexity. This noise erodes signal-to-noise ratio and trains teams to ignore the reviewer.

Closes #103

## Changes
- `templates/review-prompt.md`: Added **Pre-Existing Conditions** subsection under Scope Rules with delta-only, no-inflation guidance
- `.opencode/agents/maintainability.md`: Added a bad-finding few-shot example showing the ARTEMIS anti-pattern from the issue evidence
- `tests/test_pre_existing_scope.py`: 7 invariant tests verifying the prompt language and ARTEMIS example persist

## Acceptance Criteria
- [x] Review prompt instructs reviewers to flag only the delta, not pre-existing total
- [x] Review prompt instructs reviewers not to inflate severity from accumulated debt
- [x] ARTEMIS has a concrete bad-finding example for pre-existing component size
- [x] Invariant tests prevent regression

## Manual QA
```bash
python3 -m pytest tests/test_pre_existing_scope.py -v  # 7 pass
python3 -m pytest tests/ -v                              # 539 pass
```

Verify prompt wording:
```bash
grep -A6 "Pre-Existing Conditions" templates/review-prompt.md
grep "pre-existing" .opencode/agents/maintainability.md
```

## Test Coverage
- `tests/test_pre_existing_scope.py` — 7 tests covering prompt section existence, key phrases, ordering, and ARTEMIS example

🤖 Generated with [Claude Code](https://claude.com/claude-code)