### PR TITLE
refactor: deepen review-run bootstrap boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ Shell/bash access is denied per agent via `permission` in the agent markdown fro
 - `templates/consumer-workflow-reusable.yml` - recommended workflow for downstream repositories
 - `templates/workflow-lint.yml` - optional workflow to catch YAML/syntax issues early
 - `scripts/fetch-pr-bootstrap.py` - adapter-backed bootstrap fetch for `pr.diff` and `pr-context.json`
+- `scripts/lib/review_run_bootstrap.py` - shared bootstrap module for PR artifact persistence and `review-run.json` assembly
 - `scripts/run-reviewer.sh` - orchestrates one reviewer via `scripts/run-reviewer.py` and Pi runtime
 - `scripts/parse-review.py` - extracts last ` ```json ` block, validates required fields/types
 - `scripts/post-comment.sh` - formats findings as markdown, upserts comment using HTML marker for idempotency

--- a/docs/review-run-contract.md
+++ b/docs/review-run-contract.md
@@ -35,8 +35,8 @@ bootstrap env wiring.
 
 The current action maps cleanly onto the contract:
 
-1. `action.yml` invokes `scripts/fetch-pr-bootstrap.py`, which fetches `pr.diff` and `pr-context.json` through `scripts/lib/github_platform.py`.
-2. `scripts/bootstrap-review-run.py` writes `review-run.json`.
+1. `action.yml` invokes `scripts/fetch-pr-bootstrap.py`, which fetches `pr.diff` and `pr-context.json` through `scripts/lib/github_platform.py` and persists them through `scripts/lib/review_run_bootstrap.py`.
+2. `scripts/bootstrap-review-run.py` writes `review-run.json` through the same shared bootstrap module.
 3. `scripts/run-reviewer.py` loads the contract, reads diff/context from it, and
    reconstructs GitHub runtime env for the isolated Pi process from
    `github.repo`, `github.pr_number`, and `github.token_env_var`.
@@ -57,7 +57,7 @@ python3 scripts/non_gha_review_run.py \
 This runner:
 
 1. fetches `pr.diff` and `pr-context.json` through `scripts/lib/github_platform.py`
-2. writes `review-run.json`
+2. writes `pr.diff`, `pr-context.json`, and `review-run.json` through `scripts/lib/review_run_bootstrap.py`
 3. runs the configured reviewers through `scripts/run-reviewer.sh`
 4. parses each reviewer verdict with `scripts/parse-review.py`
 5. aggregates the final verdict with `scripts/aggregate-verdict.py`

--- a/scripts/bootstrap-review-run.py
+++ b/scripts/bootstrap-review-run.py
@@ -4,12 +4,13 @@
 from __future__ import annotations
 
 import argparse
-import json
-import os
 import sys
 from pathlib import Path
 
-from lib.review_run_contract import GitHubExecutionContext, ReviewRunContract, write_review_run_contract
+from lib.review_run_bootstrap import (
+    require_existing_file,
+    write_review_run_bootstrap,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -27,29 +28,6 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def require_existing_file(path: Path, label: str) -> None:
-    if not path.is_file():
-        raise FileNotFoundError(f"{label} file not found: {path}")
-
-
-def load_branch_refs(pr_context_file: Path) -> tuple[str, str]:
-    """Read head/base refs from the fetched PR context JSON."""
-
-    try:
-        payload = json.loads(pr_context_file.read_text(encoding="utf-8"))
-    except OSError as exc:
-        raise OSError(f"unable to read PR context file {pr_context_file}: {exc}") from exc
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"invalid JSON in PR context file {pr_context_file}: {exc}") from exc
-
-    if not isinstance(payload, dict):
-        raise ValueError(f"invalid PR context file {pr_context_file}: expected object")
-
-    head_ref = str(payload.get("headRefName") or "").strip()
-    base_ref = str(payload.get("baseRefName") or "").strip()
-    return head_ref, base_ref
-
-
 def main() -> int:
     args = parse_args()
     diff_file = Path(args.diff_file)
@@ -59,23 +37,14 @@ def main() -> int:
     try:
         require_existing_file(diff_file, "diff")
         require_existing_file(pr_context_file, "PR context")
-        head_ref, base_ref = load_branch_refs(pr_context_file)
-        contract = ReviewRunContract(
-            repository=args.repo,
+        write_review_run_bootstrap(
+            output=output,
+            repo=args.repo,
             pr_number=args.pr,
-            diff_file=str(diff_file),
-            pr_context_file=str(pr_context_file),
-            workspace_root=os.getcwd(),
-            temp_dir=str(output.parent),
-            head_ref=head_ref,
-            base_ref=base_ref,
-            github=GitHubExecutionContext(
-                repo=args.repo,
-                pr_number=args.pr,
-                token_env_var=args.token_env_var,
-            ),
+            diff_file=diff_file,
+            pr_context_file=pr_context_file,
+            token_env_var=args.token_env_var,
         )
-        write_review_run_contract(output, contract)
     except (OSError, ValueError) as exc:
         print(f"bootstrap-review-run: {exc}", file=sys.stderr)
         return 2

--- a/scripts/fetch-pr-bootstrap.py
+++ b/scripts/fetch-pr-bootstrap.py
@@ -11,6 +11,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from lib import github_platform as platform
+from lib.review_run_bootstrap import fetch_pr_bootstrap, write_pr_bootstrap_files
 
 
 @dataclass(frozen=True)
@@ -42,14 +43,13 @@ def main() -> int:
     result_file.parent.mkdir(parents=True, exist_ok=True)
 
     try:
-        diff_file.parent.mkdir(parents=True, exist_ok=True)
-        pr_context_file.parent.mkdir(parents=True, exist_ok=True)
-
-        diff = platform.fetch_pr_diff(args.repo, args.pr)
-        pr_context = platform.fetch_pr_context(args.repo, args.pr)
-
-        diff_file.write_text(diff, encoding="utf-8")
-        pr_context_file.write_text(json.dumps(pr_context), encoding="utf-8")
+        diff, pr_context = fetch_pr_bootstrap(args.repo, args.pr)
+        write_pr_bootstrap_files(
+            diff_file=diff_file,
+            pr_context_file=pr_context_file,
+            diff=diff,
+            pr_context=pr_context,
+        )
         result = BootstrapResult(ok=True, error_kind="", error_message="")
     except platform.GitHubAuthError as exc:
         result = BootstrapResult(ok=False, error_kind="auth", error_message=str(exc))

--- a/scripts/lib/review_run_bootstrap.py
+++ b/scripts/lib/review_run_bootstrap.py
@@ -1,0 +1,119 @@
+"""Shared bootstrap helpers for review-run artifacts and contract assembly."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Mapping
+
+from . import github_platform as platform
+from .review_run_contract import GitHubExecutionContext, ReviewRunContract, write_review_run_contract
+
+
+def require_existing_file(path: Path, label: str) -> None:
+    """Fail fast with the caller-facing bootstrap error wording."""
+
+    if not path.is_file():
+        raise FileNotFoundError(f"{label} file not found: {path}")
+
+
+def fetch_pr_bootstrap(repo: str, pr_number: int) -> tuple[str, dict[str, object]]:
+    """Fetch the diff and PR context needed to bootstrap a review run."""
+
+    diff = platform.fetch_pr_diff(repo, pr_number)
+    pr_context = platform.fetch_pr_context(repo, pr_number)
+    return diff, pr_context
+
+
+def write_pr_bootstrap_files(
+    *,
+    diff_file: Path,
+    pr_context_file: Path,
+    diff: str,
+    pr_context: Mapping[str, object],
+) -> None:
+    """Persist bootstrap artifacts to disk."""
+
+    diff_file.parent.mkdir(parents=True, exist_ok=True)
+    pr_context_file.parent.mkdir(parents=True, exist_ok=True)
+    diff_file.write_text(diff, encoding="utf-8")
+    pr_context_file.write_text(json.dumps(pr_context), encoding="utf-8")
+
+
+def read_pr_context_file(pr_context_file: Path) -> dict[str, object]:
+    """Load and validate the bootstrap PR context payload."""
+
+    try:
+        payload = json.loads(pr_context_file.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise OSError(f"unable to read PR context file {pr_context_file}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in PR context file {pr_context_file}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"invalid PR context file {pr_context_file}: expected object")
+
+    return payload
+
+
+def _branch_refs(pr_context: Mapping[str, object]) -> tuple[str, str]:
+    head_ref = str(pr_context.get("headRefName") or "").strip()
+    base_ref = str(pr_context.get("baseRefName") or "").strip()
+    return head_ref, base_ref
+
+
+def build_review_run(
+    *,
+    repo: str,
+    pr_number: int,
+    diff_file: Path,
+    pr_context_file: Path,
+    temp_dir: Path,
+    token_env_var: str = "GH_TOKEN",
+    workspace_root: str | None = None,
+    pr_context: Mapping[str, object] | None = None,
+) -> ReviewRunContract:
+    """Build the provider-agnostic review-run contract from bootstrap artifacts."""
+
+    payload = pr_context if pr_context is not None else read_pr_context_file(pr_context_file)
+    head_ref, base_ref = _branch_refs(payload)
+    resolved_workspace_root = workspace_root or os.getcwd()
+    return ReviewRunContract(
+        repository=repo,
+        pr_number=pr_number,
+        diff_file=str(diff_file),
+        pr_context_file=str(pr_context_file),
+        workspace_root=resolved_workspace_root,
+        temp_dir=str(temp_dir),
+        head_ref=head_ref,
+        base_ref=base_ref,
+        github=GitHubExecutionContext(repo=repo, pr_number=pr_number, token_env_var=token_env_var),
+    )
+
+
+def write_review_run_bootstrap(
+    *,
+    output: Path,
+    repo: str,
+    pr_number: int,
+    diff_file: Path,
+    pr_context_file: Path,
+    token_env_var: str = "GH_TOKEN",
+    workspace_root: str | None = None,
+    pr_context: Mapping[str, object] | None = None,
+) -> ReviewRunContract:
+    """Write a review-run contract from already-fetched bootstrap artifacts."""
+
+    contract = build_review_run(
+        repo=repo,
+        pr_number=pr_number,
+        diff_file=diff_file,
+        pr_context_file=pr_context_file,
+        temp_dir=output.parent,
+        token_env_var=token_env_var,
+        workspace_root=workspace_root,
+        pr_context=pr_context,
+    )
+    write_review_run_contract(output, contract)
+    return contract

--- a/scripts/non_gha_review_run.py
+++ b/scripts/non_gha_review_run.py
@@ -12,12 +12,14 @@ import time
 from pathlib import Path
 
 from lib.defaults_config import load_defaults_config
-from lib.github_platform import fetch_pr_context, fetch_pr_diff
-from lib.review_run_contract import GitHubExecutionContext, ReviewRunContract, write_review_run_contract
+from lib.review_run_bootstrap import (
+    fetch_pr_bootstrap,
+    write_pr_bootstrap_files,
+    write_review_run_bootstrap,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_CONTEXT_FIELDS = ["title", "author", "headRefName", "baseRefName", "body"]
 DEFAULT_REVIEW_TIMEOUT_SECONDS = 660
 DEFAULT_HELPER_TIMEOUT_SECONDS = 120
 
@@ -65,31 +67,6 @@ def positive_int_from_env(name: str, default: int) -> int:
     except ValueError:
         return default
     return value if value > 0 else default
-
-
-def build_review_run(
-    *,
-    repo: str,
-    pr_number: int,
-    diff_path: Path,
-    pr_context_path: Path,
-    output_dir: Path,
-    token_env_var: str,
-) -> ReviewRunContract:
-    payload = json.loads(pr_context_path.read_text(encoding="utf-8"))
-    head_ref = str(payload.get("headRefName") or "").strip()
-    base_ref = str(payload.get("baseRefName") or "").strip()
-    return ReviewRunContract(
-        repository=repo,
-        pr_number=pr_number,
-        diff_file=str(diff_path),
-        pr_context_file=str(pr_context_path),
-        workspace_root=str(Path.cwd()),
-        temp_dir=str(output_dir),
-        head_ref=head_ref,
-        base_ref=base_ref,
-        github=GitHubExecutionContext(repo=repo, pr_number=pr_number, token_env_var=token_env_var),
-    )
 
 
 def run_command(
@@ -250,8 +227,7 @@ def main() -> int:
         return 2
 
     try:
-        diff = fetch_pr_diff(args.repo, args.pr)
-        pr_context = fetch_pr_context(args.repo, args.pr, fields=DEFAULT_CONTEXT_FIELDS)
+        diff, pr_context = fetch_pr_bootstrap(args.repo, args.pr)
     except Exception as exc:  # pragma: no cover - focused by unit tests through helpers
         print(f"non-gha-review-run: failed to fetch PR inputs: {exc}", file=sys.stderr)
         return 2
@@ -260,18 +236,20 @@ def main() -> int:
     pr_context_path = output_dir / "pr-context.json"
     review_run_path = output_dir / "review-run.json"
 
-    diff_path.write_text(diff, encoding="utf-8")
-    write_json(pr_context_path, pr_context)
-    write_review_run_contract(
-        review_run_path,
-        build_review_run(
-            repo=args.repo,
-            pr_number=args.pr,
-            diff_path=diff_path,
-            pr_context_path=pr_context_path,
-            output_dir=output_dir,
-            token_env_var=args.token_env_var,
-        ),
+    write_pr_bootstrap_files(
+        diff_file=diff_path,
+        pr_context_file=pr_context_path,
+        diff=diff,
+        pr_context=pr_context,
+    )
+    write_review_run_bootstrap(
+        output=review_run_path,
+        repo=args.repo,
+        pr_number=args.pr,
+        diff_file=diff_path,
+        pr_context_file=pr_context_path,
+        token_env_var=args.token_env_var,
+        pr_context=pr_context,
     )
 
     base_env = dict(os.environ)

--- a/tests/test_execution_boundary.py
+++ b/tests/test_execution_boundary.py
@@ -16,6 +16,7 @@ PROTECTED_ENGINE_PATHS = (
     "scripts/render-review-prompt.py",
     "scripts/run-reviewer.py",
     "scripts/lib/github.py",
+    "scripts/lib/review_run_bootstrap.py",
     "scripts/lib/review_run_contract.py",
     "scripts/lib/runtime_facade.py",
 )

--- a/tests/test_non_gha_review_runner.py
+++ b/tests/test_non_gha_review_runner.py
@@ -115,17 +115,19 @@ def test_enrich_verdict_metadata_records_runtime_model_and_description(monkeypat
 
 
 def test_main_runs_local_review_lane(monkeypatch, tmp_path: Path, capsys) -> None:
-    monkeypatch.setattr(mod, "fetch_pr_diff", lambda repo, pr_number: "diff --git a b\n")
     monkeypatch.setattr(
         mod,
-        "fetch_pr_context",
-        lambda repo, pr_number, fields=None: {
-            "title": "PR",
-            "author": {"login": "dev"},
-            "headRefName": "feature/branch",
-            "baseRefName": "master",
-            "body": "desc",
-        },
+        "fetch_pr_bootstrap",
+        lambda repo, pr_number: (
+            "diff --git a b\n",
+            {
+                "title": "PR",
+                "author": {"login": "dev"},
+                "headRefName": "feature/branch",
+                "baseRefName": "master",
+                "body": "desc",
+            },
+        ),
     )
 
     commands: list[tuple[list[str], int]] = []
@@ -367,7 +369,11 @@ def test_main_returns_two_when_fetch_fails(monkeypatch, tmp_path: Path, capsys) 
         )(),
     )
     monkeypatch.setattr(mod, "selected_reviewers", lambda raw: ["trace"])
-    monkeypatch.setattr(mod, "fetch_pr_diff", lambda repo, pr_number: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(
+        mod,
+        "fetch_pr_bootstrap",
+        lambda repo, pr_number: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
 
     assert mod.main() == 2
     assert "failed to fetch PR inputs" in capsys.readouterr().err
@@ -390,11 +396,10 @@ def test_main_returns_two_when_pr_context_fetch_fails(monkeypatch, tmp_path: Pat
         )(),
     )
     monkeypatch.setattr(mod, "selected_reviewers", lambda raw: ["trace"])
-    monkeypatch.setattr(mod, "fetch_pr_diff", lambda repo, pr_number: "diff --git a b\n")
     monkeypatch.setattr(
         mod,
-        "fetch_pr_context",
-        lambda repo, pr_number, fields=None: (_ for _ in ()).throw(RuntimeError("context boom")),
+        "fetch_pr_bootstrap",
+        lambda repo, pr_number: (_ for _ in ()).throw(RuntimeError("context boom")),
     )
 
     assert mod.main() == 2
@@ -402,17 +407,19 @@ def test_main_returns_two_when_pr_context_fetch_fails(monkeypatch, tmp_path: Pat
 
 
 def test_main_returns_one_when_verdict_file_is_missing(monkeypatch, tmp_path: Path, capsys) -> None:
-    monkeypatch.setattr(mod, "fetch_pr_diff", lambda repo, pr_number: "diff --git a b\n")
     monkeypatch.setattr(
         mod,
-        "fetch_pr_context",
-        lambda repo, pr_number, fields=None: {
-            "title": "PR",
-            "author": {"login": "dev"},
-            "headRefName": "feature/branch",
-            "baseRefName": "master",
-            "body": "desc",
-        },
+        "fetch_pr_bootstrap",
+        lambda repo, pr_number: (
+            "diff --git a b\n",
+            {
+                "title": "PR",
+                "author": {"login": "dev"},
+                "headRefName": "feature/branch",
+                "baseRefName": "master",
+                "body": "desc",
+            },
+        ),
     )
 
     def fake_run_reviewer(*, perspective: str, output_dir: Path, base_env: dict[str, str]) -> None:
@@ -445,17 +452,19 @@ def test_main_returns_one_when_verdict_file_is_missing(monkeypatch, tmp_path: Pa
 
 
 def test_main_returns_one_when_run_reviewer_raises_value_error(monkeypatch, tmp_path: Path, capsys) -> None:
-    monkeypatch.setattr(mod, "fetch_pr_diff", lambda repo, pr_number: "diff --git a b\n")
     monkeypatch.setattr(
         mod,
-        "fetch_pr_context",
-        lambda repo, pr_number, fields=None: {
-            "title": "PR",
-            "author": {"login": "dev"},
-            "headRefName": "feature/branch",
-            "baseRefName": "master",
-            "body": "desc",
-        },
+        "fetch_pr_bootstrap",
+        lambda repo, pr_number: (
+            "diff --git a b\n",
+            {
+                "title": "PR",
+                "author": {"login": "dev"},
+                "headRefName": "feature/branch",
+                "baseRefName": "master",
+                "body": "desc",
+            },
+        ),
     )
     monkeypatch.setattr(
         mod,

--- a/tests/test_review_run_bootstrap.py
+++ b/tests/test_review_run_bootstrap.py
@@ -1,0 +1,83 @@
+"""Tests for shared review-run bootstrap helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from scripts.lib import review_run_bootstrap as mod
+
+
+def test_fetch_pr_bootstrap_delegates_to_platform(monkeypatch) -> None:
+    seen: list[tuple[str, str, int]] = []
+
+    def fake_fetch_pr_diff(repo: str, pr_number: int) -> str:
+        seen.append(("diff", repo, pr_number))
+        return "diff --git a/app.py b/app.py\n"
+
+    def fake_fetch_pr_context(repo: str, pr_number: int) -> dict[str, object]:
+        seen.append(("context", repo, pr_number))
+        return {"title": "PR", "headRefName": "feature", "baseRefName": "master"}
+
+    monkeypatch.setattr(mod.platform, "fetch_pr_diff", fake_fetch_pr_diff)
+    monkeypatch.setattr(mod.platform, "fetch_pr_context", fake_fetch_pr_context)
+
+    diff, pr_context = mod.fetch_pr_bootstrap("misty-step/cerberus", 326)
+
+    assert diff == "diff --git a/app.py b/app.py\n"
+    assert pr_context["headRefName"] == "feature"
+    assert seen == [
+        ("diff", "misty-step/cerberus", 326),
+        ("context", "misty-step/cerberus", 326),
+    ]
+
+
+def test_write_review_run_bootstrap_uses_existing_pr_context_file(monkeypatch, tmp_path: Path) -> None:
+    diff_file = tmp_path / "pr.diff"
+    pr_context_file = tmp_path / "pr-context.json"
+    output = tmp_path / "review-run.json"
+    diff_file.write_text("diff --git a/app.py b/app.py\n", encoding="utf-8")
+    pr_context_file.write_text(
+        json.dumps({"title": "PR", "headRefName": "feature/run", "baseRefName": "master"}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    contract = mod.write_review_run_bootstrap(
+        output=output,
+        repo="misty-step/cerberus",
+        pr_number=323,
+        diff_file=diff_file,
+        pr_context_file=pr_context_file,
+        token_env_var="CERBERUS_TOKEN",
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["repository"] == "misty-step/cerberus"
+    assert payload["pr_number"] == 323
+    assert payload["head_ref"] == "feature/run"
+    assert payload["base_ref"] == "master"
+    assert payload["workspace_root"] == os.getcwd()
+    assert payload["temp_dir"] == str(tmp_path)
+    assert payload["github"] == {
+        "repo": "misty-step/cerberus",
+        "pr_number": 323,
+        "token_env_var": "CERBERUS_TOKEN",
+    }
+    assert contract.head_ref == "feature/run"
+
+
+def test_write_pr_bootstrap_files_creates_parent_directories(tmp_path: Path) -> None:
+    diff_file = tmp_path / "nested" / "pr.diff"
+    pr_context_file = tmp_path / "nested" / "pr-context.json"
+
+    mod.write_pr_bootstrap_files(
+        diff_file=diff_file,
+        pr_context_file=pr_context_file,
+        diff="diff --git a/app.py b/app.py\n",
+        pr_context={"title": "PR", "headRefName": "feature", "baseRefName": "master"},
+    )
+
+    assert diff_file.read_text(encoding="utf-8") == "diff --git a/app.py b/app.py\n"
+    assert json.loads(pr_context_file.read_text(encoding="utf-8"))["baseRefName"] == "master"


### PR DESCRIPTION
## Reviewer Evidence
- Start here: `Walkthrough` and `Test Coverage` below.
- Direct video download: N/A. This is an internal bootstrap-boundary refactor.
- Walkthrough notes: terminal proof from the targeted bootstrap suite on this branch.
- Fast claim: review bootstrap artifact persistence and `review-run.json` assembly now live in one shared module reused by the action helpers and the non-GHA runner, which removes duplicate logic and closes the stale `fields=` drift in `scripts/non_gha_review_run.py`.

## Why This Matters
- Problem: branch-ref parsing, bootstrap artifact writes, and review-run contract assembly were split across three entrypoints.
- Value: one deeper bootstrap module means one place to change when the contract or artifact layout evolves.
- Why now: the repo already established the execution boundary; leaving bootstrap duplicated would keep inviting drift across the action and local runner paths.
- Issue: not ticketed; shipped from a `/simplify` architecture pass against the review bootstrap boundary.

## Trade-offs / Risks
- Value gained: smaller entrypoints, one source of truth for bootstrap assembly, and an explicit boundary test for the new shared module.
- Cost / risk incurred: one more `scripts/lib/` module and tighter coupling between the CLI entrypoints and that shared API.
- Why this is still the right trade: it deletes more duplicated logic than it adds and preserves the existing CLI contracts and artifact paths.
- Reviewer watch-outs: bootstrap failure wording and emitted artifact paths must remain stable for both the GitHub Action lane and the non-GHA runner.

## What Changed
This PR deepens the review bootstrap boundary by moving bootstrap artifact persistence and review-run contract assembly into `scripts/lib/review_run_bootstrap.py`, then rewiring `scripts/fetch-pr-bootstrap.py`, `scripts/bootstrap-review-run.py`, and `scripts/non_gha_review_run.py` to compose that module instead of each partially rebuilding the same flow.

### Base Branch
```mermaid
graph TD
  A["fetch-pr-bootstrap.py"] --> B["writes pr.diff + pr-context.json"]
  C["bootstrap-review-run.py"] --> D["re-reads pr-context.json and rebuilds contract"]
  E["non_gha_review_run.py"] --> F["fetches bootstrap inputs and rebuilds contract inline"]
  D --> G["review-run.json"]
  F --> G
