### PR TITLE
test: guard execution boundary drift

### DIFF
--- a/.groom/retro.md
+++ b/.groom/retro.md
@@ -119,6 +119,15 @@
 - **blockers**: `make validate` initially failed only in `ruff` because a compatibility import kept for the retry tests looked unused after the transport refactor; the fix was to make the back-compat surface explicit instead of deleting it and breaking callers/tests.
 - **pattern**: Boundary refactors in mature codepaths go faster when the new deep module is introduced underneath stable compatibility seams. For Cerberus, preserving `lib.github` and `collect-overrides.py` wrapper surfaces while moving transport underneath `github_platform` kept the diff small and the tests credible.
 
+## 2026-03-12 — Issue #328: coupling guard for execution boundary
+
+- **issue**: #328
+- **predicted effort**: p1 (small — under a day)
+- **actual effort**: ~1.5 hours
+- **scope changes**: Enriched the issue before coding, added one narrow execution-boundary regression test, expanded ADR 004 with explicit extension-point guidance, and added a walkthrough artifact for the lane.
+- **blockers**: The first guard test overreached by flagging harmless `"gh ..."` strings in error text rather than actual subprocess call sites; narrowing the assertion to call sites kept the guard useful instead of noisy.
+- **pattern**: Boundary guardrails need both halves: executable enforcement plus contributor-facing routing language. A test without the ADR becomes a trap; an ADR without the test becomes drift-prone.
+
 ## 2026-03-12 — Issue #302: mutable action ref severity in guard
 
 - **issue**: #302

--- a/docs/adr/004-review-execution-boundary.md
+++ b/docs/adr/004-review-execution-boundary.md
@@ -83,6 +83,13 @@ surface for the GitHub lane is:
 - The GitHub Action path now has one more artifact to manage.
 - Legacy env fallbacks must remain for compatibility during migration.
 
+## Extension Points
+
+- If a new review-path feature needs direct GitHub CLI or GitHub API transport, extend `scripts/lib/github_platform.py`.
+- If a change belongs to fetch/bootstrap setup before the engine runs, extend the GitHub workflow bootstrap.
+- Do not add raw `gh` transport directly to engine-path modules such as `run-reviewer.py`, `review_run_contract.py`, `runtime_facade.py`, `github.py`, `github_reviews.py`, or their review-path callers.
+- Compatibility wrappers may preserve caller-visible contracts, but their transport must still route through `github_platform`.
+
 ## Alternatives Considered
 
 1. Keep raw `GH_*` env bootstrap in engine code.

