### PR TITLE
refactor: type override policy config lookup

### DIFF
--- a/scripts/lib/defaults_config.py
+++ b/scripts/lib/defaults_config.py
@@ -24,6 +24,14 @@ class Reviewer:
     perspective: str
     model: str | None = None
     description: str | None = None
+    override: str | None = None
+
+
+@dataclass(frozen=True)
+class OverrideConfig:
+    """Data class for global override policy."""
+
+    actor: str = "pr_author"
 
 
 @dataclass(frozen=True)
@@ -65,6 +73,7 @@ class DefaultsConfig:
     """Data class for Defaults Config."""
     reviewers: list[Reviewer]
     model: ModelConfig
+    override: OverrideConfig = field(default_factory=OverrideConfig)
     waves: WavesConfig = field(default_factory=WavesConfig)
 
     def reviewer_for_perspective(self, perspective: str) -> Reviewer | None:
@@ -73,6 +82,14 @@ class DefaultsConfig:
             if reviewer.perspective == perspective:
                 return reviewer
         return None
+
+    def reviewer_override_policies(self) -> dict[str, str]:
+        """Effective override policy for each reviewer."""
+
+        return {
+            reviewer.name: reviewer.override or self.override.actor
+            for reviewer in self.reviewers
+        }
 
 
 def _require_mapping(value: Any, ctx: str) -> dict[str, Any]:
@@ -164,12 +181,16 @@ def load_defaults_config(path: Path) -> DefaultsConfig:
         description = _optional_str(
             reviewer.get("description"), f"config.reviewers[{idx}].description"
         )
+        override = _optional_str(
+            reviewer.get("override"), f"config.reviewers[{idx}].override"
+        )
         reviewers.append(
             Reviewer(
                 name=name,
                 perspective=perspective,
                 model=model,
                 description=description,
+                override=override,
             )
         )
 
@@ -199,6 +220,14 @@ def load_defaults_config(path: Path) -> DefaultsConfig:
                     models, f"config.model.wave_pools[{wave_name}]"
                 )
         model = ModelConfig(default=model_default, pool=pool, tiers=tiers, wave_pools=wave_pools)
+
+    override_cfg = OverrideConfig()
+    override_raw = cfg.get("override")
+    if override_raw is not None:
+        override_map = _require_mapping(override_raw, "config.override")
+        override_cfg = OverrideConfig(
+            actor=_optional_str(override_map.get("actor"), "config.override.actor") or "pr_author"
+        )
 
     waves_raw = cfg.get("waves")
     waves = WavesConfig()
@@ -290,4 +319,4 @@ def load_defaults_config(path: Path) -> DefaultsConfig:
             definitions=definitions,
         )
 
-    return DefaultsConfig(reviewers=reviewers, model=model, waves=waves)
+    return DefaultsConfig(reviewers=reviewers, model=model, override=override_cfg, waves=waves)

--- a/scripts/read-defaults-config.py
+++ b/scripts/read-defaults-config.py
@@ -9,6 +9,7 @@ Commands:
   model-pool     Print: model.pool entries (one per line)
   model-pool-for-tier  Print: model.tiers.<tier> entries (one per line, requires --tier)
   model-pool-for-wave  Print: model.wave_pools.<wave> entries (one per line, requires --wave)
+  override-policies  Print JSON or GitHub Action outputs for override policies
   wave-order     Print: waves.order entries (one per line)
   wave-reviewers Print: waves.definitions.<wave>.reviewers entries (one per line, requires --wave)
   wave-max-for-tier Print: waves.max_for_tier.<tier> (or 0 if unset)
@@ -17,8 +18,10 @@ Commands:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
+from uuid import uuid4
 
 from lib.defaults_config import ConfigError, load_defaults_config
 
@@ -28,6 +31,18 @@ def _single_line(value: str | None) -> str:
         return ""
     # Make shell parsing safe; descriptions with newlines render poorly anyway.
     return " ".join(value.replace("\t", " ").split())
+
+
+def _append_multiline_output(path: Path, key: str, value: str) -> None:
+    delimiter = f"CERBERUS_{key.upper()}_{uuid4().hex}"
+    while delimiter in value:
+        delimiter = f"CERBERUS_{key.upper()}_{uuid4().hex}"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(f"{key}<<{delimiter}\n")
+        fh.write(value)
+        if not value.endswith("\n"):
+            fh.write("\n")
+        fh.write(f"{delimiter}\n")
 
 
 def main(argv: list[str]) -> int:
