### PR TITLE
Inline PR review comments for council findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ consumer workflow (.github/workflows/cerberus.yml)
         └── uses: misty-step/cerberus/verdict@v2  (verdict/action.yml)
             ├── download verdict artifacts
             ├── aggregate-verdict.py  (override handling + council decision)
-            └── post council comment + optional fail on FAIL
+            ├── post council comment
+            ├── post PR review w/ inline comments
+            └── optional fail on FAIL
 
     └── triage job (optional, separate workflow/job)
         └── uses: misty-step/cerberus/triage@v2  (triage/action.yml)
@@ -67,6 +69,7 @@ Shell/bash access is denied per agent via `permission` in the agent markdown fro
 - `scripts/parse-review.py` - extracts last ` ```json ` block, validates required fields/types
 - `scripts/post-comment.sh` - formats findings as markdown, upserts comment using HTML marker for idempotency
 - `scripts/aggregate-verdict.py` - reads verdict JSON artifacts, applies override logic, writes council verdict
+- `scripts/post-council-review.py` - posts a single PR review with inline comments (best-effort) for council findings
 - `scripts/triage.py` - triage trigger router + circuit breaker + diagnosis/fix runtime
 
 ## Verdict Logic

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ jobs:
 1. Each reviewer runs as a parallel matrix job
 2. OpenCode CLI analyzes the PR diff from each reviewer's perspective (default: Kimi K2.5 via OpenRouter, configurable per reviewer)
 3. Reviewer runtime retries transient provider failures (429, 5xx, network) up to 3 times with 2s/4s/8s backoff and honors `Retry-After` when present
-4. Each reviewer posts a structured comment with findings
-5. The verdict job aggregates all reviews into a verdict-first council comment with collapsible reviewer sections, severity-tagged findings, file/line references, review scope, and per-reviewer timing
+4. Each reviewer uploads a structured verdict artifact (optionally posts a per-reviewer PR comment)
+5. The verdict job aggregates all reviews, posts a council comment, and posts a PR review with inline comments (up to 30) anchored to diff lines
 6. Council verdict: **FAIL** on critical fail or 2+ fails, **WARN** on warnings or a single non-critical fail, **PASS** otherwise
 
 ## Auto-Triage (v1.1)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Cerberus is agentic DevOps composed from distinct, focused modules. Each module 
 ## Modules
 
 ### Module 1: Council Review (GitHub Action) — **v1.0**
-**What:** Multi-AI code review council. 6 specialist reviewers analyze every PR from different angles (correctness, architecture, security, performance, maintainability, testing). Synthesizes verdicts into a unified council comment.
+**What:** Multi-AI code review council. 6 specialist reviewers analyze every PR from different angles (correctness, architecture, security, performance, maintainability, testing). Synthesizes verdicts into a unified council comment and a PR review with inline comments.
 
 **Status:** Working. Deployed across all Misty Step repos. Needs hardening.
 

--- a/scripts/lib/diff_positions.py
+++ b/scripts/lib/diff_positions.py
@@ -1,0 +1,52 @@
+"""Unified diff helpers for GitHub PR review comments.
+
+GitHub's PR review APIs accept `position`, which is a 1-indexed line offset
+within a file's diff patch (the `patch` field from `pulls/{pr}/files`).
+
+This module maps new-file absolute line numbers to diff positions.
+"""
+
+from __future__ import annotations
+
+import re
+
+_HUNK_RE = re.compile(
+    r"^@@ -(?P<old_start>\d+)(?:,(?P<old_count>\d+))? \+(?P<new_start>\d+)(?:,(?P<new_count>\d+))? @@"
+)
+
+
+def build_newline_to_position(patch: str) -> dict[int, int]:
+    """Return map: new-file line number -> patch position (1-indexed).
+
+    Only lines present in the patch (context or additions) are mapped.
+    Deletions don't advance the new-file line counter.
+    """
+    mapping: dict[int, int] = {}
+    new_line: int | None = None
+
+    for position, raw in enumerate((patch or "").splitlines(), start=1):
+        m = _HUNK_RE.match(raw)
+        if m:
+            new_line = int(m.group("new_start"))
+            continue
+
+        if new_line is None:
+            continue
+
+        if not raw:
+            continue
+
+        prefix = raw[0]
+        if prefix == "\\":
+            # "\ No newline at end of file" marker line.
+            continue
+
+        if prefix in {" ", "+"}:
+            mapping[new_line] = position
+            new_line += 1
+            continue
+
+        if prefix == "-":
+            continue
+
+    return mapping

--- a/scripts/lib/github_reviews.py
+++ b/scripts/lib/github_reviews.py
@@ -1,0 +1,98 @@
+"""GitHub PR review utilities.
+
+This module is intentionally small: list reviews, list PR files (with patches),
+create a single PR review with inline comments.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import dataclass
+
+from lib import github as gh
+
+
+@dataclass(frozen=True)
+class ReviewComment:
+    path: str
+    position: int
+    body: str
+
+
+def list_pr_reviews(repo: str, pr_number: int) -> list[dict]:
+    result = gh._run_gh(["api", f"repos/{repo}/pulls/{pr_number}/reviews?per_page=100"])
+    data = json.loads(result.stdout)
+    return data if isinstance(data, list) else []
+
+
+def find_review_id_by_marker(reviews: list[dict], marker: str) -> int | None:
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        body = str(review.get("body", "") or "")
+        if marker in body:
+            rid = review.get("id")
+            if isinstance(rid, int):
+                return rid
+    return None
+
+
+def list_pr_files(repo: str, pr_number: int) -> list[dict]:
+    # --paginate without --slurp does not produce valid JSON.
+    result = gh._run_gh(
+        [
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/pulls/{pr_number}/files?per_page=100",
+        ]
+    )
+    pages = json.loads(result.stdout)
+    if not isinstance(pages, list):
+        return []
+    files: list[dict] = []
+    for page in pages:
+        if isinstance(page, list):
+            for item in page:
+                if isinstance(item, dict):
+                    files.append(item)
+    return files
+
+
+def create_pr_review(
+    *,
+    repo: str,
+    pr_number: int,
+    commit_id: str,
+    body: str,
+    comments: list[ReviewComment],
+) -> dict:
+    payload: dict[str, object] = {
+        "event": "COMMENT",
+        "commit_id": commit_id,
+        "body": body,
+    }
+    if comments:
+        payload["comments"] = [
+            {"path": c.path, "position": c.position, "body": c.body} for c in comments
+        ]
+
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        json.dump(payload, handle)
+        handle.flush()
+        tmp_path = handle.name
+
+    result = gh._run_gh(
+        [
+            "api",
+            "-X",
+            "POST",
+            f"repos/{repo}/pulls/{pr_number}/reviews",
+            "--input",
+            tmp_path,
+        ]
+    )
+    data = json.loads(result.stdout or "{}")
+    return data if isinstance(data, dict) else {}
+

--- a/scripts/post-council-review.py
+++ b/scripts/post-council-review.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Post council output as a PR review with inline comments.
+
+This is additive: the verdict action still posts the council issue comment
+(used by triage). This script posts a single PR review for the same SHA with
+up to 30 inline comments anchored to diff `position`s.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from lib.diff_positions import build_newline_to_position
+from lib.github import CommentPermissionError, TransientGitHubError
+from lib.github_reviews import ReviewComment, create_pr_review, find_review_id_by_marker, list_pr_files, list_pr_reviews
+from lib.markdown import severity_icon
+
+MAX_INLINE_COMMENTS = 30
+
+_SEVERITY_ORDER = {"critical": 0, "major": 1, "minor": 2, "info": 3}
+
+
+def fail(message: str, code: int = 2) -> None:
+    print(f"post-council-review: {message}", file=sys.stderr)
+    sys.exit(code)
+
+
+def warn(message: str) -> None:
+    print(f"::warning::{message}", file=sys.stderr)
+
+
+def notice(message: str) -> None:
+    print(f"::notice::{message}", file=sys.stderr)
+
+
+def as_int(value: object) -> int | None:
+    try:
+        i = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return i
+
+
+def normalize_severity(value: object) -> str:
+    text = str(value or "").strip().lower()
+    return text if text in _SEVERITY_ORDER else "info"
+
+
+def normalize_path(path: object) -> str:
+    text = str(path or "").strip()
+    if text.startswith(("a/", "b/")):
+        text = text[2:]
+    if text.startswith("./"):
+        text = text[2:]
+    return text
+
+
+def read_json(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        fail(f"unable to read {path}: {exc}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+    return data if isinstance(data, dict) else {}
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        fail(f"unable to read {path}: {exc}")
+
+
+def review_marker(head_sha: str) -> str:
+    short = head_sha[:12] if head_sha else "<head-sha>"
+    return f"<!-- cerberus:council-review sha={short} -->"
+
+
+def collect_inline_findings(council: dict) -> list[dict]:
+    reviewers = council.get("reviewers")
+    if not isinstance(reviewers, list):
+        return []
+
+    out: list[dict] = []
+    for reviewer in reviewers:
+        if not isinstance(reviewer, dict):
+            continue
+        rname = str(reviewer.get("reviewer") or reviewer.get("perspective") or "unknown")
+        findings = reviewer.get("findings")
+        if not isinstance(findings, list):
+            continue
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            file = normalize_path(finding.get("file"))
+            line = as_int(finding.get("line"))
+            if not file or line is None or line <= 0:
+                continue
+            out.append(
+                {
+                    "reviewer": rname,
+                    "severity": normalize_severity(finding.get("severity")),
+                    "category": str(finding.get("category") or "").strip() or "uncategorized",
+                    "file": file,
+                    "line": line,
+                    "title": str(finding.get("title") or "").strip() or "Untitled finding",
+                    "description": str(finding.get("description") or "").strip(),
+                    "suggestion": str(finding.get("suggestion") or "").strip(),
+                    "evidence": str(finding.get("evidence") or "").strip(),
+                }
+            )
+    return out
+
+
+def truncate(text: str, *, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1].rstrip() + "…"
+
+
+def render_inline_comment(finding: dict) -> str:
+    sev = normalize_severity(finding.get("severity"))
+    icon = severity_icon(sev)
+    title = truncate(str(finding.get("title") or "Untitled finding"), max_len=200)
+    category = truncate(str(finding.get("category") or "uncategorized"), max_len=80)
+    reviewer = truncate(str(finding.get("reviewer") or "unknown"), max_len=40)
+    description = truncate(str(finding.get("description") or ""), max_len=700)
+    suggestion = truncate(str(finding.get("suggestion") or ""), max_len=700)
+    evidence = truncate(str(finding.get("evidence") or ""), max_len=900)
+
+    lines = [f"{icon} **{title}** (`{category}`) ({reviewer})"]
+    if description:
+        lines.append("")
+        lines.append(description)
+    if suggestion:
+        lines.append("")
+        lines.append(f"Suggestion: {suggestion}")
+    if evidence:
+        lines.append("")
+        lines.append("<details>")
+        lines.append("<summary>Evidence</summary>")
+        lines.append("")
+        lines.append("```text")
+        lines.extend(evidence.splitlines())
+        lines.append("```")
+        lines.append("")
+        lines.append("</details>")
+    return "\n".join(lines).strip() + "\n"
+
+
+def build_patch_index(repo: str, pr_number: int) -> dict[str, tuple[str, dict[int, int]]]:
+    """Map normalized path -> (canonical filename, newline->position map)."""
+    files = list_pr_files(repo, pr_number)
+    index: dict[str, tuple[str, dict[int, int]]] = {}
+    for item in files:
+        filename = item.get("filename")
+        if not isinstance(filename, str) or not filename.strip():
+            continue
+        patch = item.get("patch")
+        if not isinstance(patch, str) or not patch.strip():
+            continue
+        mapping = build_newline_to_position(patch)
+        canonical = filename.strip()
+        index[normalize_path(canonical)] = (canonical, mapping)
+        prev = item.get("previous_filename")
+        if isinstance(prev, str) and prev.strip():
+            index[normalize_path(prev)] = (canonical, mapping)
+    return index
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Post Cerberus council as a PR review with inline comments.")
+    p.add_argument("--repo", required=True, help="owner/repo")
+    p.add_argument("--pr", type=int, required=True, help="PR number")
+    p.add_argument("--head-sha", default="", help="Head SHA (default: env GH_HEAD_SHA)")
+    p.add_argument(
+        "--council-json",
+        default="/tmp/council-verdict.json",
+        help="Path to council verdict JSON.",
+    )
+    p.add_argument(
+        "--body-file",
+        default="/tmp/council-comment.md",
+        help="Council markdown body file (used as review body).",
+    )
+    args = p.parse_args()
+
+    head_sha = (args.head_sha or os.environ.get("GH_HEAD_SHA") or "").strip()
+    if not head_sha:
+        fail("missing head sha (set --head-sha or GH_HEAD_SHA)")
+
+    marker = review_marker(head_sha)
+
+    try:
+        reviews = list_pr_reviews(args.repo, args.pr)
+        if find_review_id_by_marker(reviews, marker) is not None:
+            notice(f"Council review already posted for sha={head_sha[:12]} (marker match). Skipping.")
+            return
+
+        council = read_json(Path(args.council_json))
+        council_body = read_text(Path(args.body_file)).strip()
+
+        findings = collect_inline_findings(council)
+        patch_index = build_patch_index(args.repo, args.pr)
+
+        mapped: list[tuple[ReviewComment, tuple[int, str, int, str, str]]] = []
+        for finding in findings:
+            path_key = normalize_path(finding.get("file"))
+            line = as_int(finding.get("line"))
+            if not path_key or line is None or line <= 0:
+                continue
+            entry = patch_index.get(path_key)
+            if not entry:
+                continue
+            canonical_path, line_map = entry
+            position = line_map.get(line)
+            if not position:
+                continue
+
+            comment = ReviewComment(
+                path=canonical_path,
+                position=position,
+                body=render_inline_comment(finding),
+            )
+            sort_key = (
+                _SEVERITY_ORDER[normalize_severity(finding.get("severity"))],
+                canonical_path,
+                line,
+                str(finding.get("reviewer") or ""),
+                str(finding.get("title") or ""),
+            )
+            mapped.append((comment, sort_key))
+
+        mapped.sort(key=lambda item: item[1])
+        inline = [c for (c, _k) in mapped[:MAX_INLINE_COMMENTS]]
+
+        eligible = len(findings)
+        posted = len(inline)
+        omitted = max(0, eligible - posted)
+        limit_note = ""
+        if omitted:
+            limit_note = f" (top {posted}/{eligible}; GitHub cap {MAX_INLINE_COMMENTS})"
+
+        review_body = "\n".join(
+            [
+                marker,
+                f"> Inline comments posted: {posted}/{eligible}{limit_note}. Full details also in council issue comment.",
+                "",
+                council_body,
+                "",
+            ]
+        ).strip() + "\n"
+
+        try:
+            create_pr_review(
+                repo=args.repo,
+                pr_number=args.pr,
+                commit_id=head_sha,
+                body=review_body,
+                comments=inline,
+            )
+            notice(f"Posted council PR review for sha={head_sha[:12]} with {posted} inline comments.")
+        except subprocess.CalledProcessError as exc:
+            # If the review rejects inline comments (bad positions), retry with body-only.
+            if inline:
+                warn(f"Review with inline comments failed; retrying body-only. ({exc.stderr or exc})")
+                create_pr_review(
+                    repo=args.repo,
+                    pr_number=args.pr,
+                    commit_id=head_sha,
+                    body=review_body,
+                    comments=[],
+                )
+                notice(f"Posted council PR review (body-only) for sha={head_sha[:12]}.")
+            else:
+                raise
+
+    except CommentPermissionError as exc:
+        warn(str(exc))
+    except TransientGitHubError as exc:
+        warn(str(exc))
+    except Exception as exc:  # don't block verdict on UX extras
+        warn(f"Unable to post council PR review: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_diff_positions.py
+++ b/tests/test_diff_positions.py
@@ -1,0 +1,76 @@
+from lib.diff_positions import build_newline_to_position
+
+
+def test_single_hunk_maps_context_and_additions() -> None:
+    patch = "\n".join(
+        [
+            "@@ -1,3 +1,4 @@",
+            " line1",
+            "-line2",
+            "+line2b",
+            " line3",
+            "+line4",
+        ]
+    )
+    mapping = build_newline_to_position(patch)
+
+    # positions are 1-indexed in the patch text
+    # 1: @@ ... @@  (no mapping)
+    # 2:  line1     -> new line 1
+    # 3: -line2     (no new line)
+    # 4: +line2b    -> new line 2
+    # 5:  line3     -> new line 3
+    # 6: +line4     -> new line 4
+    assert mapping[1] == 2
+    assert mapping[2] == 4
+    assert mapping[3] == 5
+    assert mapping[4] == 6
+
+
+def test_multiple_hunks_reset_new_line_counter() -> None:
+    patch = "\n".join(
+        [
+            "@@ -1,2 +1,2 @@",
+            " a",
+            "+b",
+            "@@ -10 +20 @@",
+            " c",
+        ]
+    )
+    mapping = build_newline_to_position(patch)
+
+    assert mapping[1] == 2
+    assert mapping[2] == 3
+    assert mapping[20] == 5
+
+
+def test_deletions_do_not_advance_new_line() -> None:
+    patch = "\n".join(
+        [
+            "@@ -5,3 +5,2 @@",
+            "-gone1",
+            "-gone2",
+            " keep1",
+            " keep2",
+        ]
+    )
+    mapping = build_newline_to_position(patch)
+
+    assert mapping[5] == 4
+    assert mapping[6] == 5
+
+
+def test_ignores_lines_before_first_hunk() -> None:
+    patch = "\n".join(
+        [
+            "diff --git a/x b/x",
+            "index 000..111 100644",
+            "--- a/x",
+            "+++ b/x",
+            "@@ -1 +1 @@",
+            "+hi",
+        ]
+    )
+    mapping = build_newline_to_position(patch)
+    assert mapping[1] == 6
+

--- a/tests/test_github_reviews.py
+++ b/tests/test_github_reviews.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from lib.github_reviews import (
+    ReviewComment,
+    create_pr_review,
+    find_review_id_by_marker,
+    list_pr_files,
+    list_pr_reviews,
+)
+
+
+def test_find_review_id_by_marker() -> None:
+    reviews = [
+        {"id": 1, "body": "nope"},
+        {"id": 2, "body": "<!-- cerberus:council-review sha=abc -->\nhi"},
+    ]
+    assert (
+        find_review_id_by_marker(reviews, "<!-- cerberus:council-review sha=abc -->")
+        == 2
+    )
+
+
+def test_list_pr_reviews_parses_json_list(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def mock_run_gh(args, *, check=True, max_retries=3, base_delay=1.0):
+        calls.append(args)
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout='[{"id": 9, "body": "ok"}]',
+            stderr="",
+        )
+
+    import lib.github as gh
+
+    monkeypatch.setattr(gh, "_run_gh", mock_run_gh)
+
+    reviews = list_pr_reviews("owner/repo", 42)
+    assert calls[0][0:2] == ["api", "repos/owner/repo/pulls/42/reviews?per_page=100"]
+    assert isinstance(reviews, list)
+    assert reviews[0]["id"] == 9
+
+
+def test_list_pr_files_flattens_paginated_slurp(monkeypatch) -> None:
+    def mock_run_gh(args, *, check=True, max_retries=3, base_delay=1.0):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    [{"filename": "a.py", "patch": "@@ -1 +1 @@\n+hi"}],
+                    [{"filename": "b.py"}],
+                ]
+            ),
+            stderr="",
+        )
+
+    import lib.github as gh
+
+    monkeypatch.setattr(gh, "_run_gh", mock_run_gh)
+
+    files = list_pr_files("owner/repo", 5)
+    assert [f.get("filename") for f in files] == ["a.py", "b.py"]
+
+
+def test_create_pr_review_posts_json_payload(monkeypatch) -> None:
+    seen_payload: dict | None = None
+
+    def mock_run_gh(args, *, check=True, max_retries=3, base_delay=1.0):
+        nonlocal seen_payload
+        assert args[0:4] == ["api", "-X", "POST", "repos/owner/repo/pulls/7/reviews"]
+        assert "--input" in args
+        payload_path = args[args.index("--input") + 1]
+        seen_payload = json.loads(open(payload_path, encoding="utf-8").read())
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout='{"id": 123}', stderr=""
+        )
+
+    import lib.github as gh
+
+    monkeypatch.setattr(gh, "_run_gh", mock_run_gh)
+
+    out = create_pr_review(
+        repo="owner/repo",
+        pr_number=7,
+        commit_id="deadbeef",
+        body="hello",
+        comments=[ReviewComment(path="a.py", position=3, body="c")],
+    )
+
+    assert out["id"] == 123
+    assert seen_payload is not None
+    assert seen_payload["event"] == "COMMENT"
+    assert seen_payload["commit_id"] == "deadbeef"
+    assert seen_payload["body"] == "hello"
+    assert seen_payload["comments"][0]["path"] == "a.py"
+    assert seen_payload["comments"][0]["position"] == 3
+

