### PR TITLE
fix(action): accept deprecated kimi-api-key input

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Use `templates/triage-workflow.yml` to enable:
 | `perspective` | yes | - | Review perspective |
 | `github-token` | yes | - | GitHub token for PR comments |
 | `api-key` | no | - | OpenRouter API key (optional if `CERBERUS_API_KEY` or `OPENROUTER_API_KEY` env is set) |
+| `kimi-api-key` | no | - | Deprecated alias for `api-key` (OpenRouter API key) |
 | `context` | no | `''` | Maintainer-provided project context injected into the reviewer prompt (do not include secrets) |
 | `model` | no | `defaults/config.yml` | Model override (else per-reviewer config, then `model.default`) |
 | `fallback-models` | no | `openrouter/google/gemini-3-flash-preview,...` | Comma-separated fallback models, tried on transient failure |

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   api-key:
     description: 'OpenRouter API key (optional if CERBERUS_API_KEY or OPENROUTER_API_KEY env is set)'
     required: false
+  kimi-api-key:
+    description: 'Deprecated alias for api-key (OpenRouter API key)'
+    required: false
   model:
     description: 'Model name (optional; defaults to per-reviewer config)'
     default: ''
@@ -79,6 +82,7 @@ runs:
       env:
         CERBERUS_ROOT: ${{ github.action_path }}
         INPUT_API_KEY: ${{ inputs.api-key }}
+        INPUT_KIMI_API_KEY: ${{ inputs.kimi-api-key }}
         CERBERUS_API_KEY: ${{ env.CERBERUS_API_KEY }}
         OPENROUTER_API_KEY: ${{ env.OPENROUTER_API_KEY }}
       run: |

--- a/scripts/validate-inputs.sh
+++ b/scripts/validate-inputs.sh
@@ -3,6 +3,24 @@ set -euo pipefail
 
 resolved_key="${INPUT_API_KEY:-}"
 if [[ -z "$resolved_key" ]]; then
+  if [[ -n "${INPUT_KIMI_API_KEY:-}" ]]; then
+    resolved_key="${INPUT_KIMI_API_KEY}"
+    cat >&2 <<'EOF'
+::warning::Input 'kimi-api-key' is deprecated. Use 'api-key' (OpenRouter key).
+
+Migration (recommended):
+- uses: misty-step/cerberus@v2
+  with:
+    api-key: ${{ secrets.OPENROUTER_API_KEY }}
+
+Legacy (deprecated alias):
+- uses: misty-step/cerberus@v1
+  with:
+    kimi-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+EOF
+  fi
+fi
+if [[ -z "$resolved_key" ]]; then
   resolved_key="${CERBERUS_API_KEY:-}"
 fi
 if [[ -z "$resolved_key" ]]; then
@@ -14,8 +32,9 @@ if [[ -z "$resolved_key" ]]; then
 ::error::Missing API key for Cerberus review.
 Provide one of:
 1) with: api-key  (recommended)
-2) env: CERBERUS_API_KEY  (job-level env only)
-3) env: OPENROUTER_API_KEY  (job-level env only)
+2) with: kimi-api-key  (deprecated alias)
+3) env: CERBERUS_API_KEY  (job-level env only)
+4) env: OPENROUTER_API_KEY  (job-level env only)
 
 Note: step-level env: does NOT propagate into composite actions.
 Use 'with: api-key' or set env at the job level.


### PR DESCRIPTION
Closes #160.

### What
- Re-add `kimi-api-key` as a deprecated alias for `api-key` in `action.yml`
- Teach `validate-inputs.sh` to accept the alias + emit a migration warning
- Document the deprecated alias in `README.md`
- Add tests for alias + precedence

### Why
`@v1` consumers using `with: kimi-api-key:` were silently passing an empty input after the OpenRouter migration.

### Notes
This only restores the old input name as an alias for the OpenRouter key. Consumers still need an OpenRouter key value (or upgrade to `@v2` and rename the input).
