### PR TITLE
fix: preserve verdict result on comment timeouts

### DIFF
--- a/.groom/retro.md
+++ b/.groom/retro.md
@@ -46,3 +46,12 @@
 - **scope changes**: Tightened auth-only heuristics in `parse-review.py`, added timeout-vs-auth regression coverage, and corrected rate-limit operator guidance so non-auth SKIPs no longer point users at API keys.
 - **blockers**: `make validate` passed the full pytest phase (`1526 passed, 1 skipped`) but failed later in `ruff` on unrelated pre-existing lint debt outside this diff.
 - **pattern**: Skip-classification bugs are cross-boundary contract bugs. Fix the classifier and pin the emitted titles/suggestions with regression tests instead of patching downstream comment renderers.
+
+## 2026-03-10 — Issue #290: Verdict job should not fail on transient PASS comment timeouts
+
+- **issue**: #290
+- **predicted effort**: p1 (small-medium)
+- **actual effort**: ~1 hour
+- **scope changes**: Added a configurable transient-exit policy to the shared GitHub comment helper, extended transient detection to TCP timeouts, and added a walkthrough artifact for the verdict path.
+- **blockers**: `make validate` still fails in `ruff` on unrelated pre-existing lint debt after the full pytest suite passes.
+- **pattern**: Keep transport retry detection centralized, but let the caller decide whether a transient delivery failure is merge-blocking. That preserves one retry path without flattening distinct workflow semantics.

--- a/docs/walkthroughs/issue-290-verdict-comment-resilience.md
+++ b/docs/walkthroughs/issue-290-verdict-comment-resilience.md
@@ -1,0 +1,37 @@
+# Walkthrough: Issue #290
+
+## Summary
+
+This change keeps the verdict job authoritative while making verdict-comment delivery resilient to transient GitHub network failures.
+
+## Before
+
+- `scripts/lib/github.py` only treated HTTP 502/503/504 responses as transient.
+- TCP-level failures such as `i/o timeout` were treated as hard command failures.
+- The verdict action always inherited the comment-posting exit code, so a `PASS` verdict could still fail the job after a transient comment outage.
+
+## After
+
+- `scripts/lib/github.py` now classifies common TCP connection failures as transient and retries them through the existing retry loop.
+- The shared comment helper accepts `--transient-error-exit-code` so callers can choose whether a transient outage should fail the step.
+- `verdict/action.yml` now sets transient comment failures to:
+  - exit `0` for `PASS` and `WARN`
+  - exit `1` for `FAIL`
+
+## Why This Shape Is Better
+
+- Retry classification stays in one place instead of duplicating network heuristics in workflow YAML.
+- The verdict action owns the policy decision about whether comment delivery is merge-blocking.
+- `FAIL` verdicts remain hard failures, while transient comment outages no longer turn `PASS` into a red check.
+
+## Persistent Verification
+
+- `tests/test_github.py`
+- `tests/test_verdict_action.py`
+
+## Commands
+
+```bash
+python3 -m pytest tests/test_github.py tests/test_verdict_action.py -q
+python3 -m ruff check scripts/lib/github.py tests/test_github.py tests/test_verdict_action.py
+```

--- a/scripts/lib/github.py
+++ b/scripts/lib/github.py
@@ -23,14 +23,23 @@ class TransientGitHubError(Exception):
 
 
 def _is_transient_error(stderr: str) -> bool:
-    """Check if error is a transient GitHub API error (5xx)."""
+    """Check if error is a transient GitHub API or network error."""
     transient_codes = ("502", "503", "504")
     lower_stderr = stderr.lower()
     # Handle both gh CLI format "(http 503)" and raw "HTTP 503" formats
