### PR TITLE
fix: install pyyaml in verdict action

### DIFF
--- a/artifacts/pr-365-walkthrough.md
+++ b/artifacts/pr-365-walkthrough.md
@@ -1,0 +1,37 @@
+# PR Walkthrough: Issue #365
+
+## Goal
+
+Keep the shipped verdict composite action from failing before verdict synthesis when `scripts/read-defaults-config.py` imports `yaml`.
+
+## Before
+
+- `verdict/action.yml` provisioned Python 3.12 but did not install `PyYAML`.
+- The first bootstrap read of `defaults/config.yml` happened in that under-provisioned environment.
+- Downstream repositories could get a false-red required `review / Cerberus` check even though review shards had already completed.
+
+## After
+
+- `verdict/action.yml` now installs `PyYAML` immediately after `actions/setup-python`.
+- The install happens before the action invokes `scripts/read-defaults-config.py`.
+- `tests/test_verdict_action.py` now locks that ordering so the verdict bootstrap dependency cannot silently drift out again.
+
+## Verification
+
+- RED:
+  - `uvx --from pytest pytest tests/test_verdict_action.py tests/test_defaults_config_reader.py -q`
+  - Outcome before the action fix: the new verdict-action regression failed because `pip install pyyaml --quiet` was missing, and the defaults-config reader CLI reproduced `ModuleNotFoundError: No module named 'yaml'` in a clean runner.
+- GREEN:
+  - `uvx --with pyyaml --from pytest pytest tests/test_verdict_action.py tests/test_defaults_config_reader.py -q`
+  - Outcome after the fix: `32 passed in 0.76s`
+  - `uvx ruff check tests/test_verdict_action.py`
+  - Outcome: `All checks passed!`
+
+## Persistent Check
+
+`uvx --with pyyaml --from pytest pytest tests/test_verdict_action.py tests/test_defaults_config_reader.py -q`
+
+## Residual Risk
+
+- This lane fixes the concrete bootstrap dependency gap in the shipped verdict action.
+- `make validate` still depends on a separately provisioned local Python toolchain in this worktree, so branch verification stays focused on the touched verdict/bootstrap surface.

--- a/tests/test_verdict_action.py
+++ b/tests/test_verdict_action.py
@@ -32,6 +32,16 @@ def test_verdict_action_reads_override_policies_via_typed_defaults_cli() -> None
     assert "re.search(r'^\\s*override:" not in content
 
 
+def test_verdict_action_installs_pyyaml_before_defaults_bootstrap() -> None:
+    content = VERDICT_ACTION_FILE.read_text()
+
+    setup_idx = content.index("Setup Python")
+    install_idx = content.index("pip install pyyaml --quiet")
+    read_defaults_idx = content.index("scripts/read-defaults-config.py")
+
+    assert setup_idx < install_idx < read_defaults_idx
+
+
 def test_verdict_action_uses_shared_upsert() -> None:
     content = VERDICT_ACTION_FILE.read_text()
 

--- a/verdict/action.yml
+++ b/verdict/action.yml
@@ -46,6 +46,10 @@ runs:
       with:
         python-version: '3.12'
 
