### PR TITLE
fix: restore full retry budget for unknown runtime failures

### DIFF
--- a/scripts/run-reviewer.py
+++ b/scripts/run-reviewer.py
@@ -688,15 +688,14 @@ def main(argv: list[str]) -> int:
                 run_completed = True
                 break
 
-            max_for_type = MAX_RETRIES
-            if detected_error_type in {"transient", "unknown"} and retry_count < max_for_type:
+            if detected_error_type in {"transient", "unknown"} and retry_count < MAX_RETRIES:
                 retry_count += 1
                 wait_seconds = default_backoff_seconds(retry_count)
                 if detected_error_class == "rate_limit" and detected_retry_after and detected_retry_after > 0:
                     wait_seconds = detected_retry_after
                 print(
                     f"Retrying {detected_error_type} error "
-                    f"(class={detected_error_class}) attempt {retry_count}/{max_for_type}; wait={wait_seconds}s"
+                    f"(class={detected_error_class}) attempt {retry_count}/{MAX_RETRIES}; wait={wait_seconds}s"
                 )
                 maybe_sleep(wait_seconds)
                 continue

--- a/tests/test_run_reviewer_runtime.py
+++ b/tests/test_run_reviewer_runtime.py
@@ -1236,7 +1236,8 @@ def test_unknown_error_with_scratchpad_only_skips(tmp_path: Path) -> None:
         text=True,
         timeout=30,
     )
-    # Scratchpad content = evidence of API interaction -> should SKIP.
+    # Scratchpad content = evidence of API interaction -> should SKIP after the full retry budget.
+    assert retry_counter.read_text() == "4"
     assert result.returncode == 0
     assert "Unknown API/runtime error detected. Writing error verdict." in result.stdout
 

--- a/walkthrough/issue-293/runtime-retry-proof.txt
+++ b/walkthrough/issue-293/runtime-retry-proof.txt
@@ -4,8 +4,8 @@ rootdir: /Users/phaedrus/.codex/worktrees/8d78/cerberus
 configfile: pytest.ini
 plugins: anyio-4.12.1, mock-3.15.1, timeout-2.4.0, asyncio-1.3.0, cov-7.0.0
 asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
-collected 28 items / 23 deselected / 5 selected
+collected 28 items / 22 deselected / 6 selected
 
-tests/test_run_reviewer_runtime.py .....                                 [100%]
+tests/test_run_reviewer_runtime.py ......                                [100%]
 
-======================= 5 passed, 23 deselected in 1.35s =======================
+======================= 6 passed, 22 deselected in 1.54s =======================


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [runtime retry proof](../blob/cx/issue-293-retry-aborts/walkthrough/issue-293/runtime-retry-proof.txt?raw=1)
- Direct artifact: [terminal capture](../blob/cx/issue-293-retry-aborts/walkthrough/issue-293/runtime-retry-proof.txt?raw=1)
- Walkthrough notes: backend-only lane; proof is the targeted runtime test capture plus the full `make validate` gate.
- Fast claim: Cerberus now gives `unknown` runtime failures the full retry budget, including the scratchpad-only path, so transient provider instability no longer collapses reviewer coverage after a single retry.

## Why This Matters
- Problem: reviewer runs could burn through a model after two total attempts whenever the runtime classified the failure as `unknown`, even though the configured budget and operator expectation were four total attempts.
- Value: this restores reviewer coverage on flaky provider/runtime paths and reduces false SKIPs or hard failures caused by premature fallback.
- Why now: `#293` is a `p1`/`now` reliability issue on the production-readiness track.
- Issue: Closes #293.

## Trade-offs / Risks
- Value gained: more resilience against ambiguous runtime failures without weakening auth/quota fail-fast behavior.
- Cost / risk incurred: a truly unrecoverable unknown failure can spend a bit more time retrying before surfacing.
- Why this is still the right trade: the runtime already advertises a four-attempt budget, and burning only one retry on ambiguous infrastructure failures was the incorrect behavior.
- Reviewer watch-outs: pressure-test whether any path besides `unknown` should still keep a smaller retry budget.

## What Changed
This branch removes the special one-retry cap for `unknown` runtime failures, inlines the now-shared retry budget directly in the retry loop, and updates the runtime regression tests to prove the full-budget behavior across success, exhaustion, fallback, output-backed SKIP, scratchpad-backed SKIP, and `Request was aborted` transient recovery.

### Base Branch
```mermaid
graph TD
  A["Pi attempt exits 1"] --> B{"classified as unknown?"}
  B -->|yes| C["retry once"]
  C --> D["mark model exhausted"]
  D --> E["fallback or fail early"]
```

### This PR
```mermaid
graph TD
  A["Pi attempt exits 1"] --> B{"classified as unknown?"}
  B -->|yes| C["retry through full standard budget"]
  C --> D["exhaust model only after four total attempts"]
  D --> E["fallback or fail with full evidence"]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> Attempt
  Attempt --> Success: exit 0 with output
  Attempt --> Retry: transient or unknown failure
  Retry --> Attempt: retry budget remains
  Retry --> Fallback: retry budget exhausted for model
  Fallback --> Attempt: next model available
  Fallback --> Failed: no models left
  Success --> [*]
  Failed --> [*]
```