-    return any(
+    if any(
         f"(http {code})" in lower_stderr or f"http {code}" in lower_stderr
         for code in transient_codes
+    ):
+        return True
+
+    transient_network_markers = (
+        "i/o timeout",
+        "connection timed out",
+        "connection refused",
+        "connection reset",
     )
+    return any(marker in lower_stderr for marker in transient_network_markers)
 
 
 def _run_gh(
@@ -217,6 +226,13 @@ def main() -> None:
     parser.add_argument("--pr", type=int, required=True, help="PR number")
     parser.add_argument("--marker", required=True, help="HTML comment marker")
     parser.add_argument("--body-file", required=True, help="Path to comment body markdown")
+    parser.add_argument(
+        "--transient-error-exit-code",
+        type=int,
+        choices=(0, 1),
+        default=0,
+        help="Exit code to use when comment posting fails due to transient GitHub/network errors.",
+    )
     args = parser.parse_args()
 
     if not Path(args.body_file).exists():
@@ -234,14 +250,13 @@ def main() -> None:
         print(f"::error::{exc}", file=sys.stderr)
         sys.exit(1)
     except TransientGitHubError as exc:
-        # Treat transient errors as non-fatal - warn but don't fail the job
         print(f"::warning::{exc}", file=sys.stderr)
         print(
             "::warning::Comment post failed due to GitHub outage. "
             "Review artifact still uploaded; check logs for review results.",
             file=sys.stderr,
         )
-        sys.exit(0)  # Exit successfully to avoid merge blockers
+        sys.exit(args.transient_error_exit_code)
     except subprocess.CalledProcessError as exc:
         print(f"gh command failed: {exc.stderr}", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -7,7 +7,6 @@ import pytest
 
 from lib.github import (
     CommentPermissionError,
-    TransientGitHubError,
     find_comment_by_marker,
     upsert_pr_comment,
 )
@@ -506,6 +505,7 @@ class TestTransientErrorRetry:
     @pytest.mark.parametrize("error_stderr", [
         "gh: HTTP 502: Bad Gateway",
         "gh: HTTP 504: Gateway Timeout",
+        'Post "https://api.github.com/repos/x/y/issues/1/comments": dial tcp 140.82.112.6:443: i/o timeout',
     ])
     def test_5xx_error_triggers_retry(self, monkeypatch, error_stderr):
         call_count = 0
@@ -623,6 +623,44 @@ class TestTransientErrorHandlingInMain:
             mod.main()
 
         assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "GitHub outage" in captured.err
+
+    def test_transient_error_can_exit_nonzero_when_requested(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        body_file = tmp_path / "body.md"
+        body_file.write_text("Test body")
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "prog",
+                "--repo",
+                "o/r",
+                "--pr",
+                "1",
+                "--marker",
+                "m",
+                "--body-file",
+                str(body_file),
+                "--transient-error-exit-code",
+                "1",
+            ],
+        )
+
+        def mock_upsert(*args, **kwargs):
+            import lib.github as mod
+            raise mod.TransientGitHubError("HTTP 503 after retries")
+
+        import lib.github as mod
+
+        monkeypatch.setattr(mod, "upsert_pr_comment", mock_upsert)
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+
+        assert exc_info.value.code == 1
         captured = capsys.readouterr()
         assert "GitHub outage" in captured.err
 

--- a/tests/test_verdict_action.py
+++ b/tests/test_verdict_action.py
@@ -29,6 +29,7 @@ def test_verdict_action_uses_shared_upsert() -> None:
     assert "scripts/lib/github.py" in content
     assert '--body-file "${CERBERUS_TMP}/verdict-comment.md"' in content
     assert "--marker" in content
+    assert "--transient-error-exit-code" in content
 
 
 def test_verdict_action_posts_inline_review_comments() -> None:
@@ -144,6 +145,14 @@ def test_verdict_action_uses_python_renderer_for_verdict_comment() -> None:
 
     assert "scripts/render-verdict-comment.py" in content
     assert '--output "${CERBERUS_TMP}/verdict-comment.md"' in content
+
+
+def test_verdict_action_only_hard_fails_comment_post_for_fail_verdicts() -> None:
+    content = VERDICT_ACTION_FILE.read_text()
+
+    assert 'COMMENT_FAILURE_EXIT_CODE="0"' in content
+    assert 'if [ "$VERDICT" = "FAIL" ]; then' in content
+    assert 'COMMENT_FAILURE_EXIT_CODE="1"' in content
 
 
 def test_verdict_action_does_not_use_sparse_checkout_dot() -> None:

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -143,6 +143,10 @@ runs:
           echo "::error::Cerberus verdict output is empty; was the aggregate step skipped or failed?"
           exit 1
         fi
+        COMMENT_FAILURE_EXIT_CODE="0"
+        if [ "$VERDICT" = "FAIL" ]; then
+          COMMENT_FAILURE_EXIT_CODE="1"
+        fi
         python3 "$CERBERUS_ROOT/scripts/render-verdict-comment.py" \
           --verdict-json "${CERBERUS_TMP}/verdict.json" \
           --output "${CERBERUS_TMP}/verdict-comment.md"
@@ -151,7 +155,8 @@ runs:
           --repo "$REPO" \
           --pr "$PR_NUMBER" \
           --marker "<!-- cerberus:verdict -->" \
-          --body-file "${CERBERUS_TMP}/verdict-comment.md"
+          --body-file "${CERBERUS_TMP}/verdict-comment.md" \
+          --transient-error-exit-code "$COMMENT_FAILURE_EXIT_CODE"
 
     - name: Post inline review comments
       if: always() && steps.aggregate.outcome == 'success'


### PR DESCRIPTION
## Why This Matters
A transient GitHub comment outage should not turn a passing Cerberus verdict into a red merge blocker. Issue #290 captures a real failure mode from `misty-step/vox-cloud` where verdict computation returned `PASS`, but the later PR comment POST hit a TCP timeout and failed the entire verdict job. This fix keeps the verdict path authoritative: comment delivery becomes best-effort for `PASS`/`WARN`, while `FAIL` verdicts still block when comment publication exhausts retries.

Closes #290.

## Trade-offs / Risks
We now let the verdict caller choose the exit code for transient comment-post failures. That adds one small policy input to the shared helper, but it avoids duplicating retry logic in workflow YAML and keeps failure semantics explicit at the call site.

Unrelated repo-wide `ruff` violations still prevent `make validate` from going fully green after the full pytest suite passes. That debt predates this lane and is called out below.

## Intent Reference
Issue intent summary: keep verdict computation authoritative, treat transient verdict-comment delivery failures as non-blocking for `PASS`/`WARN`, preserve hard failure behavior for `FAIL`, and improve retry handling for TCP-level GitHub outages in the existing shared GitHub helper.

Source: [Issue #290](https://github.com/misty-step/cerberus/issues/290)

## Changes
- Extend `scripts/lib/github.py` transient detection to include TCP-level connection failures such as `i/o timeout`.
- Add `--transient-error-exit-code` to the shared comment upsert CLI so callers can decide whether transient comment delivery is merge-blocking.
- Update `verdict/action.yml` so transient verdict-comment failures exit `0` for `PASS`/`WARN` and exit `1` for `FAIL`.
- Add targeted regression coverage in `tests/test_github.py` and `tests/test_verdict_action.py`.
- Add reviewer evidence in `docs/walkthroughs/issue-290-verdict-comment-resilience.md` and append the retro entry in `.groom/retro.md`.

## Alternatives Considered
Do nothing: keep blocking merges on transient comment transport failures. Rejected because it makes the verdict job lie about the actual review result.

Make all comment-post failures non-fatal: rejected because a `FAIL` verdict must remain hard-blocking.

Duplicate retry and downgrade logic directly in `verdict/action.yml`: rejected because retry classification already belongs in `scripts/lib/github.py` and should stay centralized.

## Acceptance Criteria
- [x] Given a PASS verdict and a TCP timeout during comment POST, when the verdict job runs, then the job exits 0 (PASS check stays green).
- [x] Given a PASS verdict and GitHub returning HTTP 503 during comment POST, when the verdict job runs, then the comment post is retried up to 3 times before degrading to a warning.
- [x] Given a FAIL verdict and a TCP timeout during comment POST, when the verdict job runs, then the job exits 1 (hard fail preserved — code review failed).
- [x] Given any verdict and a 403 permission error during comment POST, when the verdict job runs, then the job logs a clear error and exits non-zero (not silently swallowed).

## Manual QA
1. Run `python3 -m pytest tests/test_github.py tests/test_verdict_action.py -q`.
   Expected: all targeted regressions pass.
2. Run `python3 -m ruff check scripts/lib/github.py tests/test_github.py tests/test_verdict_action.py`.
   Expected: touched files are lint-clean.
3. Run `make validate`.
   Expected for this branch: full pytest suite passes; repo-wide `ruff` step still fails on unrelated pre-existing violations outside this diff.

## What Changed
Base branch flow:
```mermaid
flowchart TD
    A[aggregate verdict] --> B[render verdict comment]
    B --> C[post PR comment]
    C --> D{transient outage?}
    D -->|yes| E[step fails]
    D -->|no| F[check verdict]
    E --> G[verdict job red]
    F --> H[PASS or FAIL based on verdict]
```

PR flow:
```mermaid
flowchart TD
    A[aggregate verdict] --> B[render verdict comment]
    B --> C[post PR comment via shared helper]
    C --> D{transient outage?}
    D -->|no| E[check verdict]
    D -->|yes and PASS/WARN| F[warn and continue]
    D -->|yes and FAIL| G[fail step]
    F --> E
    E --> H[final verdict gate reflects actual verdict]
```

Helper/state diagram:
```mermaid
flowchart TD
    A[gh stderr] --> B{HTTP 502/503/504?}
    B -->|yes| R[retry loop]
    B -->|no| C{TCP timeout/reset/refused?}
    C -->|yes| R
    C -->|no| D{403 or permission error?}
    D -->|yes| E[CommentPermissionError]
    D -->|no| F[CalledProcessError]
    R --> G{retries exhausted?}
    G -->|no| H[retry]
    G -->|yes| I[TransientGitHubError]
```

The new shape is better because transport classification stays centralized, but the verdict action now owns the policy choice about whether a transient delivery failure should block merges.

## Before / After
Before: a passing verdict could still produce a red verdict job if the later PR comment POST hit a transient TCP timeout.

After: transient verdict-comment outages downgrade to warnings for `PASS` and `WARN`, but remain hard failures for `FAIL` verdicts.

Walkthrough artifact: [`docs/walkthroughs/issue-290-verdict-comment-resilience.md`](https://github.com/misty-step/cerberus/blob/codex/issue-290-verdict-comment-resilience/docs/walkthroughs/issue-290-verdict-comment-resilience.md)

## Test Coverage
- `tests/test_github.py`
  Covers TCP timeout retry classification and configurable transient exit handling in the shared comment helper.
- `tests/test_verdict_action.py`
  Covers verdict-action wiring for verdict-specific transient failure policy.
- `make validate`
  Full pytest suite passed (`1526 passed, 1 skipped`), but the repo-wide lint stage still fails on unrelated existing `ruff` findings outside this diff.

## Merge Confidence
High. The root cause is narrow, the retry behavior remains centralized, and targeted regressions cover both the transport classification and the verdict-specific failure policy. Residual risk is limited to the repo’s unrelated existing `ruff` baseline, not the functional behavior changed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable handling for transient comment/posting errors via a --transient-error-exit-code so callers can choose whether transient outages fail the job.
  * Transient error detection extended to include TCP/network connection failures; retries applied where appropriate.
  * Verdicts with status FAIL now surface comment-posting as hard failures when configured.

* **Documentation**
  * Added a walkthrough documenting verdict-comment resilience, rationale, and verification steps.

* **Tests**
  * New/updated tests covering transient error detection, retry behavior, and exit-code handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->