### PR TITLE
fix: use step outputs instead of re-reading /tmp/council-verdict.json (closes #213)

### DIFF
--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -101,7 +101,14 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
         python3 "$CERBERUS_ROOT/scripts/aggregate-verdict.py" ./verdicts/
-        echo "verdict=$(jq -r .verdict /tmp/council-verdict.json)" >> "$GITHUB_OUTPUT"
+        VERDICT=$(jq -r .verdict /tmp/council-verdict.json 2>/dev/null)
+        if [ "$VERDICT" = "null" ] || [ -z "$VERDICT" ]; then
+          echo "::error::aggregate-verdict.py did not write a valid .verdict to /tmp/council-verdict.json"
+          echo "council-verdict.json contents:" >&2
+          cat /tmp/council-verdict.json 2>/dev/null || echo "(file missing)" >&2
+          exit 1
+        fi
+        echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
 
     - name: Post council verdict
       if: always() && steps.aggregate.outcome == 'success'
@@ -119,9 +126,9 @@ runs:
         FAIL_ON_VERDICT: ${{ inputs.fail-on-verdict }}
         CERBERUS_VERSION: ${{ github.action_ref || 'dev' }}
       run: |
-        VERDICT=$(jq -r .verdict /tmp/council-verdict.json)
+        VERDICT="${{ steps.aggregate.outputs.verdict }}"
         if [ "$VERDICT" = "null" ] || [ -z "$VERDICT" ]; then
-          echo "::error::Council verdict JSON is malformed"
+          echo "::error::Council verdict output is empty; was the aggregate step skipped or failed?"
           exit 1
         fi
         python3 "$CERBERUS_ROOT/scripts/render-council-comment.py" \
@@ -166,7 +173,7 @@ runs:
         FAIL_ON_VERDICT: ${{ inputs.fail-on-verdict }}
         FAIL_ON_SKIP: ${{ inputs.fail-on-skip }}
       run: |
-        VERDICT=$(jq -r .verdict /tmp/council-verdict.json)
+        VERDICT="${{ steps.aggregate.outputs.verdict }}"
         if [ "$VERDICT" = "FAIL" ] && [ "$FAIL_ON_VERDICT" = "true" ]; then
           echo "::error::Council Verdict: FAIL"
           exit 1


### PR DESCRIPTION
## Problem

Closes #213

The `Post council verdict` and `Check verdict` steps re-read `/tmp/council-verdict.json` with `jq` after the `Aggregate verdicts` step already captured the verdict in `steps.aggregate.outputs.verdict`. This intermittently failed with `Council verdict JSON is malformed` even when aggregate-verdict.py succeeded (the Python print confirmed the file was written). Rerunning without code changes fixed it — a transient file-read race.

## Fix

- **Aggregate step**: validate `.verdict` before writing to GITHUB_OUTPUT; dump file contents on error for easier diagnosis
- **Post council verdict**: use `${{ steps.aggregate.outputs.verdict }}` instead of re-reading the file  
- **Check verdict**: same substitution

The authoritative read of /tmp/council-verdict.json remains only in the aggregate step. Python scripts that need the full JSON still read the file directly (correct).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced verdict validation with improved error detection and reporting when verdict data is missing or malformed.
  * Improved workflow reliability through consistent use of aggregated verdict outputs instead of repeated file reads.
  * Strengthened error handling with clearer messages for troubleshooting workflow issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->