--- a/tests/test_verdict_action.py
+++ b/tests/test_verdict_action.py
@@ -31,6 +31,14 @@ def test_verdict_action_uses_shared_upsert() -> None:
     assert "--marker" in content
 
 
+def test_verdict_action_posts_inline_review_comments() -> None:
+    content = VERDICT_ACTION_FILE.read_text()
+
+    assert "scripts/post-council-review.py" in content
+    assert "--council-json /tmp/council-verdict.json" in content
+    assert "--body-file /tmp/council-comment.md" in content
+
+
 def test_post_comment_uses_shared_upsert() -> None:
     content = POST_COMMENT_SCRIPT.read_text()
 

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -134,6 +134,23 @@ runs:
           --marker "<!-- cerberus:council -->" \
           --body-file /tmp/council-comment.md
 
+    - name: Post council inline review comments
+      if: always() && steps.aggregate.outcome == 'success'
+      shell: bash
+      env:
+        CERBERUS_ROOT: ${{ github.action_path }}/..
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        python3 "$CERBERUS_ROOT/scripts/post-council-review.py" \
+          --repo "$REPO" \
+          --pr "$PR_NUMBER" \
+          --head-sha "$GH_HEAD_SHA" \
+          --council-json /tmp/council-verdict.json \
+          --body-file /tmp/council-comment.md
+
     - name: Upload quality report artifact
       if: always() && steps.aggregate.outcome == 'success'
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #143

What
- Verdict action posts a PR review with inline comments for findings with valid file+line (best-effort, max 30).
- Keeps existing council issue comment (marker <!-- cerberus:council -->) for triage + backwards compat.
- Idempotent per-SHA via review-body marker <!-- cerberus:council-review sha=<sha> -->.

How
- Fetch PR file patches (pulls/{pr}/files) and map new-file line -> diff position from hunk headers.
- Submit one PR review (pulls/{pr}/reviews) with body = council markdown + inline comments.

Tests
- python3 -m pytest tests/ -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verdict workflow now splits into distinct steps: posting council comments and inline PR review comments anchored to diff lines (up to 30 per review), with optional fail condition separate.
  * Enhanced communication pattern integrates inline findings directly into PR reviews alongside council comments.

* **Documentation**
  * Updated architecture documentation to reflect new verdict output capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->