### PR TITLE
perf: early-exit when scanning issue comments for marker

### DIFF
--- a/scripts/post-council-review.py
+++ b/scripts/post-council-review.py
@@ -294,7 +294,8 @@ def main() -> None:
 
         council_comment_url = ""
         try:
-            comments = fetch_comments(args.repo, args.pr)
+            # Use stop_on_marker for early exit - we only need to find the council comment
+            comments = fetch_comments(args.repo, args.pr, stop_on_marker="<!-- cerberus:council -->")
             council_comment_url = find_comment_url_by_marker(comments, "<!-- cerberus:council -->") or ""
         except (CommentPermissionError, TransientGitHubError, subprocess.CalledProcessError) as exc:
             warn(f"Unable to fetch council comment URL: {exc}")


### PR DESCRIPTION
## Summary

Adds optional stop_on_marker parameter to fetch_comments() that stops pagination early when a marker is found, reducing latency on noisy PRs.

## Changes

- scripts/lib/github.py: Add optional stop_on_marker parameter with docstring
- scripts/post-council-review.py: Use the new parameter when looking up council comment URL  
- tests/test_github.py: Add 3 new tests covering early-exit behavior

## Testing

- All 645 tests pass
- Python syntax validation passes
- Backward compatible (default behavior unchanged)

Fixes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Streamlined comment retrieval in review workflows with intelligent pagination that exits early when specific content markers are detected, reducing unnecessary data fetching and improving response times for council review operations.

* **Tests**
  * Added comprehensive test coverage for early-exit pagination scenarios and marker-based filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->