### PR TITLE
fix: add chmod before rm in cleanup to fix permission denied in go/pkg/mod (fixes #247)

### DIFF
--- a/scripts/run-reviewer.sh
+++ b/scripts/run-reviewer.sh
@@ -28,6 +28,9 @@ cerberus_cleanup() {
   # Note: model-used is NOT cleaned here — downstream steps read it.
   # Note: parse-failure-models.txt and parse-failure-retries.txt are NOT
   # cleaned here — parse-review.py reads them to enrich SKIP verdicts.
+  # Go module cache (go/pkg/mod) may have restrictive permissions; chmod first
+  # to ensure we can delete, then remove. Both operations are best-effort.
+  chmod -R 755 "${CERBERUS_ISOLATED_HOME:-}" 2>/dev/null || true
   rm -rf "${CERBERUS_ISOLATED_HOME:-}" 2>/dev/null || true
 
   if [[ -z "$cerberus_staging_backup_dir" ]]; then


### PR DESCRIPTION
The Go module cache (go/pkg/mod) can create files with restrictive permissions that cause 'rm: Permission denied' errors during cleanup.

This adds a `chmod -R 755` before the `rm -rf` to ensure we can delete the files. Both operations are best-effort (`|| true`) to prevent cleanup failures from affecting the review outcome.

Fixes #247