Why this is better:
- The retry loop now matches the configured runtime budget instead of carrying a hidden special-case branch for `unknown` failures.
- The tests describe the intended behavior at the shell-orchestration layer, so future runtime changes have to preserve it mechanically.

<details>
<summary>Intent Reference</summary>

## Intent Reference
Issue [#293](https://github.com/misty-step/cerberus/issues/293) now defines the lane intent as: protect reviewer coverage during ambiguous provider/runtime failures, preserve transient classification for aborted requests, and verify the retry budget mechanically in tests.

</details>

<details>
<summary>Changes</summary>

## Changes
- `scripts/run-reviewer.py` removes the separate unknown-error retry cap and now references `MAX_RETRIES` directly in the shared retry path.
- `tests/test_run_reviewer_runtime.py` now asserts four total attempts for persistent unknown failures, validates fallback after full exhaustion, covers the scratchpad-only SKIP path, and keeps the transient abort regression covered.
- `walkthrough/issue-293/runtime-retry-proof.txt` captures the refreshed six-test terminal proof used in review.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A - Do nothing
- Upside: no runtime change.
- Downside: reviewer coverage keeps collapsing after two total attempts on ambiguous failures.
- Why rejected: it preserves the exact bug described in `#293`.

### Option B - Reclassify more errors into transient buckets only
- Upside: narrower behavioral change.
- Downside: still leaves future unclassified runtime failures under-retried.
- Why rejected: the root cause is the special retry budget, not just one missing classifier.

### Option C - Current approach
- Upside: fixes the retry policy at the orchestration layer and keeps abort classification covered.
- Downside: unknown hard failures may take slightly longer to surface.
- Why chosen: it resolves the general bug with the smallest reversible diff.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Given a reviewer runtime failure classified as `unknown`, when the same model keeps failing without output, then Cerberus consumes the full standard retry budget before exhausting that model.
- [x] Given a transient provider abort message such as `Request was aborted`, when the runtime retries, then the failure stays classified as transient/network rather than collapsing into `unknown`.
- [x] Given the runtime retry regression coverage, when `python3 -m pytest tests/test_run_reviewer_runtime.py -q -k "unknown_error_retries_to_full_budget or unknown_error_exhausts_retries or unknown_error_with_output_skips or unknown_error_with_scratchpad_only_skips or unknown_error_fallback_model_succeeds or request_was_aborted_is_transient"`, then all targeted tests pass.
- [x] Given the full repository validation gate, when `make validate`, then the suite passes.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
python3 -m pytest tests/test_run_reviewer_runtime.py -q -k "unknown_error_retries_to_full_budget or unknown_error_exhausts_retries or unknown_error_with_output_skips or unknown_error_with_scratchpad_only_skips or unknown_error_fallback_model_succeeds or request_was_aborted_is_transient"
make validate
```
Expected output:
- targeted runtime regression tests: `6 passed`
- full gate: pytest, ruff, and shellcheck all pass

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: terminal output capture
- Artifact: [runtime retry proof](../blob/cx/issue-293-retry-aborts/walkthrough/issue-293/runtime-retry-proof.txt?raw=1)
- Claim: `unknown` runtime failures now consume the full retry budget before a model is exhausted, including the scratchpad-only path.
- Before / After scope: runtime retry orchestration in the reviewer execution path
- Persistent verification: `tests/test_run_reviewer_runtime.py` targeted retry regressions plus `make validate`
- Residual gap: no live provider outage was replayed in this branch; confidence comes from deterministic runtime harness coverage rather than an external-network repro

</details>

<details>
<summary>Before / After</summary>

## Before / After
Before: an `unknown` runtime failure could only use one retry before the model was abandoned, despite logs showing a four-attempt budget.
After: `unknown` failures use the same retry budget as other retryable runtime failures, and fallback only begins after full exhaustion.
Screenshots are not needed because this is an internal runtime change with no UI surface.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `tests/test_run_reviewer_runtime.py`
- `make validate` (`tests/`, `ruff`, `shellcheck`)

Gap note:
- No external provider integration test was added in this lane; coverage is via the existing local runtime harness.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high
- Strongest evidence: targeted RED->GREEN runtime regression tests and a clean `make validate`
- Remaining uncertainty: real provider aborts may still present new stderr shapes that deserve explicit classification later
- What could still go wrong after merge: a future runtime error mode could still land in `unknown`, but it will now get the full retry budget before surfacing

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Retry limits unified across error types—unknown errors now use the same retry cap as transient errors.
  * Unknown error retry budget increased (from 2 to 4), affecting primary retry/fallback sequencing.

* **Tests**
  * Test suite updated to validate the revised retry counts and fallback transitions.

* **Documentation**
  * Walkthrough/test output updated to reflect the new runtime retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->