### PR TITLE
fix: sync-v1-tag test uses bare remote for proper isolation

### DIFF
--- a/scripts/tests/sync-v1-tag.test.sh
+++ b/scripts/tests/sync-v1-tag.test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # Test configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TEST_DIR=$(mktemp -d)
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/sync-v1-tag.XXXXXX")
 TEST_REPO="$TEST_DIR/repo"
 BARE_REMOTE="$TEST_DIR/remote.git"
 trap 'rm -rf "$TEST_DIR"' EXIT
@@ -47,7 +47,7 @@ setup_repo() {
   git tag -a v2.0.0 -m "Version 2.0.0"
 
   # Push everything to bare remote
-  git push origin master --tags
+  git push origin HEAD --tags
 }
 
 # Test: Finds latest v1.x.x tag


### PR DESCRIPTION
## Summary
Fixes the `Sync v1 Tag` CI workflow test failure. The test shared a single temp directory across all 4 test functions, causing `fatal: tag 'v1.0.0' already exists` on the second `setup_repo()` call.

## Changes
- Each test now creates a fresh bare remote + working clone pair
- `sync-v1-tag.sh` can properly `git fetch origin` and `git push origin` during tests
- Removed `|| true` from `test_updates_v1_tag` since the script now succeeds properly

## Test plan
- [x] All 4 sync-v1-tag tests pass locally
- [x] Main test suite (551 tests) unaffected
- [ ] CI `Sync v1 Tag` workflow should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for tag synchronization: uses an isolated remote-backed test repository, pushes branches and tags to that remote, and runs flows against the remote-tracked state.
  * Ensures explicit pushes when tags change, tighter isolation, and minor test formatting/flow refinements for more reliable tag-sync assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Acceptance Criteria
- [ ] All 4 test functions in `scripts/tests/sync-v1-tag.test.sh` pass when run in sequence
- [ ] Each test creates isolated bare remote and working clone (no shared state)
- [ ] `test_updates_v1_tag` succeeds without `|| true` (script exits cleanly)
- [ ] `git fetch origin` and `git push origin` work correctly in test environment
- [ ] CI `Sync v1 Tag` workflow passes on this PR

## Manual QA Steps
```bash
# Clone the repo
cd ~/repos/misty-step/cerberus

# Run the sync-v1-tag tests directly
bash scripts/tests/sync-v1-tag.test.sh

# Verify exit code is 0 (all tests passed)
echo "Exit code: $?"

# Run full test suite to ensure no regressions
python3 -m pytest tests/ -v --timeout=30 -x
```