--- a/docs/walkthroughs/issue-328-execution-boundary-guard.md
+++ b/docs/walkthroughs/issue-328-execution-boundary-guard.md
@@ -1,0 +1,87 @@
+# Issue #328 Walkthrough: Execution Boundary Guard
+
+## Reviewer Evidence
+
+- Core claim: Cerberus now has a regression test and ADR guidance that keep raw `gh` transport out of protected engine-path modules while preserving the existing GitHub Action contract path.
+- Primary artifact: terminal walkthrough with real branch execution evidence.
+- Persistent verification: `python3 -m pytest tests/test_execution_boundary.py tests/test_bootstrap_review_run.py tests/test_review_run_contract.py tests/test_github_read_integration.py -q`
+
+## Walkthrough
+
+### What was missing before
+
+- ADR 004 explained the review-run contract and `github_platform` boundary, but it did not tell contributors exactly where new GitHub-specific behavior should land.
+- The repo had no focused regression test that would fail if a protected engine-path module embedded raw `gh` transport directly.
+
+### What changed on this branch
+
+- Added `tests/test_execution_boundary.py` to guard protected engine-path modules against direct raw `gh` subprocess calls.
+- Extended `docs/adr/004-review-execution-boundary.md` with explicit extension-point guidance for `github_platform` and workflow bootstrap changes.
+- Enriched issue `#328` with product spec, intent contract, technical design, affected files, and verification commands before implementation.
+
+### What is true after
+
+- Protected engine-path modules now fail a focused regression suite if they embed raw `gh` transport directly.
+- ADR 004 now tells contributors to extend `scripts/lib/github_platform.py` for review-path transport and workflow bootstrap for pre-engine setup.
+- The existing GitHub lane contract tests still pass unchanged, so the new guardrail does not regress the current bootstrap path.
+
+## Execution Proof
+
+### RED -> GREEN boundary suite
+
+```text
+$ python3 -m pytest tests/test_execution_boundary.py tests/test_bootstrap_review_run.py tests/test_review_run_contract.py tests/test_github_read_integration.py -q
+2 failed, 14 passed in 0.11s
+
+$ python3 -m pytest tests/test_execution_boundary.py tests/test_bootstrap_review_run.py tests/test_review_run_contract.py tests/test_github_read_integration.py -q
+16 passed in 0.08s
+```
+
+### Transport compatibility slice
+
+```text
+$ python3 -m pytest tests/test_github_platform.py tests/test_github.py tests/test_github_reviews.py -q
+51 passed in 0.13s
+```
+
+### Full repo gate
+
+```text
+$ make validate
+1641 passed, 1 skipped in 48.50s
+ruff clean
+shellcheck clean
+```
+
+## Before / After Shape
+
+### Before
+
+```mermaid
+graph TD
+  A["ADR 004 boundary exists"] --> B["Contributor adds GitHub behavior"]
+  B --> C["Placement depends on memory and local judgment"]
+  C --> D["No focused test catches raw gh in protected engine paths"]
+```
+
+### After
+
+```mermaid
+graph TD
+  A["ADR 004 extension points"] --> B["Contributor adds GitHub behavior"]
+  B --> C["github_platform or workflow bootstrap"]
+  D["test_execution_boundary.py"] --> E["Protected engine-path modules"]
+  E --> F["Raw gh call added directly?"]
+  F -->|Yes| G["Focused test fails"]
+  F -->|No| H["Boundary stays intact"]
+```
+
+## Why the new shape is better
+
+- The execution boundary is now both documented and enforced.
+- Contributors get one named place for GitHub transport work instead of inferring it from scattered history.
+- The new guard stays narrow: it protects engine-path modules without blocking unrelated maintenance tooling.
+
+## Residual Gap
+
+- The guard test focuses on direct subprocess call sites in protected Python modules. It does not attempt to police every repo script or every possible indirect shell wrapper outside the documented execution boundary.

