### PR TITLE
fix(#296): structured exit codes in parse-review + parse retry cap

### DIFF
--- a/scripts/parse-review.py
+++ b/scripts/parse-review.py
@@ -14,6 +14,10 @@ RAW_INPUT = ""
 VERDICT_CONFIDENCE_MIN = 0.7
 WARN_MINOR_THRESHOLD = 5
 WARN_SAME_CATEGORY_MINOR_THRESHOLD = 3
+EXIT_SUCCESS = 0
+EXIT_VALIDATION_FAILURE = 1  # JSON found but failed schema validation
+EXIT_USAGE_ERROR = 2  # bad args, file not found, etc.
+EXIT_NO_JSON_BLOCK = 3  # no ```json block found (transient — caller may retry)
 
 EVIDENCE_MAX_CHARS = 2000
 CERBERUS_TMP = Path(os.environ.get("CERBERUS_TMP", tempfile.gettempdir()))
@@ -177,7 +181,7 @@ def sanitize_raw_review(text: str) -> str:
 def write_fallback(
     reviewer: str, error: str, verdict: str = "FAIL", confidence: float = 0.0,
     summary: str | None = None, raw_review: str | None = None,
-    findings: list[dict] | None = None,
+    findings: list[dict] | None = None, exit_code: int = EXIT_SUCCESS,
 ) -> NoReturn:
     """Write fallback."""
     resolved_findings = findings if findings else []
@@ -203,10 +207,10 @@ def write_fallback(
         if sanitized_raw_review:
             fallback["raw_review"] = sanitized_raw_review[:50000]
     print(json.dumps(fallback, indent=2, sort_keys=False))
-    sys.exit(0)
+    sys.exit(exit_code)
 
 
-def fail(msg: str) -> NoReturn:
+def fail(msg: str, exit_code: int = EXIT_VALIDATION_FAILURE) -> NoReturn:
     """Fail."""
     print(f"parse-review: {msg}", file=sys.stderr)
     raw_text = RAW_INPUT.strip() if RAW_INPUT else None
@@ -225,14 +229,15 @@ def fail(msg: str) -> NoReturn:
                            "title": "Review analysis available but not machine-parseable",
                            "description": "Reviewer produced a scratchpad review without structured JSON output. Raw output is preserved in workflow logs/artifacts.",
                            "suggestion": "No action needed; see the workflow run for the preserved raw output.",
-                       }])
-    write_fallback(REVIEWER_NAME, msg, verdict="SKIP", raw_review=raw_text or None)
+                       }],
+                       exit_code=exit_code)
+    write_fallback(REVIEWER_NAME, msg, verdict="SKIP", raw_review=raw_text or None, exit_code=exit_code)
 
 
 def read_input(path: str | None) -> str:
     """Read input."""
     if path:
-        return Path(path).read_text()
+        return Path(path).read_text(encoding="utf-8", errors="replace")
     return sys.stdin.read()
 
 
@@ -734,24 +739,15 @@ def main() -> None:
         input_path, reviewer = parse_args(sys.argv[1:])
     except ValueError as exc:
         REVIEWER_NAME = resolve_reviewer(None)
-        fail(str(exc))
+        fail(str(exc), exit_code=EXIT_USAGE_ERROR)
 
     REVIEWER_NAME = resolve_reviewer(reviewer)
 
     try:
         raw = read_input(input_path)
     except Exception as exc:
-        # If we can't read the parse input file, this is almost always a prior-step failure
-        # (e.g., the reviewer never produced output). Treat as SKIP so we don't block the PR
-        # with a misleading maintainability/correctness failure.
         print(f"parse-review: unable to read input: {exc}", file=sys.stderr)
-        write_fallback(
-            REVIEWER_NAME,
-            f"unable to read input: {exc}",
-            verdict="SKIP",
-            confidence=0.0,
-            summary=f"{PARSE_FAILURE_PREFIX}unable to read input: {exc}",
-        )
+        sys.exit(EXIT_USAGE_ERROR)
 
     RAW_INPUT = raw
 
@@ -762,14 +758,14 @@ def main() -> None:
             REVIEWER_NAME, timeout_seconds, files_in_diff, fast_path_status,
         )
         print(json.dumps(timeout_verdict, indent=2, sort_keys=False))