@@ -52,6 +67,10 @@ def main(argv: list[str]) -> int:
     model_pool_for_wave = sub.add_parser("model-pool-for-wave")
     model_pool_for_wave.add_argument("--config", required=True)
     model_pool_for_wave.add_argument("--wave", required=True)
+
+    override_policies = sub.add_parser("override-policies")
+    override_policies.add_argument("--config", required=True)
+    override_policies.add_argument("--github-output", default="")
 
     wave_order = sub.add_parser("wave-order")
     wave_order.add_argument("--config", required=True)
@@ -124,6 +143,25 @@ def main(argv: list[str]) -> int:
         wave_pool = cfg.model.wave_pools.get(wave, [])
         for item in wave_pool:
             print(_single_line(item))
+        return 0
+
+    if args.cmd == "override-policies":
+        payload = {
+            "global_policy": cfg.override.actor,
+            "reviewer_policies": cfg.reviewer_override_policies(),
+        }
+        github_output = str(args.github_output).strip()
+        if github_output:
+            output_path = Path(github_output)
+            with output_path.open("a", encoding="utf-8") as fh:
+                fh.write(f"global_policy={cfg.override.actor}\n")
+            _append_multiline_output(
+                output_path,
+                "reviewer_policies",
+                json.dumps(payload["reviewer_policies"], separators=(",", ":")),
+            )
+            return 0
+        print(json.dumps(payload, indent=2, sort_keys=False))
         return 0
 
     if args.cmd == "wave-order":

--- a/tests/test_defaults_config.py
+++ b/tests/test_defaults_config.py
@@ -7,6 +7,7 @@ from lib.defaults_config import (
     ConfigError,
     DefaultsConfig,
     ModelConfig,
+    OverrideConfig,
     Reviewer,
     load_defaults_config,
 )
@@ -52,6 +53,9 @@ reviewers:
     perspective: security
     model: openrouter/specific
     description: Security reviewer
+    override: maintainers_only
+override:
+  actor: write_access
 """)
         cfg = load_defaults_config(path)
         assert cfg.model.default == "openrouter/kimi-k2.5"
@@ -63,6 +67,8 @@ reviewers:
         }
         assert cfg.reviewers[0].model == "openrouter/specific"
         assert cfg.reviewers[0].description == "Security reviewer"
+        assert cfg.reviewers[0].override == "maintainers_only"
+        assert cfg.override.actor == "write_access"
 
     def test_model_tiers_parsed(self, tmp_path):
         path = write_config(tmp_path, """
@@ -428,3 +434,20 @@ class TestReviewerForPerspective:
             model=ModelConfig(),
         )
         assert cfg.reviewer_for_perspective("security") is None
+
+
+class TestOverridePolicies:
+    def test_reviewer_override_policies_uses_global_default(self):
+        cfg = DefaultsConfig(
+            reviewers=[
+                Reviewer(name="A", perspective="correctness"),
+                Reviewer(name="B", perspective="security", override="maintainers_only"),
+            ],
+            model=ModelConfig(),
+            override=OverrideConfig(actor="write_access"),
+        )
+
+        assert cfg.reviewer_override_policies() == {
+            "A": "write_access",
+            "B": "maintainers_only",
+        }

--- a/tests/test_read_defaults_config_cli.py
+++ b/tests/test_read_defaults_config_cli.py
@@ -1,6 +1,7 @@
 """Tests for scripts/read-defaults-config.py CLI."""
 
 import importlib
+import json
 from pathlib import Path
 
 # Import the script module directly.
@@ -164,6 +165,53 @@ reviewers:
         assert code == 2
         captured = capsys.readouterr()
         assert "--wave must be non-empty" in captured.err
+
+
+class TestOverridePolicies:
+    def test_prints_json_payload(self, tmp_path, capsys):
+        cfg = _write_config(tmp_path, """
+override:
+  actor: write_access
+reviewers:
+  - name: TRACE
+    perspective: correctness
+  - name: GUARD
+    perspective: security
+    override: maintainers_only
+""")
+        code = main(["override-policies", "--config", cfg])
+        assert code == 0
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload == {
+            "global_policy": "write_access",
+            "reviewer_policies": {
+                "TRACE": "write_access",
+                "GUARD": "maintainers_only",
+            },
+        }
+
+    def test_writes_github_outputs(self, tmp_path):
+        cfg = _write_config(tmp_path, """
+reviewers:
+  - name: TRACE
+    perspective: correctness
+""")
+        output_path = tmp_path / "github-output.txt"
+        code = main(
+            [
+                "override-policies",
+                "--config",
+                cfg,
+                "--github-output",
+                str(output_path),
+            ]
+        )
+        assert code == 0
+        output = output_path.read_text()
+        assert "global_policy=pr_author" in output
+        assert "reviewer_policies<<" in output
+        assert '{"TRACE":"pr_author"}' in output
 
 
 class TestWaveHelpers:

