### PR TITLE
chore(models): drop qwen3-max-thinking from defaults

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -25,8 +25,8 @@ jobs:
           - { reviewer: ATHENA,    perspective: architecture,     model: 'openrouter/z-ai/glm-5' }
           - { reviewer: SENTINEL,  perspective: security,         model: 'openrouter/minimax/minimax-m2.5' }
           - { reviewer: VULCAN,    perspective: performance,      model: 'openrouter/google/gemini-3-flash-preview' }
-          - { reviewer: ARTEMIS,   perspective: maintainability,  model: 'openrouter/qwen/qwen3-max-thinking' }
-          - { reviewer: CASSANDRA, perspective: testing,          model: 'openrouter/qwen/qwen3-max-thinking' }
+          - { reviewer: ARTEMIS,   perspective: maintainability,  model: 'openrouter/moonshotai/kimi-k2.5' }
+          - { reviewer: CASSANDRA, perspective: testing,          model: 'openrouter/google/gemini-3-flash-preview' }
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ matrix:
     - { reviewer: ATHENA,    perspective: architecture,    model: 'openrouter/z-ai/glm-5' }
     - { reviewer: SENTINEL,  perspective: security,        model: 'openrouter/minimax/minimax-m2.5' }
     - { reviewer: VULCAN,    perspective: performance,     model: 'openrouter/google/gemini-3-flash-preview' }
-    - { reviewer: ARTEMIS,   perspective: maintainability, model: 'openrouter/qwen/qwen3-max-thinking' }
-    - { reviewer: CASSANDRA, perspective: testing,         model: 'openrouter/qwen/qwen3-max-thinking' }
+    - { reviewer: ARTEMIS,   perspective: maintainability, model: 'openrouter/moonshotai/kimi-k2.5' }
+    - { reviewer: CASSANDRA, perspective: testing,         model: 'openrouter/google/gemini-3-flash-preview' }
 ```
 
 If a reviewer's primary model fails with a transient error (429, 5xx, network), it retries with exponential backoff then falls through to the `fallback-models` chain before emitting SKIP.

--- a/defaults/config.yml
+++ b/defaults/config.yml
@@ -80,7 +80,7 @@ reviewers:
 
   - name: ARTEMIS
     perspective: maintainability
-    model: "openrouter/qwen/qwen3-max-thinking"  # upgraded: flagship Qwen reasoning model
+    model: "openrouter/moonshotai/kimi-k2.5"  # replaced qwen3-max-thinking (frequent fallbacks)
     description: "Maintainability & DX — Think like the next developer"
     override: pr_author
     tools:
@@ -88,7 +88,7 @@ reviewers:
 
   - name: CASSANDRA
     perspective: testing
-    model: "openrouter/qwen/qwen3-max-thinking"  # rotated from qwen3-coder-next (empty output 4x)
+    model: "openrouter/google/gemini-3-flash-preview"  # replaced qwen3-max-thinking (frequent fallbacks)
     description: "Testing & Coverage — See what will break"
     override: pr_author
     tools:

--- a/vision.md
+++ b/vision.md
@@ -12,7 +12,7 @@ CodeRabbit: $30/seat/mo (GitHub Marketplace). Single-model, single-pass review w
 
 Cerberus differentiators:
 - **Multi-perspective council** — 6 specialized reviewers vs single-pass
-- **Model diversity** — each reviewer can use a different model (Kimi, Gemini, DeepSeek, GLM, Minimax, Qwen)
+- **Model diversity** — each reviewer can use a different model (Kimi, Gemini, GLM, Minimax)
 - **Council verdict with override protocol** — not binary pass/fail
 - **Open core** — OSS GitHub Action (BYOK) + optional managed Cerberus Cloud
 - **Agentic triage** — findings auto-remediated via fix PRs


### PR DESCRIPTION
Problem:
- openrouter/qwen/qwen3-max-thinking has been flaking (empty output / retries) and routinely falling back.

Change:
- Replace ARTEMIS + CASSANDRA primary models with more reliable options:
  - ARTEMIS: openrouter/moonshotai/kimi-k2.5
  - CASSANDRA: openrouter/google/gemini-3-flash-preview
- Update repo self-workflow + README example + vision blurb so Qwen is no longer in active rotation.

Notes:
- Fallback chain already includes gemini-3-flash-preview + glm-5.
- No behavior change beyond model selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reviewer model assignments for enhanced performance
  * Refreshed documentation to reflect current model lineup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->