--- a/tests/test_execution_boundary.py
+++ b/tests/test_execution_boundary.py
@@ -1,0 +1,64 @@
+"""Guardrails for the review execution boundary from ADR 004."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR_004 = ROOT / "docs" / "adr" / "004-review-execution-boundary.md"
+PROTECTED_ENGINE_PATHS = (
+    "scripts/bootstrap-review-run.py",
+    "scripts/collect-overrides.py",
+    "scripts/post-verdict-review.py",
+    "scripts/render-review-prompt.py",
+    "scripts/run-reviewer.py",
+    "scripts/lib/github.py",
+    "scripts/lib/github_reviews.py",
+    "scripts/lib/review_run_contract.py",
+    "scripts/lib/runtime_facade.py",
+)
+
+
+def _literal_starts_with_gh(node: ast.AST) -> bool:
+    if isinstance(node, ast.List | ast.Tuple) and node.elts:
+        first = node.elts[0]
+        return isinstance(first, ast.Constant) and first.value == "gh"
+    return isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value.startswith("gh ")
+
+
+def _find_raw_gh_subprocess_calls(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        if _literal_starts_with_gh(node.args[0]):
+            lines.append(node.lineno)
+    return sorted(set(lines))
+
+
+def test_protected_engine_paths_do_not_embed_raw_gh_transport() -> None:
+    offenders: list[str] = []
+    for rel_path in PROTECTED_ENGINE_PATHS:
+        path = ROOT / rel_path
+        assert path.exists(), f"Protected execution-boundary path is missing: {rel_path}"
+        lines = _find_raw_gh_subprocess_calls(path)
+        if lines:
+            offenders.append(f"{rel_path}:{','.join(str(line) for line in lines)}")
+
+    assert offenders == [], (
+        "Protected engine-path files must route GitHub CLI transport through "
+        "scripts/lib/github_platform.py instead of embedding raw gh calls: "
+        + "; ".join(offenders)
+    )
+
+
+def test_adr_004_names_the_allowed_extension_points() -> None:
+    text = ADR_004.read_text(encoding="utf-8")
+    lowered = text.lower()
+
+    assert "extend `scripts/lib/github_platform.py`" in text
+    assert "workflow bootstrap" in lowered
+    assert "do not add raw `gh` transport directly to engine-path modules" in lowered


### PR DESCRIPTION
## Reviewer Evidence
- Start here: `Why This Matters`, then open the walkthrough artifact below.
- Direct video download: N/A. This lane is internal and is proved with terminal execution evidence.
- Walkthrough notes: [Execution boundary walkthrough](https://github.com/misty-step/cerberus/blob/codex/issue-328-execution-boundary-guard/docs/walkthroughs/issue-328-execution-boundary-guard.md)
- Fast claim: This PR turns ADR 004 from tribal knowledge into an enforced repo contract by adding one focused guard test and explicit extension-point guidance, while keeping the current GitHub Action contract path green.

## Why This Matters
- Problem: Cerberus had an execution boundary on paper, but no focused regression test or contributor guidance preventing raw `gh` transport from leaking back into protected engine-path modules.
- Value: Future review-path work now has a clear place to land and a failing test if someone recouples GitHub transport in the wrong layer.
- Why now: `#323` established the review-run contract and adapter boundary; this is the follow-up lane that locks that boundary in.
- Issue: Closes #328.

## Trade-offs / Risks
- Value gained: Cheap boundary drift detection, clearer contributor routing, and stronger self-hosted/alternate-runner posture.
- Cost / risk incurred: The new guard is intentionally narrow and only watches protected Python engine-path modules, so it does not police every shell wrapper or maintenance script in the repo.
- Why this is still the right trade: A narrow, explicit guard is safer than a broad noisy one; contributors get a real failure signal without false positives from unrelated tooling.
- Reviewer watch-outs: Pressure-test the protected-path list and the exact boundary language in ADR 004. If the boundary expands later, the test manifest should expand with it.

## What Changed
This PR adds one executable guardrail and one documentation guardrail for the execution boundary introduced in `#323`: protected engine-path modules now fail a focused test if they embed raw `gh` subprocess calls directly, and ADR 004 now tells contributors to extend `scripts/lib/github_platform.py` or workflow bootstrap rather than scattering GitHub transport back through the engine.

### Base Branch
```mermaid
graph TD
  A["ADR 004 boundary exists"] --> B["Contributor adds GitHub behavior"]
  B --> C["Placement depends on memory and local judgment"]
  C --> D["No focused test catches raw gh in protected engine paths"]
```

### This PR
```mermaid
graph TD
  A["Contributor adds GitHub behavior"] --> B{"Where does it belong?"}
  B -->|"review-path transport"| C["scripts/lib/github_platform.py"]
  B -->|"pre-engine bootstrap"| D["workflow bootstrap"]
  E["tests/test_execution_boundary.py"] --> F["Protected engine-path modules"]
  F --> G{"Raw gh call added directly?"}
  G -->|"Yes"| H["Focused test fails"]
  G -->|"No"| I["Boundary stays intact"]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> ImplicitBoundary
  ImplicitBoundary --> DriftRisk: "Docs exist but routing is implicit"
  DriftRisk --> GuardedBoundary: "Add focused test + explicit extension points"
  GuardedBoundary --> [*]
```

Why this is better:
- The boundary is now enforced, not just described.
- Contributors get named extension points instead of inferring them from old PRs.
- Existing GitHub Action contract tests still pass, so the guard does not destabilize the current lane.

<details>
<summary>Intent Reference</summary>

## Intent Reference
Issue [`#328`](https://github.com/misty-step/cerberus/issues/328) now states the intent explicitly: keep engine-path code on the review-run contract and shared GitHub adapter, fail CI if protected engine-path modules grow raw `gh` transport again, and document the allowed extension points so new work lands in the right boundary.

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `tests/test_execution_boundary.py` to guard protected engine-path modules against direct raw `gh` subprocess calls and to pin ADR 004 extension-point guidance.
- Updated `docs/adr/004-review-execution-boundary.md` with explicit contributor-facing routing for `github_platform` and workflow bootstrap changes.
- Added `docs/walkthroughs/issue-328-execution-boundary-guard.md` as the walkthrough artifact for this branch.
- Appended `.groom/retro.md` with the lane signal for `#328`.
- Enriched issue `#328` itself before implementation with product spec, intent contract, design, affected files, and verification commands.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A: Do nothing
- Upside: No new guard to maintain.
- Downside: ADR 004 remains soft guidance and future recoupling can slip in unnoticed.
- Why rejected: The whole point of the boundary work was to make the seam durable.

### Option B: Broad repo-wide raw-`gh` ban
- Upside: Stronger theoretical coverage.
- Downside: Would immediately create noise for bootstrap flows and unrelated tooling that are intentionally GitHub-specific.
- Why rejected: Too blunt for the actual boundary this issue is trying to protect.

### Option C: Narrow protected-path guard plus ADR routing (chosen)
- Upside: High signal, small diff, and aligned with ADR 004's actual scope.
- Downside: Protected path list must stay current as the boundary evolves.
- Why chosen: It locks the current boundary without inventing a wider policy than the repo has agreed to.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Given protected engine-path modules, when a raw `gh` subprocess call is added outside the allowed adapter/bootstrap files, then the new guard test fails with the offending path.
- [x] Given the GitHub Action execution path, when contract/bootstrap tests run, then they still prove the GitHub lane writes and consumes the review-run contract rather than depending on linked-issue env injection.
- [x] Given a contributor reading the architecture docs, when they need to add GitHub-specific review-path behavior, then the docs tell them to extend `scripts/lib/github_platform.py` or workflow bootstrap instead of scattering raw transport logic.
- [x] Given the branch changes, when `python3 -m pytest tests/test_execution_boundary.py tests/test_bootstrap_review_run.py tests/test_review_run_contract.py tests/test_github_read_integration.py -q` runs, then it passes.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
- `python3 -m pytest tests/test_execution_boundary.py tests/test_bootstrap_review_run.py tests/test_review_run_contract.py tests/test_github_read_integration.py -q`
- `python3 -m pytest tests/test_github_platform.py tests/test_github.py tests/test_github_reviews.py -q`
- `make validate`

Expected / observed:
- Focused RED -> GREEN sequence ended at `16 passed in 0.08s`.
- GitHub transport compatibility slice passed at `51 passed in 0.13s`.
- Full repo gate passed at `1641 passed, 1 skipped in 48.50s`, followed by clean `ruff` and `shellcheck`.

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: terminal walkthrough
- Artifact: [docs/walkthroughs/issue-328-execution-boundary-guard.md](https://github.com/misty-step/cerberus/blob/codex/issue-328-execution-boundary-guard/docs/walkthroughs/issue-328-execution-boundary-guard.md)
- Claim: The execution boundary from ADR 004 is now both documented and enforced for protected engine-path modules.
- Before / After scope: `tests/test_execution_boundary.py`, `docs/adr/004-review-execution-boundary.md`, and the existing contract/bootstrap suites.
- Persistent verification: `python3 -m pytest tests/test_execution_boundary.py tests/test_bootstrap_review_run.py tests/test_review_run_contract.py tests/test_github_read_integration.py -q`
- Residual gap: The guard stays intentionally narrow and does not attempt to ban raw `gh` usage in unrelated maintenance tooling.
- Observable artifact from actual branch execution:
```text
$ python3 -m pytest tests/test_execution_boundary.py tests/test_bootstrap_review_run.py tests/test_review_run_contract.py tests/test_github_read_integration.py -q
16 passed in 0.08s

$ make validate
1641 passed, 1 skipped in 48.50s
ruff clean
shellcheck clean
```

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: ADR 004 described the boundary, but contributors still had to infer where new GitHub-specific logic belonged, and no focused regression test would fail if protected engine-path modules embedded raw `gh` transport directly.
- After: contributors have explicit extension-point guidance, and protected engine-path modules are covered by a dedicated boundary guard test that fails on direct raw `gh` subprocess drift.
- Screenshots: not applicable. This is an internal contract and documentation lane.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- New: `tests/test_execution_boundary.py`
- Re-verified: `tests/test_bootstrap_review_run.py`
- Re-verified: `tests/test_review_run_contract.py`
- Re-verified: `tests/test_github_read_integration.py`
- Adjacent transport verification: `tests/test_github_platform.py`, `tests/test_github.py`, `tests/test_github_reviews.py`
- Full repo gate: `make validate`
- Gap: the new guard watches explicit protected Python modules; expanding the boundary later requires updating that manifest.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: High
- Strongest evidence: focused RED -> GREEN proof for the new guard, passing contract/bootstrap/transport slices, and a clean full `make validate` run on this branch.
- Remaining uncertainty: future boundary expansion could outgrow the current protected-path list if maintainers forget to update it.
- What could still go wrong after merge: a new engine-path module could be added later without being added to the protected manifest, which would create a blind spot until the guard is extended.

</details>