--- a/tests/test_verdict_action.py
+++ b/tests/test_verdict_action.py
@@ -23,6 +23,15 @@ def test_verdict_action_uses_python_override_collection() -> None:
     assert "user.get(\"login\")" in collector
 
 
+def test_verdict_action_reads_override_policies_via_typed_defaults_cli() -> None:
+    content = VERDICT_ACTION_FILE.read_text()
+
+    assert "scripts/read-defaults-config.py" in content
+    assert "override-policies" in content
+    assert '--github-output "$GITHUB_OUTPUT"' in content
+    assert "re.search(r'^\\s*override:" not in content
+
+
 def test_verdict_action_uses_shared_upsert() -> None:
     content = VERDICT_ACTION_FILE.read_text()
 

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -53,34 +53,10 @@ runs:
         CERBERUS_ROOT: ${{ github.action_path }}/..
       run: |
         CONFIG="$CERBERUS_ROOT/defaults/config.yml"
-        python3 - "$CONFIG" <<'PYEOF'
-        import json, os, re, sys
-        config_path = sys.argv[1]
-        with open(config_path) as fh:
-            raw = fh.read()
-        # Strip comment-only lines to prevent matching commented-out entries.
-        text = "\n".join(
-            line for line in raw.splitlines()
-            if not line.lstrip().startswith("#")
-        )
-        # Extract global override actor policy.
-        m = re.search(r'^\s*override:\s*\n(?:.*\n)*?^\s+actor:\s*(\S+)', text, re.MULTILINE)
-        global_policy = m.group(1).strip("\"'") if m else "pr_author"
-        # Extract per-reviewer override policies from reviewers list.
-        policies = {}
-        for block in re.finditer(
-            r'^\s*-\s+name:\s*(\S+).*?(?=^\s*-\s+name:|\Z)', text, re.DOTALL | re.MULTILINE
-        ):
-            name = block.group(1).strip("\"'")
-            om = re.search(r'^\s*override:\s*(\S+)', block.group(0), re.MULTILINE)
-            if om:
-                policies[name] = om.group(1).strip("\"'")
-            else:
-                policies[name] = global_policy
-        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-            f.write(f"global_policy={global_policy}\n")
-            f.write(f"reviewer_policies={json.dumps(policies)}\n")
-        PYEOF
+        python3 "$CERBERUS_ROOT/scripts/read-defaults-config.py" \
+          override-policies \
+          --config "$CONFIG" \
+          --github-output "$GITHUB_OUTPUT"
 
     - name: Check for override
       id: override


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [Walkthrough](#walkthrough)
- Direct video download: N/A, this is an internal refactor with terminal evidence
- Walkthrough notes: focused pytest transcript is embedded below from real branch execution
- Fast claim: verdict override policy now comes from the typed defaults loader/CLI, so workflow glue no longer regex-parses `defaults/config.yml`

## Why This Matters
- Problem: `verdict/action.yml` was carrying its own ad hoc regex parser for override policy even though the repo already had a typed config boundary for `defaults/config.yml`
- Value: override policy now has one source of truth, which reduces change amplification and makes the verdict job easier to reason about and test
- Why now: this fell out of the simplify pass as the safest high-leverage deletion of shallow workflow logic
- Issue: none, shipped from the `/simplify` lane

## Trade-offs / Risks
- Value gained: one less workflow-specific parser, stronger config contract, and clearer tests around override policy resolution
- Cost / risk incurred: `scripts/lib/defaults_config.py` now owns one more slice of the config surface
- Why this is still the right trade: the repo already treats typed config readers as the preferred boundary, so moving override policy into that boundary removes duplication instead of adding abstraction
- Reviewer watch-outs: pressure-test whether any caller still depends on the old implicit `pr_author` fallback behavior

## What Changed
This PR promotes override policy into the typed defaults config model, adds a dedicated `override-policies` CLI path for workflow consumers, and swaps the verdict action over to that CLI instead of parsing YAML inline.

### Base Branch
```mermaid
graph TD
  A["defaults/config.yml"] --> B["verdict/action.yml inline regex"]
  B --> C["global_policy + reviewer_policies outputs"]
  C --> D["aggregate-verdict.py"]
```

### This PR
```mermaid
graph TD
  A["defaults/config.yml"] --> B["load_defaults_config()"]
  B --> C["read-defaults-config.py override-policies"]
  C --> D["verdict/action.yml"]
  D --> E["aggregate-verdict.py"]
```

### Architecture / State Change
```mermaid
graph TD
  A["config.override.actor"] --> B["OverrideConfig.actor"]
  C["config.reviewers[].override"] --> D["Reviewer.override"]
  B --> E["DefaultsConfig.reviewer_override_policies()"]
  D --> E
  E --> F["workflow outputs"]
```

Why this is better:
- one config contract now serves both library callers and workflow glue
- reviewer-specific override fallback stays explicit in code instead of implicit in regex groups
- tests can pin the behavior without asserting against YAML parsing internals

<details>
<summary>Intent Reference</summary>

## Intent Reference
- Source: repository `/simplify` pass
- Simplification goal: remove the most complexity per unit of risk in one PR
- Chosen seam: the verdict workflow step that still parsed YAML directly instead of using the repo's typed config boundary

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `OverrideConfig`, reviewer-level `override`, and `reviewer_override_policies()` to [scripts/lib/defaults_config.py](/Users/phaedrus/.codex/worktrees/1b8d/cerberus/scripts/lib/defaults_config.py)
- Added `override-policies` output support to [scripts/read-defaults-config.py](/Users/phaedrus/.codex/worktrees/1b8d/cerberus/scripts/read-defaults-config.py)
- Replaced the inline regex parser in [verdict/action.yml](/Users/phaedrus/.codex/worktrees/1b8d/cerberus/verdict/action.yml)
- Added coverage for the new config, CLI, and action wiring in [tests/test_defaults_config.py](/Users/phaedrus/.codex/worktrees/1b8d/cerberus/tests/test_defaults_config.py), [tests/test_read_defaults_config_cli.py](/Users/phaedrus/.codex/worktrees/1b8d/cerberus/tests/test_read_defaults_config_cli.py), and [tests/test_verdict_action.py](/Users/phaedrus/.codex/worktrees/1b8d/cerberus/tests/test_verdict_action.py)

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Verdict workflow reads override policies through the typed defaults config boundary
- [x] Global and per-reviewer override policy remain available to `aggregate-verdict.py`
- [x] Focused tests cover config parsing, CLI output, and workflow wiring

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A - Do nothing
- Upside: zero code churn
- Downside: workflow YAML keeps its own parser for a config format the repo already models elsewhere
- Why rejected: it leaves the shallowest special case in place

### Option B - Broader metadata consolidation around verdict JSON
- Upside: removes more cross-file coupling in reviewer comment flow
- Downside: touches a larger runtime surface and is harder to prove in one simplification PR
- Why rejected: better follow-up, worse first move

### Option C - Current approach
- Upside: deletes the regex parser now and strengthens an existing module boundary
- Downside: does not address every remaining sidecar/config duplication in the pipeline
- Why chosen: best complexity-reduction-to-risk ratio for one PR

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
- `python3 -m pytest tests/test_defaults_config.py tests/test_read_defaults_config_cli.py tests/test_verdict_action.py`
- Expected: all targeted tests pass and the verdict action no longer contains inline regex parsing for override policy

</details>

## Walkthrough
- Renderer: terminal transcript
- Artifact: focused pytest transcript embedded below from branch execution
- Claim: override policy resolution now lives in the typed defaults config path instead of workflow-local YAML regex
- Before / After scope: `scripts/lib/defaults_config.py`, `scripts/read-defaults-config.py`, and `verdict/action.yml`
- Persistent verification: `python3 -m pytest tests/test_defaults_config.py tests/test_read_defaults_config_cli.py tests/test_verdict_action.py`
- Residual gap: reviewer-comment metadata still has broader consolidation opportunities outside this PR

<details>
<summary>Terminal Walkthrough Transcript</summary>

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0 -- /Users/phaedrus/.asdf/installs/python/3.12.8/bin/python3
cachedir: .pytest_cache
rootdir: /Users/phaedrus/.codex/worktrees/1b8d/cerberus
configfile: pytest.ini
plugins: anyio-4.12.1, mock-3.15.1, timeout-2.4.0, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 80 items

tests/test_defaults_config.py::TestLoadDefaultsConfig::test_minimal_valid_config PASSED [  1%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_full_config_with_model PASSED [  2%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_tiers_parsed PASSED [  3%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_wave_pools_parsed PASSED [  5%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_waves_config_parsed PASSED [  6%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_legacy_list_format PASSED [  7%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_missing_reviewers_key PASSED [  8%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_empty_reviewers_list PASSED [ 10%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_reviewer_not_a_mapping PASSED [ 11%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_reviewer_missing_name PASSED [ 12%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_reviewer_missing_perspective PASSED [ 13%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_reviewer_empty_name PASSED [ 15%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_reviewer_non_string_name PASSED [ 16%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_not_a_mapping PASSED [ 17%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_pool_not_a_list PASSED [ 18%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_pool_item_not_string PASSED [ 20%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_tiers_not_a_mapping PASSED [ 21%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_tier_not_a_list PASSED [ 22%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_tier_item_not_string PASSED [ 23%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_wave_pools_not_a_mapping PASSED [ 25%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_waves_definition_unknown_reviewer PASSED [ 26%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_waves_enabled_must_be_boolean PASSED [ 27%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_waves_max_for_tier_must_be_integer PASSED [ 28%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_waves_max_for_tier_must_be_positive PASSED [ 30%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_waves_order_rejects_duplicates PASSED [ 31%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_waves_order_references_defined_waves_only PASSED [ 32%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_waves_definition_reviewer_list_must_be_non_empty PASSED [ 33%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_optional_str_non_string PASSED [ 35%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_optional_str_empty_becomes_none PASSED [ 36%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_missing_file PASSED [ 37%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_invalid_yaml PASSED [ 38%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_top_level_not_mapping_or_list PASSED [ 40%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_reviewers_not_a_list PASSED [ 41%]
tests/test_defaults_config.py::TestLoadDefaultsConfig::test_model_default_non_string PASSED [ 42%]
tests/test_defaults_config.py::TestReviewerForPerspective::test_found PASSED [ 43%]
tests/test_defaults_config.py::TestReviewerForPerspective::test_not_found PASSED [ 45%]
tests/test_defaults_config.py::TestOverridePolicies::test_reviewer_override_policies_uses_global_default PASSED [ 46%]
tests/test_read_defaults_config_cli.py::TestSingleLine::test_none_returns_empty PASSED [ 47%]
tests/test_read_defaults_config_cli.py::TestSingleLine::test_empty_returns_empty PASSED [ 48%]
tests/test_read_defaults_config_cli.py::TestSingleLine::test_multiline_collapsed PASSED [ 50%]
tests/test_read_defaults_config_cli.py::TestSingleLine::test_tabs_replaced PASSED [ 51%]
tests/test_read_defaults_config_cli.py::TestReviewerMeta::test_found PASSED [ 52%]
tests/test_read_defaults_config_cli.py::TestReviewerMeta::test_unknown_perspective PASSED [ 53%]
tests/test_read_defaults_config_cli.py::TestModelDefault::test_prints_default PASSED [ 55%]
tests/test_read_defaults_config_cli.py::TestModelPool::test_prints_pool PASSED [ 56%]
tests/test_read_defaults_config_cli.py::TestModelPoolForTier::test_prints_tier_pool PASSED [ 57%]
tests/test_read_defaults_config_cli.py::TestModelPoolForTier::test_unknown_tier_prints_nothing PASSED [ 58%]
tests/test_read_defaults_config_cli.py::TestModelPoolForTier::test_empty_tier_is_error PASSED [ 60%]
tests/test_read_defaults_config_cli.py::TestModelPoolForWave::test_prints_wave_pool PASSED [ 61%]
tests/test_read_defaults_config_cli.py::TestModelPoolForWave::test_empty_wave_is_error PASSED [ 62%]
tests/test_read_defaults_config_cli.py::TestOverridePolicies::test_prints_json_payload PASSED [ 63%]
tests/test_read_defaults_config_cli.py::TestOverridePolicies::test_writes_github_outputs PASSED [ 65%]
tests/test_read_defaults_config_cli.py::TestWaveHelpers::test_wave_order_reviewers_and_max PASSED [ 66%]
tests/test_read_defaults_config_cli.py::TestWaveHelpers::test_wave_reviewers_empty_wave_is_error PASSED [ 67%]
tests/test_read_defaults_config_cli.py::TestWaveHelpers::test_wave_reviewers_unknown_wave_prints_nothing PASSED [ 68%]
tests/test_read_defaults_config_cli.py::TestWaveHelpers::test_wave_max_for_tier_empty_tier_is_error PASSED [ 70%]
tests/test_read_defaults_config_cli.py::TestConfigError::test_bad_config_file PASSED [ 71%]
tests/test_verdict_action.py::test_verdict_action_uses_python_override_collection PASSED [ 72%]
tests/test_verdict_action.py::test_verdict_action_reads_override_policies_via_typed_defaults_cli PASSED [ 73%]
tests/test_verdict_action.py::test_verdict_action_uses_shared_upsert PASSED [ 75%]
tests/test_verdict_action.py::test_verdict_action_posts_inline_review_comments PASSED [ 76%]
tests/test_verdict_action.py::test_post_comment_uses_shared_upsert PASSED [ 77%]
tests/test_verdict_action.py::test_action_uses_api_key_fallback_validator PASSED [ 78%]
tests/test_verdict_action.py::test_action_validates_perspective_from_defaults_config PASSED [ 80%]
tests/test_verdict_action.py::test_action_pins_pi_install_version PASSED [ 81%]
tests/test_verdict_action.py::test_action_reads_primary_model_file_when_present PASSED [ 82%]
tests/test_verdict_action.py::test_action_reads_configured_model_file_when_present PASSED [ 83%]
tests/test_verdict_action.py::test_consumer_template_passes_key_via_input PASSED [ 85%]
tests/test_verdict_action.py::test_workflow_templates_use_current_major_version PASSED [ 86%]
tests/test_verdict_action.py::test_readme_quick_start_uses_cerberus_openrouter_secret_name PASSED [ 87%]
tests/test_verdict_action.py::test_permission_help_is_present_in_shared_module PASSED [ 88%]
tests/test_verdict_action.py::test_verdict_action_avoids_heredoc_in_run_block PASSED [ 90%]
tests/test_verdict_action.py::test_verdict_action_uses_python_renderer_for_verdict_comment PASSED [ 91%]
tests/test_verdict_action.py::test_verdict_action_only_hard_fails_comment_post_for_fail_verdicts PASSED [ 92%]
tests/test_verdict_action.py::test_verdict_action_does_not_use_sparse_checkout_dot PASSED [ 93%]
tests/test_verdict_action.py::test_fail_on_skip_is_wired_in_actions PASSED [ 95%]
tests/test_verdict_action.py::test_skip_verdict_emits_warning_not_notice PASSED [ 96%]
tests/test_verdict_action.py::test_fail_on_skip_env_passed_to_render_step PASSED [ 97%]
tests/test_verdict_action.py::test_fail_on_verdict_is_wired_in_review_action PASSED [ 98%]
tests/test_verdict_action.py::test_review_prompt_references_diff_file_placeholder PASSED [100%]

============================== 80 passed in 0.13s ==============================
```

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: the verdict job extracted override policy by reading raw YAML text and matching regex blocks inside the workflow step
- After: the verdict job asks the existing defaults-config CLI for `override-policies`, which delegates the semantics to the typed loader
- Screenshots: not needed for this internal refactor

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- [tests/test_defaults_config.py](/Users/phaedrus/.codex/worktrees/1b8d/cerberus/tests/test_defaults_config.py)
- [tests/test_read_defaults_config_cli.py](/Users/phaedrus/.codex/worktrees/1b8d/cerberus/tests/test_read_defaults_config_cli.py)
- [tests/test_verdict_action.py](/Users/phaedrus/.codex/worktrees/1b8d/cerberus/tests/test_verdict_action.py)
- Gap: no end-to-end GitHub Actions run in this branch-local verification pass

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high
- Strongest evidence: 80 focused tests passed across the config loader, CLI wrapper, and verdict action wiring
- Remaining uncertainty: only full Actions runtime can prove the live `GITHUB_OUTPUT` handoff in GitHub's runner environment
- What could still go wrong after merge: a workflow-only edge if GitHub output parsing behaves differently than the local tests model

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable override policies, allowing both global defaults and per-reviewer customization for reviewer assignments.
  * Introduced `override-policies` command to retrieve and export current override configuration settings.

* **Refactor**
  * Simplified the action configuration by delegating policy extraction logic to dedicated external tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->