### PR TITLE
Retry gh pr view on auth flakes and harden parse bootstrap failure path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -179,15 +179,17 @@ runs:
         while [[ "$pr_view_attempt" -le "$max_pr_view_retries" ]]; do
           pr_view_stdout="$(mktemp /tmp/cerberus-pr-view-stdout.XXXXXX)"
           pr_view_stderr="$(mktemp /tmp/cerberus-pr-view-stderr.XXXXXX)"
-          if timeout "$pr_view_timeout_seconds" gh pr view "$PR_NUMBER" --json title,author,headRefName,baseRefName,body \
-            > "$pr_view_stdout" 2> "$pr_view_stderr"; then
+          timeout "$pr_view_timeout_seconds" gh pr view "$PR_NUMBER" --json title,author,headRefName,baseRefName,body \
+            > "$pr_view_stdout" 2> "$pr_view_stderr"
+          pr_view_rc=$?
+          if [[ "$pr_view_rc" -eq 0 ]]; then
             mv "$pr_view_stdout" /tmp/pr-context.json
             cleanup_pr_fetch_temp_files "$pr_view_stdout" "$pr_view_stderr"
             echo "pr-context-error-kind=" >> "$GITHUB_OUTPUT"
             echo "pr-context-error-message=" >> "$GITHUB_OUTPUT"
             pr_context_exit=0
             break
-          elif [[ "$?" -eq 124 ]]; then
+          elif [[ "$pr_view_rc" -eq 124 ]]; then
             pr_view_error_text="gh pr view timed out after ${pr_view_timeout_seconds}s"
             cleanup_pr_fetch_temp_files "$pr_view_stdout" "$pr_view_stderr"
             pr_view_error_kind="other"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added robust PR context retrieval with retry (up to 3 attempts), timeout handling, and exponential backoff for auth failures.
  * Downstream parse input now receives structured failure context to adjust parsing and messaging.

* **Bug Fixes**
  * Classifies failures as authentication, permissions, or other, and propagates precise error kind and messages.
  * Improved user-facing remediation guidance and clearer failure visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->