### PR TITLE
fix: model parse failures produce SKIP instead of FAIL

### DIFF
--- a/scripts/parse-review.py
+++ b/scripts/parse-review.py
@@ -227,7 +227,7 @@ def fail(msg: str) -> NoReturn:
                            "description": "Reviewer produced a scratchpad review without structured JSON output. Raw output is preserved in workflow logs/artifacts.",
                            "suggestion": "No action needed; see the workflow run for the preserved raw output.",
                        }])
-    write_fallback(REVIEWER_NAME, msg, raw_review=raw_text or None)
+    write_fallback(REVIEWER_NAME, msg, verdict="SKIP", raw_review=raw_text or None)
 
 
 def read_input(path: str | None) -> str:
@@ -406,6 +406,13 @@ def looks_like_api_error(text: str) -> tuple[bool, str, str]:
 
 
 def validate(obj: dict) -> None:
+    # Inject known metadata fields before validation — models often omit these
+    # even when the rest of the review is valid.
+    if "reviewer" not in obj:
+        obj["reviewer"] = REVIEWER_NAME
+    if "perspective" not in obj:
+        obj["perspective"] = PERSPECTIVE
+
     required_root = [
         "reviewer",
         "perspective",


### PR DESCRIPTION
## Summary

Closes #175. Model parse/validation failures in `parse-review.py` now produce **SKIP** verdicts instead of **FAIL**, preventing infrastructure issues (model timeouts, malformed output, missing fields) from blocking PRs.

## Changes

- **`validate()`**: Injects known `reviewer` and `perspective` fields from environment before validation, salvaging reviews that are complete except for metadata the model omitted
- **`fail()`**: Default fallback verdict changed from `FAIL` to `SKIP` — all `fail()` call sites represent parse/infrastructure errors, never code quality findings
- **Tests**: Updated 10 existing assertions from FAIL→SKIP for parse error scenarios; added 2 new tests covering the exact bug scenario (missing `reviewer` field salvaged via injection)

## Acceptance Criteria

- [x] Missing `reviewer`/`perspective` fields are injected from env, review parses normally
- [x] Invalid JSON, missing required fields, bad severity/confidence all produce SKIP (not FAIL)
- [x] Legitimate code quality FAILs (from `enforce_verdict_consistency`) are unaffected
- [x] 617 tests pass, 0 failures

## Manual QA

```bash
# Reproduce the exact scenario from the issue: model omits "reviewer" field
echo '```json
{"verdict":"PASS","confidence":0.85,"summary":"Clean","findings":[],"stats":{"files_reviewed":3,"files_with_issues":0,"critical":0,"major":0,"minor":0,"info":0}}
```' | REVIEWER_NAME=VULCAN PERSPECTIVE=performance python3 scripts/parse-review.py
# Expected: verdict=PASS, reviewer=VULCAN (salvaged)

# Invalid JSON still non-blocking:
echo '```json
{invalid}
```' | python3 scripts/parse-review.py
# Expected: verdict=SKIP (not FAIL)
```

## Test Coverage

- `tests/test_parse_review.py` — 115 tests covering parse errors, validation, field injection, verdict consistency, evidence downgrade, stale knowledge, speculative suggestions, API errors, timeouts, raw review preservation
- New: `test_missing_reviewer_field_salvaged`, `test_missing_reviewer_only_salvaged`


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for malformed inputs—the system now uses a non-blocking approach instead of failing, allowing processing to continue gracefully.
  * Enhanced fallback behavior to properly handle missing or invalid data without interrupting the workflow.

* **Tests**
  * Updated existing tests to reflect improved error-handling behavior.
  * Added new tests validating recovery mechanisms when critical fields are missing from external sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->