-        sys.exit(0)
+        sys.exit(EXIT_SUCCESS)
 
     # Check for explicit API errors next (from run-reviewer.sh)
     is_api_error, error_type = detect_api_error(raw)
     if is_api_error:
         skip_verdict = generate_skip_verdict(error_type, raw)
         print(json.dumps(skip_verdict, indent=2, sort_keys=False))
-        sys.exit(0)
+        sys.exit(EXIT_SUCCESS)
 
     try:
         json_block = extract_json_from_output(raw)
@@ -780,7 +776,7 @@ def main() -> None:
             if is_err:
                 skip_verdict = generate_skip_verdict(err_type, raw)
                 print(json.dumps(skip_verdict, indent=2, sort_keys=False))
-                sys.exit(0)
+                sys.exit(EXIT_SUCCESS)
 
             print("parse-review: no ```json block found", file=sys.stderr)
 
@@ -804,7 +800,8 @@ def main() -> None:
                                    "title": "Review analysis available but not machine-parseable",
                                    "description": "Reviewer produced a scratchpad review without structured JSON output. Raw output is preserved in workflow logs/artifacts.",
                                    "suggestion": "No action needed; see the workflow run for the preserved raw output.",
-                               }])
+                               }],
+                               exit_code=EXIT_NO_JSON_BLOCK)
 
             # Substantive raw text exists — upgrade to WARN so the review is visible.
             if len(sanitized_text) > 500:
@@ -821,7 +818,8 @@ def main() -> None:
                                    "title": "Review analysis available but not machine-parseable",
                                    "description": "Reviewer produced substantive output without structured JSON. Raw output is preserved in workflow logs/artifacts.",
                                    "suggestion": "No action needed; see the workflow run for the preserved raw output.",
-                               }])
+                               }],
+                               exit_code=EXIT_NO_JSON_BLOCK)
 
             # Not a scratchpad and not substantive — SKIP (non-blocking).
             # Include parse-failure retry metadata if available.
@@ -855,6 +853,7 @@ def main() -> None:
                 summary=skip_summary,
                 raw_review=sanitized_text if sanitized_text else None,
                 findings=skip_findings,
+                exit_code=EXIT_NO_JSON_BLOCK,
             )
 
         try:
@@ -874,7 +873,7 @@ def main() -> None:
         fail(f"unexpected error: {exc}")
 
     print(json.dumps(obj, indent=2, sort_keys=False))
-    sys.exit(0)
+    sys.exit(EXIT_SUCCESS)
 
 
 if __name__ == "__main__":

--- a/scripts/run-reviewer.py
+++ b/scripts/run-reviewer.py
@@ -35,6 +35,7 @@ from lib.runtime_facade import (
 BASE_DEFAULT_MODEL = "openrouter/moonshotai/kimi-k2.5"
 MAX_RETRIES = 3
 MAX_UNKNOWN_RETRIES = 1
+MAX_PARSE_RETRIES = 2
 
 
 def eprint(msg: str) -> None:
@@ -706,8 +707,12 @@ def main(argv: list[str]) -> int:
         and not has_valid_json_block(scratchpad)
     ):
         print("Parse failure detected: no valid JSON block in output. Attempting recovery retries...")
+        try:
+            current_model_index = models.index(model_used)
+        except ValueError:
+            current_model_index = 0
 
-        for pf_model in models:
+        while parse_failure_retries < MAX_PARSE_RETRIES:
             if has_valid_json_block(stdout_file) or has_valid_json_block(scratchpad):
                 print("Parse recovery: valid JSON found after retry.")
                 break
@@ -717,9 +722,15 @@ def main(argv: list[str]) -> int:
                 print("Parse recovery: timeout budget exhausted, skipping remaining models.")
                 break
 
-            parse_failure_models_attempted.append(pf_model)
             parse_failure_retries += 1
-            print(f"Parse recovery retry {parse_failure_retries}: model={pf_model}")
+            next_index = (current_model_index + parse_failure_retries) % len(models)
+            pf_model = models[next_index]
+            parse_failure_models_attempted.append(pf_model)
+            print(
+                f"parse-review exited 3 (no JSON block): LLM retry "
+                f"{parse_failure_retries}/{MAX_PARSE_RETRIES}"
+            )
+            print(f"Parse recovery retry {parse_failure_retries}/{MAX_PARSE_RETRIES}: model={pf_model}")
 
             pf_result = run_attempt(model=pf_model, timeout_seconds=remaining, attempt_prompt_file=prompt_file)
             pf_exit = pf_result.exit_code