```

### This PR
```mermaid
graph TD
  A["fetch-pr-bootstrap.py"] --> H["review_run_bootstrap"]
  C["bootstrap-review-run.py"] --> H
  E["non_gha_review_run.py"] --> H
  H --> B["pr.diff + pr-context.json"]
  H --> G["review-run.json"]
```

### Architecture / State Change
```mermaid
graph TD
  P["github_platform.py"] --> H["review_run_bootstrap.py"]
  H --> A["fetch-pr-bootstrap.py"]
  H --> B["bootstrap-review-run.py"]
  H --> C["non_gha_review_run.py"]
  B --> D["run-reviewer.py"]
  C --> D
```

Why this is better:
- The bootstrap contract is assembled in one place instead of three near-duplicates.
- The non-GHA runner now uses the same boundary module as the action helpers, which removes the stale `fields=` call path.
- The execution-boundary guard now covers the shared bootstrap module directly.

<details>
<summary>Intent Reference</summary>

## Intent Reference
- [ADR 004](docs/adr/004-review-execution-boundary.md) sets the rule that review bootstrap stays outside the engine and GitHub transport stays behind `scripts/lib/github_platform.py`.
- [Review-Run Contract](docs/review-run-contract.md) documents the bootstrap artifacts and the `review-run.json` contract that must remain stable.
- This PR keeps those caller-visible contracts intact while removing the shallow duplication around them.

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `scripts/lib/review_run_bootstrap.py` as the single module for fetching bootstrap inputs, persisting bootstrap files, and building `review-run.json`.
- Simplified `scripts/bootstrap-review-run.py` to validate inputs and delegate contract assembly.
- Simplified `scripts/fetch-pr-bootstrap.py` to delegate artifact persistence after adapter-backed fetches.
- Simplified `scripts/non_gha_review_run.py` to reuse the shared bootstrap module instead of rebuilding the contract inline.
- Added `tests/test_review_run_bootstrap.py` and expanded boundary coverage so the new module is protected against raw `gh` drift.
- Updated `CLAUDE.md` and `docs/review-run-contract.md` to describe the deeper bootstrap boundary.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] GitHub Action bootstrap still writes `pr.diff`, `pr-context.json`, and `review-run.json` with the current contract.
- [x] Non-GHA review runs still emit the same bootstrap artifacts before reviewer execution.
- [x] GitHub transport remains behind `scripts/lib/github_platform.py`.
- [x] The shared bootstrap module is covered by focused tests and the execution-boundary guard.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: zero code churn.
- Downside: keeps three bootstrap implementations in sync by convention and leaves the non-GHA runner on a drifted call path.
- Why rejected: the duplicate logic was already diverging.

### Option B — Collapse the action into one new shell step
- Upside: fewer CLI entrypoints.
- Downside: mixes workflow plumbing changes with the architectural cleanup and increases risk in the hot GitHub Action path.
- Why rejected: bigger blast radius for less immediate leverage.

### Option C — Shared bootstrap module in `scripts/lib/`
- Upside: deepens the boundary without changing public CLI surfaces.
- Downside: introduces one more library module.
- Why chosen: best complexity removed per unit of risk in one PR.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
- `python3 -m pytest tests/test_review_run_bootstrap.py tests/test_bootstrap_review_run.py tests/test_fetch_pr_bootstrap.py tests/test_non_gha_review_runner.py tests/test_execution_boundary.py -q`
- `python3 -m py_compile scripts/bootstrap-review-run.py scripts/fetch-pr-bootstrap.py scripts/non_gha_review_run.py scripts/lib/review_run_bootstrap.py`

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: terminal output capture
- Artifact: targeted bootstrap-boundary pytest run from this branch
- Claim: all three entrypoints now share one bootstrap implementation and the boundary is regression-guarded
- Before / After scope: before this PR, bootstrap artifact handling and contract assembly were duplicated; after this PR, the shared module owns both flows
- Persistent verification: `tests/test_review_run_bootstrap.py` and `tests/test_execution_boundary.py`
- Residual gap: I did not run the full `make validate` suite because this refactor is isolated to the bootstrap boundary

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
collected 27 items

tests/test_review_run_bootstrap.py ...
tests/test_bootstrap_review_run.py ...
tests/test_fetch_pr_bootstrap.py ....
tests/test_non_gha_review_runner.py ...............
tests/test_execution_boundary.py ..

============================== 27 passed in 0.15s ==============================
```

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: `fetch-pr-bootstrap.py`, `bootstrap-review-run.py`, and `non_gha_review_run.py` each knew part of the bootstrap contract and file layout.
- After: `scripts/lib/review_run_bootstrap.py` owns bootstrap file persistence and contract assembly; the entrypoints now just validate inputs and hand off.
- Screenshots: not applicable for this internal-only refactor.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- Added: `tests/test_review_run_bootstrap.py`
- Updated: `tests/test_non_gha_review_runner.py`
- Guardrail: `tests/test_execution_boundary.py`
- Focused suite run: `python3 -m pytest tests/test_review_run_bootstrap.py tests/test_bootstrap_review_run.py tests/test_fetch_pr_bootstrap.py tests/test_non_gha_review_runner.py tests/test_execution_boundary.py -q`

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high
- Strongest evidence: the targeted bootstrap suite passed after the extraction and the new boundary module is explicitly protected by the raw-`gh` guard test.
- Remaining uncertainty: I did not run the repository-wide validation suite.
- What could still go wrong after merge: an adjacent integration outside the bootstrap lane could rely on undocumented bootstrap side effects not covered by the focused suite.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared bootstrap mechanism for consistent PR artifact persistence and handling across all review workflows.
  * Unified approach to managing PR diffs, context data, and review-run artifacts through a centralized bootstrap module.

* **Improvements**
  * Enhanced error handling and validation for artifact retrieval and file operations.
  * Standardized artifact management between GitHub Actions and non-GitHub Actions workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->