### PR TITLE
refactor: simplify pool config + wave-aware fallback

### DIFF
--- a/defaults/config.yml
+++ b/defaults/config.yml
@@ -9,54 +9,19 @@ cancel_in_progress: true            # Cancel stale runs on new push
 
 model:
   default: "openrouter/moonshotai/kimi-k2.5"
-  fallback:
-    - "openrouter/google/gemini-3-flash-preview"
-    - "openrouter/z-ai/glm-5"
   wave_pools:
     wave1:
       - "openrouter/moonshotai/kimi-k2.5"
       - "openrouter/x-ai/grok-4.1-fast"
       - "openrouter/minimax/minimax-m2.5"
-      - "openrouter/google/gemini-3-flash-preview"
     wave2:
-      - "openrouter/moonshotai/kimi-k2.5"
+      - "openrouter/google/gemini-3-flash-preview"
       - "openrouter/z-ai/glm-5"
       - "openrouter/anthropic/claude-haiku-4.5"
-      - "openrouter/google/gemini-3-flash-preview"
-      - "openrouter/minimax/minimax-m2.5"
     wave3:
       - "openrouter/openai/gpt-5.3-codex"
       - "openrouter/google/gemini-3.1-pro-preview"
       - "openrouter/anthropic/claude-sonnet-4.6"
-  pool:
-    - "openrouter/moonshotai/kimi-k2.5"
-    - "openrouter/x-ai/grok-4.1-fast"
-    - "openrouter/minimax/minimax-m2.5"
-    - "openrouter/google/gemini-3-flash-preview"
-    - "openrouter/anthropic/claude-haiku-4.5"
-    - "openrouter/z-ai/glm-5"
-    - "openrouter/openai/gpt-5.3-codex"
-    - "openrouter/google/gemini-3.1-pro-preview"
-    - "openrouter/anthropic/claude-sonnet-4.6"
-  tiers:
-    flash:
-      - "openrouter/moonshotai/kimi-k2.5"
-      - "openrouter/x-ai/grok-4.1-fast"
-      - "openrouter/google/gemini-3-flash-preview"
-      - "openrouter/minimax/minimax-m2.5"
-    standard:
-      - "openrouter/moonshotai/kimi-k2.5"
-      - "openrouter/z-ai/glm-5"
-      - "openrouter/anthropic/claude-haiku-4.5"
-      - "openrouter/minimax/minimax-m2.5"
-      - "openrouter/google/gemini-3-flash-preview"
-    pro:
-      - "openrouter/openai/gpt-5.3-codex"
-      - "openrouter/google/gemini-3.1-pro-preview"
-      - "openrouter/anthropic/claude-sonnet-4.6"
-      - "openrouter/z-ai/glm-5"
-      - "openrouter/minimax/minimax-m2.5"
-      - "openrouter/google/gemini-3-flash-preview"
   cli: pi
   thinking: true
   max_steps: 25                       # Max agentic steps per reviewer


### PR DESCRIPTION
## Summary

The `model:` block in `defaults/config.yml` had four overlapping structures (`fallback`, `pool`, `tiers`, `wave_pools`) that all encoded the same model lists in slightly different shapes. OpenRouter cost logs show Gemini Flash and GLM-5 dominating wave1+2, which revealed these lists were also drifting out of sync with each other.

This PR collapses to a single structure (`wave_pools`) and changes fallback behavior: instead of falling back to a static global env var, a failing model now falls back to a different model from the **same wave pool** first. Cross-wave emergency fallback (`CERBERUS_FALLBACK_MODELS`) is still appended at the end.

No issue linked — this is a maintenance refactor driven by config drift and cost log observations.

## Changes

- **`defaults/config.yml`** — removed `model.fallback`, `model.pool`, `model.tiers`; updated `wave_pools` to have clean, distinct model sets per wave (wave1=flash tier, wave2=standard, wave3=pro). 49 → 13 lines in the model block.
- **`scripts/run-reviewer.py`** — replaced `select_pool_model()` (returns one model) with `build_wave_models_list()` (returns ordered list: primary + shuffled pool siblings). Tier→wave mapping is now a hardcoded dict (`flash→wave1, standard→wave2, pro→wave3`). `CERBERUS_FALLBACK_MODELS` appends after the wave list as cross-wave emergency fallback.
- **`tests/test_model_pool.py`** — rewrote tier/pool tests to use `wave_pools` configs. Added `test_wave_fallback_stays_in_same_pool` to explicitly assert same-pool fallback behavior.
- **`tests/test_run_reviewer_runtime.py`** — fixed `test_fallback_model_used_after_primary_transient_failure` to use a fake cerberus root with no wave pools, ensuring the env fallback is reached after primary exhausts retries (the real config now has 3 models per pool, so the second wave model would succeed before the env fallback).