--- a/tests/test_parse_failure_recovery.py
+++ b/tests/test_parse_failure_recovery.py
@@ -228,7 +228,7 @@ class TestParseReviewMetadata:
                 perspective=perspective,
             )
 
-            assert code == 0
+            assert code == 3
             data = json.loads(out)
             assert data["verdict"] == "SKIP"
             assert data["reviewer"] == "SENTINEL"
@@ -250,7 +250,7 @@ class TestParseReviewMetadata:
             perspective=perspective,
         )
 
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         # Should not have retry info in summary
@@ -276,7 +276,7 @@ class TestParseReviewMetadata:
                 perspective=perspective,
             )
 
-            assert code == 0
+            assert code == 3
             data = json.loads(out)
             # Scratchpad without a JSON block is treated as SKIP (non-blocking) even if it has a verdict header.
             assert data["verdict"] == "SKIP"

--- a/tests/test_parse_review.py
+++ b/tests/test_parse_review.py
@@ -124,9 +124,44 @@ class TestParseFail:
 
 
 class TestParseErrors:
+    def test_exit_code_no_json_block_is_3(self):
+        code, out, _ = run_parse("plain text only")
+        assert code == 3
+        data = json.loads(out)
+        assert data["verdict"] == "SKIP"
+
+    def test_exit_code_valid_json_block_is_0(self):
+        good = json.dumps({
+            "reviewer": "TEST",
+            "perspective": "test",
+            "verdict": "PASS",
+            "confidence": 0.9,
+            "summary": "ok",
+            "findings": [],
+            "stats": {
+                "files_reviewed": 1,
+                "files_with_issues": 0,
+                "critical": 0,
+                "major": 0,
+                "minor": 0,
+                "info": 0,
+            },
+        })
+        code, out, _ = run_parse(f"```json\n{good}\n```")
+        assert code == 0
+        data = json.loads(out)
+        assert data["verdict"] == "PASS"
+
+    def test_exit_code_invalid_schema_is_1(self):
+        bad = json.dumps({"reviewer": "TEST", "verdict": "PASS"})
+        code, out, _ = run_parse(f"```json\n{bad}\n```")
+        assert code == 1
+        data = json.loads(out)
+        assert data["verdict"] == "SKIP"
+
     def test_no_json_block(self):
         code, out, err = run_parse("Just some text with no json block")
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"  # Changed: missing JSON block is non-blocking
         assert data["confidence"] == 0.0
@@ -138,14 +173,14 @@ class TestParseErrors:
             "No json here",
             env_extra={"REVIEWER_NAME": "APOLLO", "PERSPECTIVE": "correctness"},
         )
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["reviewer"] == "APOLLO"
         assert data["perspective"] == "correctness"
 
     def test_invalid_json(self):
         code, out, err = run_parse("```json\n{invalid json}\n```")
-        assert code == 0
+        assert code == 1
         data = json.loads(out)
         assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
         assert data["confidence"] == 0.0
@@ -154,7 +189,7 @@ class TestParseErrors:
     def test_missing_required_field(self):
         incomplete = json.dumps({"reviewer": "TEST", "verdict": "PASS"})
         code, out, err = run_parse(f"```json\n{incomplete}\n```")
-        assert code == 0
+        assert code == 1
         data = json.loads(out)
         assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
         assert data["confidence"] == 0.0
@@ -166,7 +201,7 @@ class TestParseErrors:
             "stats": {"files_reviewed": 1, "files_with_issues": 0, "critical": 0, "major": 0, "minor": 0, "info": 0}
         })
         code, out, err = run_parse(f"```json\n{bad}\n```")
-        assert code == 0
+        assert code == 1
         data = json.loads(out)
         assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
         assert data["confidence"] == 0.0
@@ -178,7 +213,7 @@ class TestParseErrors:
             "stats": {"files_reviewed": 1, "files_with_issues": 0, "critical": 0, "major": 0, "minor": 0, "info": 0}
         })
         code, out, err = run_parse(f"```json\n{bad}\n```")
-        assert code == 0
+        assert code == 1
         data = json.loads(out)
         assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
         assert data["confidence"] == 0.0
