### PR TITLE
docs: add v1→v2 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Tip: copy `templates/consumer-workflow-minimal.yml` and `templates/workflow-lint
 
 ## Docs
 
+- Migration guide (v1 → v2): `docs/MIGRATION.md`
 - OSS vs Cloud: `docs/OSS-VS-CLOUD.md`
 - Backlog priorities: `docs/BACKLOG-PRIORITIES.md`
 - Troubleshooting: `docs/TROUBLESHOOTING.md`

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,111 @@
+# Migrating from Cerberus v1 to v2
+
+v2 is a breaking change. This guide covers everything you need to update.
+
+---
+
+## Why Upgrade
+
+v1 is EOL — no further patches or features. v2 ships:
+
+- **Smart routing** — an LLM router selects the most relevant reviewers per PR instead of running all six every time
+- **Preflight gate** — detects forks, drafts, and missing API keys before spending tokens, with optional PR comment explaining the skip
+- **Richer verdict** — inline PR comments anchored to diff lines, override support (`/cerberus override`), and skip/fail separation
+- **Model diversity** — per-reviewer model assignment, a randomized pool, and a fallback chain for resilience
+- **Reliability hardening** — empty-output retries, timeout fast-path fallback, staged OpenCode config, isolated HOME, parse-failure recovery
+
+---
+
+## What Changed
+
+| Area | v1 | v2 |
+|------|----|----|
+| CLI runtime | KimiCode CLI | OpenCode CLI |
+| Required secret | `MOONSHOT_API_KEY` | `OPENROUTER_API_KEY` |
+| Action input | `kimi-api-key` | `api-key` |
+| Skip-condition gate | `draft-check` | `preflight` (fork + draft + missing key) |
+| Reviewer panel | Fixed 6 | Smart-routed, up to 8 available |
+| Model | Single (Moonshot Kimi) | Pool + fallback chain (default: Kimi K2.5 via OpenRouter) |
+
+---
+
+## Step-by-Step Migration
+
+### 1. Add the new secret
+
+In your repository: **Settings → Secrets and variables → Actions → New repository secret**
+
+- Name: `OPENROUTER_API_KEY`
+- Value: get one at [openrouter.ai](https://openrouter.ai) (free tier available)
+
+### 2. Replace your workflow
+
+**Simplest path** — replace `.github/workflows/cerberus.yml` entirely:
+
+```yaml
+name: Cerberus
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+
+concurrency:
+  group: cerberus-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: misty-step/cerberus/.github/workflows/cerberus.yml@v2
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+Or copy `templates/consumer-workflow.yml` from this repo.
+
+**Power-user path** (full job control) — use `templates/consumer-workflow-minimal.yml`.
+
+### 3. Update any explicit `api-key` inputs
+
+If your v1 workflow passed `kimi-api-key` directly to a step, rename it:
+
+```yaml
+# before (v1)
+with:
+  kimi-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+
+# after (v2)
+with:
+  api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+### 4. Test on a non-default branch first
+
+Push to a branch and open a PR against it. Confirm the Cerberus jobs appear and complete before merging to your main branch.
+
+### 5. Clean up v1 artifacts
+
+- Remove the old `MOONSHOT_API_KEY` secret (Settings → Secrets → delete)
+- Delete any `.kimicode/` config files if you had local overrides
+
+---
+
+## Common Issues
+
+**Jobs are skipped with "missing API key"**
+: The secret name changed. Ensure `OPENROUTER_API_KEY` is set (not `MOONSHOT_API_KEY`).
+
+**`kimi-api-key` input not recognized**
+: Rename to `api-key` in your workflow `with:` block.
+
+**Fork PRs now get a PR comment instead of silently skipping**
+: This is intentional — preflight posts an explanatory comment. Set `post-comment: 'false'` on the preflight step to suppress it.
+
+---
+
+## Getting Help
+
+- [Troubleshooting guide](TROUBLESHOOTING.md)
+- [Open an issue](https://github.com/misty-step/cerberus/issues)

--- a/scripts/lib/consumer_workflow_validator.py
+++ b/scripts/lib/consumer_workflow_validator.py
@@ -134,7 +134,8 @@ _COE_REMEDIATION = (
 )
 
 _V1_UPGRADE_GUIDANCE = (
-    "Upgrade to v2: see templates/consumer-workflow-minimal.yml for the recommended setup. "
+    "Upgrade to v2: see docs/MIGRATION.md for the full migration guide "
+    "or templates/consumer-workflow-minimal.yml for the recommended setup. "
     "v2 includes reliability hardening (empty-output retries, model fallback chain, parse-failure recovery, "
     "timeout fast-path fallback, staged OpenCode config, isolated HOME) "
     "and supports fail-on-skip to turn SKIPs into CI failures."

--- a/tests/test_consumer_workflow_validator.py
+++ b/tests/test_consumer_workflow_validator.py
@@ -686,6 +686,32 @@ jobs:
     assert "isolated HOME" in msg
 
 
+def test_v1_warning_mentions_migration_guide(tmp_path: Path):
+    """The v1 warning should reference docs/MIGRATION.md."""
+    wf = tmp_path / "cerberus.yml"
+    wf.write_text("""
+name: Cerberus
+on: pull_request
+jobs:
+  check:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: misty-step/cerberus@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+""".lstrip())
+
+    findings, _ = validate_workflow_file(wf)
+    v1 = _v1_warnings(findings)
+    assert v1, "Expected a v1 upgrade warning"
+    assert any("MIGRATION.md" in w.message for w in v1), (
+        "Warning should mention docs/MIGRATION.md"
+    )
+
+
 @pytest.mark.parametrize("uses", [
     "misty-step/cerberus@v2",
     "misty-step/cerberus@v2.0.0",


### PR DESCRIPTION
## Summary

- Creates `docs/MIGRATION.md` — full v1→v2 migration guide consumers can follow
- Validator's `@v1` upgrade warning now references `docs/MIGRATION.md` alongside the template
- README Docs section links to the migration guide

## Changes

- `docs/MIGRATION.md`: three sections — Why Upgrade, What Changed (KimiCode→OpenCode, secret rename, input rename, preflight gate, routing, model pool), Step-by-Step Migration, Common Issues
- `scripts/lib/consumer_workflow_validator.py`: `_V1_UPGRADE_GUIDANCE` now mentions `docs/MIGRATION.md`
- `README.md`: migration guide added to Docs list
- `tests/test_consumer_workflow_validator.py`: `test_v1_warning_mentions_migration_guide` — asserts the warning references `MIGRATION.md`

## Acceptance Criteria

- [x] `docs/MIGRATION.md` exists with all three sections
- [x] Validator v1 warning links to migration guide
- [x] README links to migration guide
- [x] 1265 tests pass (no regressions)

## Manual QA

```bash
python3 -m pytest tests/test_consumer_workflow_validator.py -k "migration" -v
# → test_v1_warning_mentions_migration_guide PASSED
```

## Test Coverage

`tests/test_consumer_workflow_validator.py::test_v1_warning_mentions_migration_guide` — new test covering the updated guidance string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New migration guide available detailing upgrade steps, configuration changes, and troubleshooting resources
  * Added architecture documentation reference
  * Enhanced guidance messages to point users to comprehensive migration resources

* **Tests**
  * Added validation test for migration guide references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->