### PR TITLE
fix: mark unreachable fallthrough as no-cover; all three target modules hit 100%

### DIFF
--- a/scripts/read-defaults-config.py
+++ b/scripts/read-defaults-config.py
@@ -76,8 +76,8 @@ def main(argv: list[str]) -> int:
             print(_single_line(item))
         return 0
 
-    print("unknown command", file=sys.stderr)
-    return 2
+    print("unknown command", file=sys.stderr)  # pragma: no cover
+    return 2  # pragma: no cover
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #200

Issue #200 targeted three under-covered utility modules that sat near 0% and created hidden risk. Tests for all three were shipped in #226. This PR adds the final piece: a `# pragma: no cover` annotation to the dead-code fallthrough in `read-defaults-config.py`, bringing it to 100%.

The `argparse` configuration uses `required=True` and a fixed set of subcommands — there is no code path that can reach the `unknown command` branch at runtime. Coverage tools were correctly flagging it as uncovered; the fix is to explicitly exclude it.

**Before this PR:** `read-defaults-config.py` shows ~89% coverage (unreachable branch counted against it).
**After this PR:** All three target modules hit 100%, exceeding every acceptance criterion.

## Changes

- `scripts/read-defaults-config.py`: Added `# pragma: no cover` to the two lines in the unreachable post-argparse fallthrough (`print("unknown command", ...)` and `return 2`).

## Acceptance Criteria

From issue #200:

- [x] `scripts/lib/defaults_config.py` ≥ 75% → **100%**
- [x] `scripts/read-defaults-config.py` ≥ 70% → **100%**
- [x] `scripts/lib/markdown.py` ≥ 70% → **100%**
- [x] Tests assert invariants and edge cases (shipped in #226)

## Manual QA

```bash
# Clone / checkout branch
git checkout feature/issue-200

# Install deps
pip install pytest pytest-cov pyyaml

# Run coverage for the three target modules
python3 -m pytest tests/test_defaults_config.py tests/test_defaults_config_reader.py \
  tests/test_read_defaults_config_cli.py tests/test_markdown.py \
  --cov=scripts/lib/defaults_config --cov=scripts/read-defaults-config \
  --cov=scripts/lib/markdown --cov-report=term-missing -q

# Expected: all three modules show 100% in the coverage table
# Expected: 66 passed, 0 failed
```

## Before / After

**Before** (`master`, pre-PR): `read-defaults-config.py` reported ~89% statement coverage because the two-line dead-code block after the argparse dispatch was counted as uncovered. The `unknown command` branch is structurally unreachable — `argparse` with `required=True` and a closed subparser set never falls through to it.

**After** (this PR): The two lines are annotated `# pragma: no cover`. Coverage tools correctly exclude them.

```
# Before
scripts/read-defaults-config.py    ~89%   (lines 77-78 flagged uncovered)

# After
scripts/read-defaults-config.py   100%
scripts/lib/defaults_config.py    100%
scripts/lib/markdown.py           100%
```

No visible output change — this is a coverage annotation, not a behavior change.

## Test Coverage

Tests shipping in #226 (already merged to `master`) cover this module:

| Test file | What it covers |
|-----------|---------------|
| `tests/test_read_defaults_config_cli.py` | CLI paths: valid commands, missing key, bad section, invalid YAML, list output |
| `tests/test_defaults_config_reader.py` | `read_defaults_config()` load/validate/fail paths |
| `tests/test_defaults_config.py` | Full `DefaultsConfig` dataclass validation, edge cases, invalid types |
| `tests/test_markdown.py` | Escape/formatting invariants for all markdown utilities |

Gap: the `if __name__ == "__main__"` entry point is not directly invoked in tests (subprocess coverage) — acceptable since the tested `main()` path is fully covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage annotations in configuration script handling for improved testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->