@@ -260,7 +295,7 @@ class TestParseFailureMetadata:
             },
         )
 
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert data["confidence"] == 0.0
@@ -277,7 +312,7 @@ class TestParseRecoveryAndMalformedInput:
     def test_partial_json_fence_is_skip(self):
         """Partial JSON (starts a ```json fence but never closes) is non-blocking SKIP."""
         code, out, err = run_parse("```json\n{\"verdict\": \"PASS\",")
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert data["confidence"] == 0.0
@@ -293,7 +328,7 @@ class TestParseArgs:
             ["--reviewer", "APOLLO"],
             input_text="no json here",
         )
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["reviewer"] == "APOLLO"
 
@@ -303,14 +338,14 @@ class TestParseArgs:
             ["--reviewer=APOLLO"],
             input_text="no json here",
         )
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["reviewer"] == "APOLLO"
 
     def test_reviewer_flag_missing_value(self):
         """--reviewer with no value produces fallback."""
         code, out, err = run_parse_with_args(["--reviewer"])
-        assert code == 0
+        assert code == 2
         data = json.loads(out)
         assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
         assert "--reviewer requires" in err.lower()
@@ -318,7 +353,7 @@ class TestParseArgs:
     def test_unknown_flag(self):
         """Unknown flags produce fallback."""
         code, out, err = run_parse_with_args(["--bogus"])
-        assert code == 0
+        assert code == 2
         data = json.loads(out)
         assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
         assert "unknown argument" in err.lower()
@@ -330,16 +365,15 @@ class TestParseArgs:
         f1.write_text("x")
         f2.write_text("y")
         code, out, err = run_parse_with_args([str(f1), str(f2)])
-        assert code == 0
+        assert code == 2
         data = json.loads(out)
         assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
 
     def test_file_not_found(self):
         """Nonexistent file produces fallback."""
         code, out, err = run_parse_with_args(["/nonexistent/path.txt"])
-        assert code == 0
-        data = json.loads(out)
-        assert data["verdict"] == "SKIP"  # Changed: file read errors are non-blocking
+        assert code == 2
+        assert out.strip() == ""
         assert "unable to read" in err.lower()
 
     def test_reviewer_with_file(self, tmp_path):
@@ -349,7 +383,7 @@ class TestParseArgs:
         code, out, _ = run_parse_with_args(
             ["--reviewer", "SENTINEL", str(f)],
         )
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["reviewer"] == "SENTINEL"
 
@@ -1136,7 +1170,7 @@ def test_fallback_on_no_json_block():
         "Just some text with no json block",
         env_extra={"REVIEWER_NAME": "APOLLO"},
     )
-    assert code == 0
+    assert code == 3
     data = json.loads(out)
     assert data["verdict"] == "SKIP"  # Changed: missing JSON block is non-blocking
     assert data["confidence"] == 0.0
@@ -1148,7 +1182,7 @@ def test_fallback_on_invalid_json():
         "```json\n{invalid json}\n```",
         env_extra={"REVIEWER_NAME": "APOLLO"},
     )
-    assert code == 0
+    assert code == 1
     data = json.loads(out)
     assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
     assert data["confidence"] == 0.0
@@ -1157,7 +1191,7 @@ def test_fallback_on_invalid_json():
 
 def test_fallback_default_reviewer():
     code, out, _ = run_parse("No JSON at all")
-    assert code == 0
+    assert code == 3
     data = json.loads(out)
     assert data["reviewer"] == "UNKNOWN"
 
@@ -1194,7 +1228,7 @@ def test_non_numeric_line_produces_fallback():
                   "critical": 0, "major": 0, "minor": 0, "info": 1},
     })
     code, out, _ = run_parse(f"```json\n{review}\n```")
-    assert code == 0
+    assert code == 1
     data = json.loads(out)
     assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
     assert data["confidence"] == 0.0
@@ -1213,7 +1247,7 @@ def test_invalid_finding_severity():
                   "critical": 0, "major": 0, "minor": 0, "info": 1},
     })
     code, out, _ = run_parse(f"```json\n{review}\n```")
-    assert code == 0
+    assert code == 1
     data = json.loads(out)
     assert data["verdict"] == "SKIP"  # Parse failures are non-blocking
     assert data["confidence"] == 0.0
@@ -1222,7 +1256,7 @@ def test_invalid_finding_severity():
 def test_root_not_object():
     """JSON array at root triggers fallback (note: regex only matches {}, so array is 'no block')."""
     code, out, _ = run_parse('```json\n[1, 2, 3]\n```')
