### PR TITLE
UX: clearer migration for api-key vs kimi-api-key

### DIFF
--- a/scripts/validate-inputs.sh
+++ b/scripts/validate-inputs.sh
@@ -5,18 +5,16 @@ resolved_key="${INPUT_API_KEY:-}"
 if [[ -z "$resolved_key" ]]; then
   if [[ -n "${INPUT_KIMI_API_KEY:-}" ]]; then
     resolved_key="${INPUT_KIMI_API_KEY}"
-    cat >&2 <<'EOF'
-::warning::Input 'kimi-api-key' is deprecated. Use 'api-key' (OpenRouter key).
+    invoked_ref="${GITHUB_ACTION_REF:-v2}"
+    cat >&2 <<EOF
+::warning::Input 'kimi-api-key' is deprecated and will be removed in a future release. Migrate to 'api-key' (OpenRouter key).
 
 Migration (recommended):
-- uses: misty-step/cerberus@v2
+- uses: misty-step/cerberus@${invoked_ref}
   with:
-    api-key: ${{ secrets.OPENROUTER_API_KEY }}
+    api-key: \${{ secrets.OPENROUTER_API_KEY }}
 
-Legacy (deprecated alias):
-- uses: misty-step/cerberus@v1
-  with:
-    kimi-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+The 'kimi-api-key' alias continues to work for backward compatibility but may be removed in v3.
 EOF
   fi
 fi
@@ -28,7 +26,9 @@ if [[ -z "$resolved_key" ]]; then
 fi
 
 if [[ -z "$resolved_key" ]]; then
-  cat >&2 <<'EOF'
+  # Determine invoked version for accurate error message
+  invoked_ref="${GITHUB_ACTION_REF:-v2}"
+  cat >&2 <<EOF
 ::error::Missing API key for Cerberus review.
 Provide one of:
 1) with: api-key  (recommended)
@@ -40,9 +40,9 @@ Note: step-level env: does NOT propagate into composite actions.
 Use 'with: api-key' or set env at the job level.
 
 Example:
-- uses: misty-step/cerberus@v2
+- uses: misty-step/cerberus@${invoked_ref}
   with:
-    api-key: ${{ secrets.OPENROUTER_API_KEY }}
+    api-key: \${{ secrets.OPENROUTER_API_KEY }}
 EOF
   exit 1
 fi


### PR DESCRIPTION
## Summary

Improves error messages and deprecation warnings for the `kimi-api-key` → `api-key` migration to reduce user confusion.

## Changes

- **Dynamic version reference**: Error/warning messages now use `GITHUB_ACTION_REF` to show the correct version tag (e.g., `@v1` vs `@v2`) instead of hardcoded `@v2`
- **Clearer deprecation warning**: Added explicit migration guidance and note that the alias may be removed in v3
- **Improved error message**: Shows the invoked version in the example workflow

## Acceptance Criteria

- [x] Users on @v1 see @v1 in error messages, not @v2
- [x] Deprecation warning clearly states kimi-api-key is deprecated and will be removed
- [x] Migration path shows the correct syntax for the invoked version
- [x] Backward compatibility preserved (kimi-api-key still works)

## Testing

Tested locally with simulated GITHUB_ACTION_REF:
```bash
GITHUB_ACTION_REF=v1 bash scripts/validate-inputs.sh
# Shows: misty-step/cerberus@v1 in messages
```

Fixes #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced validation script with clearer deprecation notices and improved error messaging for API key configuration and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->