### PR TITLE
fix(triage): add CERBERUS_TMP lifecycle (closes #235)

### DIFF
--- a/triage/action.yml
+++ b/triage/action.yml
@@ -49,6 +49,13 @@ runs:
             ;;
         esac
 
+    - name: Create isolated temp directory
+      shell: bash
+      run: |
+        cerberus_tmp="$(mktemp -d -t cerberus.XXXXXX)"
+        chmod 0700 "$cerberus_tmp"
+        echo "CERBERUS_TMP=${cerberus_tmp}" >> "$GITHUB_ENV"
+
     - name: Run triage
       id: triage
       shell: bash
@@ -59,5 +66,14 @@ runs:
         TRIAGE_MAX_ATTEMPTS: ${{ inputs.max-attempts }}
         TRIAGE_STALE_HOURS: ${{ inputs.stale-hours }}
         TRIAGE_FIX_COMMAND: ${{ inputs.fix-command }}
+        CERBERUS_TMP: ${{ env.CERBERUS_TMP }}
       run: |
         python3 "$CERBERUS_ROOT/scripts/triage.py"
+
+    - name: Clean up temp directory
+      if: always()
+      shell: bash
+      run: |
+        if [[ -n "${CERBERUS_TMP:-}" && -d "${CERBERUS_TMP}" ]]; then
+          rm -rf "${CERBERUS_TMP}"
+        fi


### PR DESCRIPTION
Adds mktemp isolated temp dir, chmod 0700, GITHUB_ENV export, and if:always() cleanup to triage/action.yml — matching the pattern already in verdict/action.yml. Closes #235.

Self-verified: YAML valid, only triage/action.yml changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Triage workflow now creates an isolated temporary directory for each run, ensuring cleaner file separation.
  * Automatic cleanup of the temporary workspace is performed after execution completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->