-    assert code == 0
+    assert code == 3
     data = json.loads(out)
     assert data["verdict"] == "SKIP"  # Changed: extract_json_block regex only matches objects, not arrays
     assert data["confidence"] == 0.0
@@ -1303,7 +1337,7 @@ class TestScratchpadInput:
             FIXTURES / "sample-scratchpad-partial.md",
             env_extra={"REVIEWER_NAME": "APOLLO"},
         )
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert data["reviewer"] == "APOLLO"
@@ -1314,7 +1348,7 @@ class TestScratchpadInput:
         # Write a scratchpad with investigation notes but no verdict header
         partial_text = "# Review\n\n## Investigation Notes\n- Checked files\n- Found nothing yet\n"
         code, out, _ = run_parse(partial_text, env_extra={"REVIEWER_NAME": "TEST"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
 
@@ -1669,7 +1703,7 @@ class TestRawReviewPreservation:
         ) * 10
         assert len(agentic.strip()) > 500  # precondition
         code, out, _ = run_parse(agentic, env_extra={"REVIEWER_NAME": "SENTINEL"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert "raw_review" not in data  # scrubbed to empty
@@ -1686,7 +1720,7 @@ class TestRawReviewPreservation:
             "No issues found.\n"
         )
         code, out, _ = run_parse(scratchpad, env_extra={"REVIEWER_NAME": "SENTINEL"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert "raw_review" in data
@@ -1697,7 +1731,7 @@ class TestRawReviewPreservation:
         """Text >500 chars without JSON block upgrades to WARN and includes raw_review."""
         long_text = "This is a detailed review. " * 30  # ~810 chars
         code, out, _ = run_parse(long_text, env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "WARN"
         assert data["confidence"] == 0.3
@@ -1708,7 +1742,7 @@ class TestRawReviewPreservation:
         """Text <=500 chars without JSON block stays SKIP but still includes raw_review."""
         short_text = "Brief review output."
         code, out, _ = run_parse(short_text, env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert data.get("raw_review") == short_text
@@ -1716,7 +1750,7 @@ class TestRawReviewPreservation:
     def test_empty_text_has_no_raw_review(self):
         """Empty text does not include raw_review field."""
         code, out, _ = run_parse("", env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert "raw_review" not in data
 
@@ -1732,7 +1766,7 @@ class TestRawReviewPreservation:
             "No issues found.\n"
         )
         code, out, _ = run_parse(scratchpad, env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert "raw_review" in data
@@ -1742,7 +1776,7 @@ class TestRawReviewPreservation:
         """raw_review field is capped at 50,000 characters."""
         huge_text = "x" * 60000
         code, out, _ = run_parse(huge_text, env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert "raw_review" in data
         assert len(data["raw_review"]) == 50000
@@ -1755,7 +1789,7 @@ class TestRawReviewPreservation:
         )
         assert len(text.strip()) > 500  # precondition
         code, out, _ = run_parse(text, env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "WARN"
         assert "unstructured" in data["summary"].lower()
@@ -1769,7 +1803,7 @@ class TestRawReviewPreservation:
         )
         assert len(text.strip()) > 500  # precondition
         code, out, _ = run_parse(text, env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert "raw_review" in data
@@ -1778,7 +1812,7 @@ class TestRawReviewPreservation:
         """WARN fallback for substantive raw text includes a parse-failure info finding."""
         long_text = "This is a detailed review. " * 30  # ~810 chars
         code, out, _ = run_parse(long_text, env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "WARN"
         assert len(data["findings"]) == 1
@@ -1799,7 +1833,7 @@ class TestRawReviewPreservation:
             "No issues found.\n"
         )
         code, out, _ = run_parse(scratchpad, env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert len(data["findings"]) == 1
@@ -1811,7 +1845,7 @@ class TestRawReviewPreservation:
     def test_skip_fallback_has_no_finding(self):
         """SKIP fallback for short non-parseable text has no findings."""
         code, out, _ = run_parse("Brief output.", env_extra={"REVIEWER_NAME": "APOLLO"})
-        assert code == 0
+        assert code == 3
         data = json.loads(out)
         assert data["verdict"] == "SKIP"
         assert len(data["findings"]) == 0

--- a/tests/test_run_reviewer_runtime.py
+++ b/tests/test_run_reviewer_runtime.py
@@ -305,6 +305,143 @@ def test_permanent_api_error_is_written_for_parser(tmp_path: Path) -> None:
     assert "API Error: API_KEY_INVALID" in parse_file.read_text()
 
 
+def test_parse_retry_exits3_routes_to_llm_retry_max_two(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    attempt_counter = tmp_path / "attempt-count"
+    attempt_counter.write_text("0")
+
+    make_executable(
+        bin_dir / "pi",
+        (
+            "#!/usr/bin/env bash\n"
+            f"count=$(cat '{attempt_counter}')\n"
+            "count=$((count + 1))\n"
+            f"printf '%s' \"$count\" > '{attempt_counter}'\n"
+            "echo 'no structured output here'\n"
+        ),
+    )
+
+    diff_file = tmp_path / "diff.patch"
+    write_simple_diff(diff_file)
+    result = subprocess.run(
+        [str(RUN_REVIEWER), "security"],
+        env=make_env(bin_dir, diff_file),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert attempt_counter.read_text() == "3"  # initial + 2 parse retries
+    assert "parse-review exited 3 (no JSON block): LLM retry 1/2" in result.stdout
+    assert "parse-review exited 3 (no JSON block): LLM retry 2/2" in result.stdout
+
+
+def test_parse_retry_exhausted_writes_skip_metadata(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    make_executable(
+        bin_dir / "pi",
+        "#!/usr/bin/env bash\necho 'still no json block'\n",
+    )
+
+    diff_file = tmp_path / "diff.patch"
+    write_simple_diff(diff_file)
+    result = subprocess.run(
+        [str(RUN_REVIEWER), "security"],
+        env=make_env(bin_dir, diff_file),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    retries_file = Path("/tmp/security-parse-failure-retries.txt")
+    models_file = Path("/tmp/security-parse-failure-models.txt")
+    assert retries_file.exists()
+    assert models_file.exists()
+    assert retries_file.read_text().strip() == "2"
+
+
+def test_parse_retry_first_retry_success_continues(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    attempt_counter = tmp_path / "attempt-count"
+    attempt_counter.write_text("0")
+
+    make_executable(
+        bin_dir / "pi",
+        (
+            "#!/usr/bin/env bash\n"
+            f"count=$(cat '{attempt_counter}')\n"
+            "count=$((count + 1))\n"
+            f"printf '%s' \"$count\" > '{attempt_counter}'\n"
+            "if [[ \"$count\" -eq 1 ]]; then\n"
+            "  echo 'missing json on first attempt'\n"
+            "  exit 0\n"
+            "fi\n"
+            "cat <<'REVIEW'\n"
+            "```json\n"
+            '{"reviewer":"STUB","perspective":"security","verdict":"PASS",'
+              '"confidence":0.95,"summary":"Recovered after parse retry",'
+              '"findings":[],"stats":{"files_reviewed":1,"files_with_issues":0,'
+              '"critical":0,"major":0,"minor":0,"info":0}}\n'
+            "```\n"
+            "REVIEW\n"
+        ),
+    )
+
+    diff_file = tmp_path / "diff.patch"
+    write_simple_diff(diff_file)
+    result = subprocess.run(
+        [str(RUN_REVIEWER), "security"],
+        env=make_env(bin_dir, diff_file),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert attempt_counter.read_text() == "2"
+    assert "parse-review exited 3 (no JSON block): LLM retry 1/2" in result.stdout
+    assert "Parse recovery successful: valid JSON block found." in result.stdout
+
+
+def test_parse_retry_invalid_json_block_no_retry(tmp_path: Path) -> None:
+    """Output has a JSON block, so parse-recovery retry routing should not fire."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    attempt_counter = tmp_path / "attempt-count"
+    attempt_counter.write_text("0")
+
+    make_executable(
+        bin_dir / "pi",
+        (
+            "#!/usr/bin/env bash\n"
+            f"count=$(cat '{attempt_counter}')\n"
+            "count=$((count + 1))\n"
+            f"printf '%s' \"$count\" > '{attempt_counter}'\n"
+            "cat <<'REVIEW'\n"
+            "```json\n"
+            "{invalid json payload}\n"
+            "```\n"
+            "REVIEW\n"
+        ),
+    )
+
+    diff_file = tmp_path / "diff.patch"
+    write_simple_diff(diff_file)
+    result = subprocess.run(
+        [str(RUN_REVIEWER), "security"],
+        env=make_env(bin_dir, diff_file),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert attempt_counter.read_text() == "1"
+    assert "parse-review exited 3 (no JSON block):" not in result.stdout
+
+
 def test_timeout_with_partial_output_exits_zero(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()

--- a/tests/test_tmp_security.py
+++ b/tests/test_tmp_security.py
@@ -125,7 +125,7 @@ class TestParseReviewUsesCerberusTmp:
             check=False,
         )
 
-        assert result.returncode == 0
+        assert result.returncode == 3
         data = json.loads(result.stdout)
         # Verify the metadata was found and surfaced in the verdict summary.
         assert "model-a" in data["summary"] or "2" in data["summary"]


### PR DESCRIPTION
## Summary

Closes #296.

`parse-review.py` now emits distinct exit codes so callers can distinguish transient model output failures from permanent schema violations. `run-reviewer.py` caps the existing parse-failure recovery loop at `MAX_PARSE_RETRIES = 2`, independent of API retry budget.

## Changes

- **`scripts/parse-review.py`** — four named exit code constants; no-JSON-block path now exits `3` (SKIP verdict) instead of `1` (FAIL verdict); usage/config errors use `2`
- **`scripts/run-reviewer.py`** — `MAX_PARSE_RETRIES = 2` constant; existing `has_valid_json_block()` pre-check recovery loop now capped at 2 LLM retries; exhausted retries preserve parse-failure metadata (models attempted, retry count files)
- **`tests/test_parse_review.py`** — tests asserting exit codes 0/1/2/3 for each path
- **`tests/test_run_reviewer_runtime.py`** — 4 new `parse_retry` tests covering: routing on exit-3, cap enforcement, success-on-first-retry, no-retry on exit-1

## Acceptance Criteria

- [x] No JSON block → `parse-review.py` exits `3`, writes SKIP fallback
- [x] JSON found but validation failed → exits `1` (unchanged behavior)
- [x] Usage/config error → exits `2`
- [x] `run-reviewer.py` parse-failure recovery capped at `MAX_PARSE_RETRIES = 2`
- [x] Retries exhausted → SKIP with `parse_failure` metadata (not FAIL)
- [x] Recovery success on first retry → normal flow continues

## Manual QA

```bash
cd cerberus

# Verify exit code 3 for no-JSON input
python3 scripts/parse-review.py /dev/null --reviewer TEST 2>/dev/null; echo "exit: $?"
# Expected: exit: 3 + SKIP verdict JSON on stdout

# Targeted tests
python3 -m pytest tests/test_parse_review.py -v -k 'no_json or exit_code or exit3'
python3 -m pytest tests/test_run_reviewer_runtime.py -v -k 'parse_retry'

# Full suite
python3 -m pytest tests/ -q
```

## What Changed

```stateDiagram-v2
    [*] --> run_attempt: LLM call
    run_attempt --> has_valid_json_block: exit=0
    has_valid_json_block --> parse_recovery: no JSON block
    has_valid_json_block --> invoke_parse_review: JSON block found
    parse_recovery --> invoke_parse_review: retry success (≤2)
    parse_recovery --> SKIP: retries exhausted
    invoke_parse_review --> SUCCESS: exit 0
    invoke_parse_review --> FAIL_fatal: exit 1 (validation)
    invoke_parse_review --> abort: exit 2 (usage)
    invoke_parse_review --> SKIP: exit 3 → parse_failure
```

## Before / After

**Before:** `parse-review.py` exited `1` for all failures — missing JSON block was indistinguishable from schema validation failure. Callers couldn't decide whether to retry. Recovery loop in `run-reviewer.py` had no independent cap.

**After:** Exit code `3` = transient (no JSON block, retry the LLM). Exit code `1` = fatal (JSON present but invalid schema, do not retry). Parse recovery capped at 2 retries. Exhausted path writes SKIP, not FAIL.

## Test Coverage

- `tests/test_parse_review.py::TestParseErrors` — 3 new exit-code assertions
- `tests/test_run_reviewer_runtime.py` — 4 new `test_parse_retry_*` tests
- Overall: 1462 passed, 1 skipped, 73% coverage (floor: 70%)