### PR TITLE
test: increase coverage for post-council-review and quality-report

### DIFF
--- a/tests/test_quality_report.py
+++ b/tests/test_quality_report.py
@@ -467,6 +467,18 @@ class TestMain:
         assert "Warning: could not parse artifact" in io.err
         assert "Warning: failed to download artifact" in io.err
 
+    def test_main_with_artifact_dir_prints_summary_without_json_flag(self, tmp_path, capsys):
+        report_path = tmp_path / "quality-report.json"
+        report_path.write_text(json.dumps(_sample_quality_report()))
+
+        with patch.object(sys, "argv", ["quality-report.py", "--artifact-dir", str(tmp_path)]):
+            exit_code = _qr_mod.main()
+
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        assert "CERBERUS QUALITY REPORT SUMMARY" in out
+        assert "kimi" in out
+
     def test_main_requires_repo_or_artifact_dir(self):
         with patch.object(sys, "argv", ["quality-report.py"]):
             with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary

Closes #199. Part of #194.

`post-council-review.py` and `quality-report.py` were the two weakest modules in the test suite — 43% and 32% respectively. Both are on the hot path for every PR review cycle (comment emission, inline annotations, stat aggregation). Blind spots there meant regressions could silently break the output users actually see.

This PR adds targeted tests for the paths that matter: comment construction, deduplication, GitHub API failure handling, report summary generation, and model/runtime aggregation edge cases.

## Changes

- `tests/test_post_council_review.py` — expanded from 109 to ~530 lines; covers inline comment construction and deduplication, multi-reviewer aggregation, GitHub API failure/retry paths, edge cases in finding filtering and positioning
- `tests/test_quality_report.py` — expanded with comprehensive coverage; covers report summary/stat generation, model and runtime aggregation edge cases, zero-finding and partial-verdict scenarios

## Acceptance Criteria

- [x] `post-council-review.py` reaches ≥70% — **achieved 98%**
- [x] `quality-report.py` reaches ≥65% — **achieved 99%**
- [x] Existing output contracts remain stable — all 1066 tests pass, 0 failures

## Manual QA

```bash
# Run the new test files directly
python3 -m pytest tests/test_post_council_review.py tests/test_quality_report.py -v

# Confirm full suite still passes
python3 -m pytest tests/ -q

# Check per-module coverage
python3 -m pytest tests/ --cov=scripts --cov-report=term-missing -q
```

Expected: 64 tests pass for the two test files; 1066 total pass; both modules ≥98% coverage.

**Note:** Overall project coverage is ~68%, still below the 70% gate. This is a pre-existing deficit driven by `parse-review.py` (8%) and `triage.py` (52%) — out of scope for this issue.

## Before / After

**Before:** `post-council-review.py` at ~43%, `quality-report.py` at ~32%. Comment emission and report generation paths had no meaningful test coverage. Kitchen-sink tests bundled 4 unrelated assertions. Nested `with` blocks in quality-report tests reduced readability.

**After:** Both modules ≥98%. Kitchen-sink tests split into focused single-behavior tests. Nested context managers flattened to 3.10+ parenthesized form. Three new edge-case tests cover: non-dict JSON fallback, out-of-hunk finding skip, and non-JSON output path. Test count for the two files: 56 → 64. Full suite: 1058 → 1066.

## Test Coverage

| File | Coverage |
|------|----------|
| `scripts/post-council-review.py` | 98% (up from ~43%) |
| `scripts/quality-report.py` | 99% (up from ~32%) |

Test files:
- `tests/test_post_council_review.py` — 28 test cases
- `tests/test_quality_report.py` — 36 test cases

**Remaining gaps:** Lines 257, 284 in `post-council-review.py` (global inline cap break, unreachable without 30+ findings) and 3 partial branches in `quality-report.py` (all edge conditions in download error handling).

## Polish Pass

| Category | Changes |
|----------|---------|
| **Refactor** | Split 2 kitchen-sink tests into 7 focused tests; flattened nested `with` blocks; formatted long dict literals |
| **Tests** | +3 edge-case tests covering lines 109, 264, 347 |
| **Coverage** | post-council-review 97→98%, quality-report 98→99% |
| **Quality gates** | 1066 passed, shellcheck clean, py_compile clean |