+    - name: Install verdict bootstrap dependencies
+      shell: bash
+      run: pip install pyyaml --quiet
+
     - name: Read reviewer policies from config
       id: policies
       shell: bash


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [Walkthrough artifact](https://github.com/misty-step/cerberus/blob/codex/issue-365-verdict-pyyaml/artifacts/pr-365-walkthrough.md)
- Direct video download: N/A. This is a shipped action bootstrap fix, so the proof is command output plus the action diff.
- Walkthrough notes: the branch restores the verdict job's packaged dependency contract by provisioning `PyYAML` before the first config read.
- Fast claim: downstream `review / Cerberus` verdict jobs stop failing red on `ModuleNotFoundError: yaml` before verdict synthesis.

## Why This Matters
- Problem: the shipped verdict composite action invoked `scripts/read-defaults-config.py` before installing `PyYAML`, so downstream repos could get a false-red required Cerberus check for infrastructure drift instead of review content.
- Value: the verdict job now provisions the dependency its bootstrap path actually requires, which restores truthful merge gating for downstream consumers.
- Why now: this is a live blocker for `misty-step/bitterblossom#562` and keeps factory supervision lanes stuck for the wrong reason.
- Issue: Closes #365.

## Trade-offs / Risks
- Value gained: the smallest shipped fix for a production false-red path, plus a regression test that locks the action ordering.
- Cost / risk incurred: `verdict/action.yml` now installs one explicit Python package at runtime, which adds a small step and keeps dependency provisioning duplicated across composite actions.
- Why this is still the right trade: the root cause is packaging drift at the action boundary, so the correct fix is to provision the missing dependency where the action actually runs.
- Reviewer watch-outs: if Cerberus later centralizes composite-action Python dependencies, this step should move with that refactor rather than diverge silently.

## What Changed
This branch fixes the verdict action at its shipping boundary. The composite action now installs `PyYAML` immediately after `actions/setup-python`, and a focused regression test asserts that the install stays ahead of `scripts/read-defaults-config.py`.

### Base Branch
```mermaid
graph TD
  A["verdict/action.yml"] --> B["setup-python"]
  B --> C["read-defaults-config.py override-policies"]
  C --> D["lib.defaults_config imports yaml"]
  D --> E["ModuleNotFoundError in clean runner"]
```

### This PR
```mermaid
graph TD
  A["verdict/action.yml"] --> B["setup-python"]
  B --> C["pip install pyyaml"]
  C --> D["read-defaults-config.py override-policies"]
  D --> E["typed config load succeeds"]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> UnderProvisioned
  UnderProvisioned --> FalseRed: "yaml import during bootstrap"
  UnderProvisioned --> Provisioned: "install PyYAML"
  Provisioned --> TruthfulVerdict: "bootstrap succeeds"
```

Why this is better:
- The fix stays at the actual shipping boundary instead of masking the failure downstream.
- The defaults-config loader remains unchanged; only the missing runtime contract is restored.
- The new regression test makes the action ordering explicit instead of relying on reviewer memory.

<details>
<summary>Intent Reference</summary>

## Intent Reference
Issue #365 now defines the contract as: the shipped verdict action must execute `scripts/read-defaults-config.py` in a clean runner without `ModuleNotFoundError: yaml`, and the fix should stay narrow to the packaged verdict environment.

Source: [Issue #365](https://github.com/misty-step/cerberus/issues/365)

</details>

<details>
<summary>Changes</summary>

## Changes
- `verdict/action.yml`
- Add `Install verdict bootstrap dependencies` so the composite action runs `pip install pyyaml --quiet` before reading override policy from `defaults/config.yml`.
- `tests/test_verdict_action.py`
- Add a regression that asserts the verdict action installs `PyYAML` after `Setup Python` and before `scripts/read-defaults-config.py`.
- `artifacts/pr-365-walkthrough.md`
- Add the walkthrough artifact for reviewer evidence and durable verification context.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A: Do nothing
- Upside: no action churn.
- Downside: downstream repos keep getting false-red required Cerberus checks.
- Why rejected: this is a live production blocker, not a theoretical cleanup.

### Option B: Rewrite the defaults-config reader to avoid YAML dependencies
- Upside: fewer runtime installs in the verdict action.
- Downside: much wider surface area, more risk, and it ignores the actual packaging contract breach.
- Why rejected: the issue is not YAML as a format; it is that the shipped action omitted a dependency it already relies on.

### Option C: Install `PyYAML` in the verdict action (chosen)
- Upside: smallest root-cause fix at the shipping boundary.
- Downside: keeps explicit dependency installation in the composite action.
- Why chosen: it directly addresses the production failure with a reversible, testable diff.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Given a clean verdict runner environment created from the shipped composite action, when `scripts/read-defaults-config.py` runs during override-policy bootstrap, then it does not fail with `ModuleNotFoundError: yaml`.
- [x] Given downstream repos run the aggregate Cerberus verdict job, when review shards already succeeded, then the required aggregate check no longer fails solely because PyYAML was omitted from the verdict bootstrap environment.
- [x] Given the verdict action definition, when repo tests inspect it, then they assert the verdict composite action provisions `PyYAML` before invoking the defaults-config reader.
- [x] Given the branch implementation, when `uvx --with pyyaml --from pytest pytest tests/test_verdict_action.py tests/test_defaults_config_reader.py -q` runs, then the regression coverage passes.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
- `uvx --from pytest pytest tests/test_verdict_action.py tests/test_defaults_config_reader.py -q`
- Before the fix: failed because the new verdict-action regression could not find `pip install pyyaml --quiet`, and the defaults-config CLI reproduced `ModuleNotFoundError: No module named 'yaml'` in a clean runner.
- `uvx --with pyyaml --from pytest pytest tests/test_verdict_action.py tests/test_defaults_config_reader.py -q`
- After the fix: `32 passed in 0.76s`
- `uvx ruff check tests/test_verdict_action.py`
- Result: `All checks passed!`

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: Terminal walkthrough with diagrams
- Artifact: [artifacts/pr-365-walkthrough.md](https://github.com/misty-step/cerberus/blob/codex/issue-365-verdict-pyyaml/artifacts/pr-365-walkthrough.md)
- Claim: the shipped verdict action now provisions the dependency required for defaults-config bootstrap, so downstream verdict jobs stop failing before synthesis on missing `yaml`.
- Before / After scope: `verdict/action.yml`, `tests/test_verdict_action.py`, and the focused defaults reader regression surface.
- Persistent verification: `uvx --with pyyaml --from pytest pytest tests/test_verdict_action.py tests/test_defaults_config_reader.py -q`
- Residual gap: full `make validate` reproduction in this worktree still depends on a separately provisioned local Python toolchain.

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: the verdict composite action booted Python and immediately invoked a YAML-backed config reader in an environment that did not install `PyYAML`.
- After: the same shipped action explicitly installs `PyYAML` first, and the repo has a regression test proving that ordering.
- Screenshots: not applicable because this is an internal action bootstrap fix.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- Updated: `tests/test_verdict_action.py`
- Exercised: `tests/test_defaults_config_reader.py`
- Gap: no broader environment bootstrap consolidation in this lane; this PR only locks the current verdict dependency contract.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: High
- Strongest evidence: the failure reproduces in a clean runner path, the action now provisions the missing dependency, and the focused regression suite passes.
- Remaining uncertainty: local `make validate` still depends on a separately installed `pytest` toolchain in this worktree, so full-repo validation was not reproduced verbatim here.
- What could still go wrong after merge: if the verdict action later adds another undeclared Python dependency, this PR will not catch that broader pattern by itself.

</details>
