### PR TITLE
validate: warn when consumer uses misty-step/cerberus@v1

### DIFF
--- a/scripts/lib/consumer_workflow_validator.py
+++ b/scripts/lib/consumer_workflow_validator.py
@@ -135,7 +135,8 @@ _COE_REMEDIATION = (
 
 _V1_UPGRADE_GUIDANCE = (
     "Upgrade to v2: see templates/consumer-workflow-minimal.yml for the recommended setup. "
-    "v2 includes reliability hardening (empty-output retries, model fallback chain, parse-failure recovery) "
+    "v2 includes reliability hardening (empty-output retries, model fallback chain, parse-failure recovery, "
+    "timeout fast-path fallback, staged OpenCode config, isolated HOME) "
     "and supports fail-on-skip to turn SKIPs into CI failures."
 )
 

--- a/tests/test_consumer_workflow_validator.py
+++ b/tests/test_consumer_workflow_validator.py
@@ -640,6 +640,33 @@ jobs:
     )
 
 
+def test_v1_warning_mentions_v2_reliability_items(tmp_path: Path):
+    """The v1 warning should mention the full set of v2 reliability items."""
+    wf = tmp_path / "cerberus.yml"
+    wf.write_text("""
+name: Cerberus
+on: pull_request
+jobs:
+  check:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: misty-step/cerberus@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+""".lstrip())
+
+    findings, _ = validate_workflow_file(wf)
+    v1 = _v1_warnings(findings)
+    assert v1, "Expected a v1 upgrade warning"
+    msg = v1[0].message
+    assert "timeout fast-path fallback" in msg
+    assert "staged OpenCode config" in msg
+    assert "isolated HOME" in msg
+
+
 @pytest.mark.parametrize("uses", [
     "misty-step/cerberus@v2",
     "misty-step/cerberus@v2.0.0",


### PR DESCRIPTION
## Summary

Consumers stuck on `misty-step/cerberus@v1` silently miss the v2 reliability hardening: empty-output retries, model fallback chain, parse-failure recovery, timeout fast-path, and isolated HOME. This shows up as frequent unexplained SKIPs and hard-to-debug parse failures (as observed on misty-step/volume PR #355).

`validate@v2` now detects any `uses: misty-step/cerberus*@v1` step and emits a `warning`-level finding with an upgrade path.

Closes #218

---

## Changes

- **`scripts/lib/consumer_workflow_validator.py`** — Added v1 usage check inside `validate_workflow_dict`. For each step whose `uses` ends with `@v1` or contains `@v1/`, emit a `Finding("warning", ...)` referencing `templates/consumer-workflow-minimal.yml` and mentioning `fail-on-skip`.
- **`tests/test_consumer_workflow_validator.py`** — 9 new parametrized tests covering: all 5 Cerberus sub-actions at @v1, message content (template reference, fail-on-skip), v2 no false positive, and per-step deduplication.

---

## Acceptance Criteria

- [x] `validate@v2` emits a warning when any step uses `misty-step/cerberus@v1`
- [x] Warning covers all sub-actions (`/verdict@v1`, `/triage@v1`, `/draft-check@v1`, `/validate@v1`)
- [x] Warning message references `templates/consumer-workflow-minimal.yml`
- [x] Warning message mentions `fail-on-skip`
- [x] `@v2` workflows produce no false-positive v1 warnings
- [x] Each v1 step emits its own warning (not deduplicated)

---

## Manual QA

```bash
# 1. Install deps
pip install pytest pytest-cov pyyaml

# 2. Run just the new v1 tests
python3 -m pytest tests/test_consumer_workflow_validator.py -k "v1" -v

# Expected: 9 passed

# 3. Run full test suite to confirm no regressions
python3 -m pytest tests/ -v

# 4. Smoke-test the CLI directly with a v1 workflow
cat > /tmp/v1-test.yml << 'YAML'
name: Cerberus
on: pull_request
jobs:
  check:
    runs-on: ubuntu-latest
    steps:
      - uses: misty-step/cerberus@v1
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
YAML

python3 scripts/validate-workflow.py /tmp/v1-test.yml
# Expected: output contains "which is v1" and "consumer-workflow-minimal.yml"
```

---

## Before / After

**Before:** A consumer workflow using `misty-step/cerberus@v1` passed `validate@v2` silently — no hint that they were missing reliability fixes or that `fail-on-skip` existed.

**After:** `validate@v2` emits:
```
WARNING cerberus.yml: job `check` uses `misty-step/cerberus@v1` which is v1.
Upgrade to v2: see templates/consumer-workflow-minimal.yml for the recommended setup.
v2 includes reliability hardening (empty-output retries, model fallback chain,
parse-failure recovery) and supports fail-on-skip to turn SKIPs into CI failures.
```

No change to v2 workflow behavior — only v1 references trigger the warning.

---

## Test Coverage

**New tests** in `tests/test_consumer_workflow_validator.py` (lines 546–684):

| Test | What it verifies |
|------|-----------------|
| `test_v1_usage_emits_warning[cerberus@v1]` | Main action triggers warning |
| `test_v1_usage_emits_warning[verdict@v1]` | verdict sub-action triggers warning |
| `test_v1_usage_emits_warning[triage@v1]` | triage sub-action triggers warning |
| `test_v1_usage_emits_warning[draft-check@v1]` | draft-check sub-action triggers warning |
| `test_v1_usage_emits_warning[validate@v1]` | validate sub-action triggers warning |
| `test_v1_warning_mentions_v2_template` | Message references `consumer-workflow-minimal.yml` |
| `test_v1_warning_mentions_fail_on_skip` | Message mentions `fail-on-skip` |
| `test_v2_usage_no_v1_warning` | v2 workflows don't false-positive |
| `test_v1_warning_per_step_not_deduplicated` | Each v1 step gets its own warning |

**Gap:** No integration test confirming the warning surfaces in actual `validate@v2` Action output (would require a live GitHub Actions run against a v1-using consumer repo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects Cerberus workflow steps using v1 and emits a per-step warning with upgrade guidance, referencing migration templates and fail-on-skip behavior.
* **Tests**
  * Added tests covering v1 warning emission, one warning per v1 step, v2 non-warnings, continue-on-error scenarios, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Polish Pass

**Before:** Working implementation with 18 test cases. Minor naming issue (`_ref` using Python's unused-variable convention for an active local), one redundant test duplicating parametrized coverage, and missing boundary cases at the detection heuristic edges.

**After:**
- **Refactor:** Renamed `_ref` → `ref` (underscore prefix was misleading). Removed `test_v2_usage_no_v1_warning` — strict duplicate of `test_non_v1_usage_no_v1_warning[cerberus@v2]`.
- **Tests:** Added 4 new parametrized cases: `preflight@v1` (real sub-action, positive), `@abc123def456` (SHA pin, negative), `@main` (branch ref, negative), `@v1beta` (near-miss, negative). Guards against regression if the detection heuristic changes.
- **Quality:** 1156 tests pass, shellcheck clean, py_compile clean. Coverage improved from 68.59% (master) to 68.73% (branch) — the 70% gate is a pre-existing shortfall in other modules, not caused by this PR.
## Before / After (Unblock update)

Before: One major review thread remained open because `_V1_UPGRADE_GUIDANCE` omitted several v2 reliability items referenced by the issue/PR objective.

After: Guidance now explicitly includes timeout fast-path fallback, staged OpenCode config, and isolated HOME; added regression assertions in validator tests for those items; replied on-thread with commit evidence and resolved the remaining thread.