## Acceptance Criteria

- [x] `model:` block has only `wave_pools` (plus `default`, `cli`, `thinking`, `max_steps`, `timeout`)
- [x] Each wave pool has 3 distinct models with no cross-wave overlap
- [x] On model failure, retry loop walks remaining models from the same wave pool before touching `CERBERUS_FALLBACK_MODELS`
- [x] `CERBERUS_FALLBACK_MODELS` still works as cross-wave emergency fallback
- [x] Tier-named env var (`MODEL_TIER=flash`) still selects from the correct wave pool via hardcoded mapping
- [x] Full test suite passes (1432 passed, 1 skipped)

## Manual QA

```bash
cd cerberus

# Confirm config shape
python3 -c "
from pathlib import Path
from scripts.lib.defaults_config import load_defaults_config
cfg = load_defaults_config(Path('defaults/config.yml'))
print('pool:', cfg.model.pool)
print('tiers:', cfg.model.tiers)
print('fallback:', getattr(cfg.model, 'fallback', 'N/A'))
print('wave1:', cfg.model.wave_pools['wave1'])
print('wave2:', cfg.model.wave_pools['wave2'])
print('wave3:', cfg.model.wave_pools['wave3'])
"
# Expected: pool=[], tiers={}, wave pools each have 3 distinct models

# Confirm build_wave_models_list returns primary + shuffled rest
python3 -c "
import importlib.util, sys
spec = importlib.util.spec_from_file_location('rr', 'scripts/run-reviewer.py')
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
wave_pools = {
  'wave1': ['openrouter/a', 'openrouter/b', 'openrouter/c'],
  'wave2': ['openrouter/d'],
}
result = mod.build_wave_models_list(
  reviewer_name='test',
  requested_wave='wave1',
  requested_tier='flash',
  model_wave_pools=wave_pools,
)
print('primary in wave1:', result[0] in wave_pools['wave1'])
print('all from wave1:', all(m in wave_pools['wave1'] for m in result))
print('count:', len(result))  # 3
"

# Run tests
python3 -m pytest tests/test_model_pool.py tests/test_run_reviewer_runtime.py -v
```

## What Changed

**Before:** `select_pool_model()` returns one model. `models` list = `[primary] + CERBERUS_FALLBACK_MODELS`. On failure, fallback goes to env-specified cross-wave models.

**After:** `build_wave_models_list()` returns `[primary] + shuffled_remaining_from_same_pool`. `models` list = `[wave_primary, wave_b, wave_c, ...CERBERUS_FALLBACK_MODELS]`. On failure, fallback stays in the same wave pool first.

```mermaid
graph TD
    subgraph Before
        A1[select_pool_model] -->|returns 1 model| B1[models = primary]
        B1 --> C1[+ CERBERUS_FALLBACK_MODELS cross-wave]
        C1 --> D1[failure → env fallback]
    end

    subgraph After
        A2[build_wave_models_list] -->|returns ordered list| B2[models = primary + wave siblings]
        B2 --> C2[+ CERBERUS_FALLBACK_MODELS appended]
        C2 --> D2[failure → same wave pool first]
        D2 --> E2[exhausted → env fallback]
    end
```

## Before / After

**Before:** `defaults/config.yml` had 4 structures encoding the same model lists (`fallback`, `pool`, `tiers`, `wave_pools`). A change to which models to use required updates in 4 places and they drifted. On any model failure, the runner jumped straight to `CERBERUS_FALLBACK_MODELS` — potentially a completely different wave.

**After:** Single `wave_pools` structure. One edit, one place. Failures fall back within the same wave pool (preserving wave semantics), with cross-wave env fallback still available as a last resort.

## Test Coverage

- `tests/test_model_pool.py::TestModelPoolSelection` — full suite: wave lookup, tier→wave mapping, missing wave fallback (all waves flattened), same-pool fallback, empty pool → default, case-insensitive tier
- `tests/test_model_pool.py::TestModelPrecedence` — reviewer model > default, input override precedence
- `tests/test_run_reviewer_runtime.py::test_fallback_model_used_after_primary_transient_failure` — env fallback still works after primary exhausts retries

**Gap:** No test for `input_model` override combined with a wave pool (i.e., `PI_MODEL` set + pool reviewer). The override is prepended and wave models follow, but this path isn't directly tested end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured model pool configuration and selection logic, transitioning from tier-based to wave-based pooling architecture for improved fallback handling and model availability management.

* **Tests**
  * Updated test suite to validate wave-based model pooling, tier mappings, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->