### PR TITLE
feat: add spec compliance verification to trace perspective

### DIFF
--- a/pi/agents/correctness.md
+++ b/pi/agents/correctness.md
@@ -47,6 +47,19 @@ Find logic bugs, edge cases, and incorrect behavior introduced by this PR.
 - CAS/atomic retry loops with ABA or no-progress risks
 - State transitions that can become inconsistent
 
+### Spec Compliance (check when acceptance criteria are present)
+When acceptance criteria (ACs) are provided in the review context via `github_read`:
+1. For each AC, trace the code path through the diff that satisfies it.
+2. Report SATISFIED if the diff clearly implements the AC.
+3. Report NOT_SATISFIED if the AC requirement is missing or contradicted by the diff.
+4. Report CANNOT_DETERMINE if the diff is ambiguous or you lack enough context.
+5. If an AC has no corresponding test in the diff, flag it as a finding with severity: minor,
+   category: `untested-acceptance-criterion`.
+6. Include the AC text in the finding description so reviewers can map findings to requirements.
+
+Spec compliance findings follow the same evidence bar as all other findings.
+Do not fabricate AC status — if ACs are absent from the context, skip this section entirely.
+
 ### Secondary (check if relevant)
 - Logic inversions, wrong comparators, inverted boolean flags
 - Incorrect default values, missing initialization, stale state
@@ -182,6 +195,8 @@ When a finding spans multiple perspectives, apply it ONLY to the primary owner:
 - Security bug that is also a logic bug → yours (flag the logic aspect)
 - Security exploit without logic bug → guard (skip it)
 - Missing test for a correctness bug → proof (skip it)
+- AC compliance mapping (SATISFIED/NOT_SATISFIED) → yours
+- General test coverage gaps without AC link → proof (skip it)
 - Failure-path logic for dependency outages → fuse (skip it); exception: unbounded retry/requeue loops with no max-attempt bound are correctness bugs (infinite loop) and belong here
 - Backward-compat break without logic bug → pact (skip it)
 If your finding would be better owned by another reviewer, skip it.

--- a/tests/test_spec_compliance_guidance.py
+++ b/tests/test_spec_compliance_guidance.py
@@ -1,0 +1,29 @@
+"""Regression tests for spec compliance guidance in trace perspective (issue #311)."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+CORRECTNESS_AGENT = ROOT / "pi" / "agents" / "correctness.md"
+
+
+def test_trace_prompt_includes_spec_compliance_section() -> None:
+    text = CORRECTNESS_AGENT.read_text(encoding="utf-8")
+
+    assert "Spec Compliance" in text
+    assert "acceptance criteria" in text.lower()
+
+
+def test_trace_prompt_maps_ac_to_diff_code_paths() -> None:
+    text = CORRECTNESS_AGENT.read_text(encoding="utf-8")
+
+    assert "SATISFIED" in text
+    assert "NOT_SATISFIED" in text
+    assert "CANNOT_DETERMINE" in text
+
+
+def test_trace_prompt_flags_untested_ac_as_minor() -> None:
+    text = CORRECTNESS_AGENT.read_text(encoding="utf-8")
+
+    assert "no corresponding test" in text.lower()
+    assert "minor" in text.lower()


### PR DESCRIPTION
## Why This Matters

The `trace` (correctness) reviewer evaluates code correctness in isolation but doesn't verify against acceptance criteria. With ACs already injected into the review context (#310), trace should explicitly map each AC to diff code paths — giving PR authors structured, per-AC compliance feedback instead of generic correctness checks.

Closes #311.

## Trade-offs / Risks

- **Prompt inflation:** +13 lines (~100 words) to a 264-line prompt. Minimal impact on token budget.
- **Over-focus risk:** Framed as "check when present" not "always check" — trace falls back to pure correctness when no ACs exist.

## Intent Reference

> When ACs are present, trace explicitly maps each AC to diff code paths and flags missing test coverage.

Source: [#311](https://github.com/misty-step/cerberus/issues/311)

## Changes

- `pi/agents/correctness.md` — Added "Spec Compliance" subsection to Primary scope with AC mapping rules (SATISFIED/NOT_SATISFIED/CANNOT_DETERMINE) and untested-AC flagging
- `pi/agents/correctness.md` — Added deconfliction entries (AC compliance → trace, general coverage gaps → proof)
- `tests/test_spec_compliance_guidance.py` — 3 regression tests asserting prompt content

## Alternatives Considered

- **New reviewer for spec compliance** — Rejected per issue; enhancing trace is lighter and avoids panel bloat
- **Do nothing** — ACs injected but ignored by trace; wastes the #310 investment

## Acceptance Criteria

- [x] Given ACs are present in the review prompt, when `trace` runs, then it explicitly verifies each AC against the diff
- [x] Given an AC has no corresponding test in the diff, when `trace` runs, then it flags this as a finding (severity: minor)

## Manual QA

```bash
grep -qi 'acceptance\|spec compliance\|AC' pi/agents/correctness.md
python3 -m pytest tests/test_spec_compliance_guidance.py -v
```

## What Changed

```mermaid
graph LR
    A[PR Diff] --> B[trace reviewer]
    B --> C[Correctness findings]
```

```mermaid
graph LR
    A[PR Diff] --> B[trace reviewer]
    B --> C[Correctness findings]
    B --> D[AC compliance mapping]
    D --> E[SATISFIED / NOT_SATISFIED / CANNOT_DETERMINE]
    D --> F["Untested AC findings (minor)"]
```

Trace now has a dual lens: correctness bugs AND spec compliance when ACs are available.

## Test Coverage

- `tests/test_spec_compliance_guidance.py` — 3 tests covering section presence, AC status labels, and untested-AC flagging
- Full suite: 1840 passed, 0 failures

## Merge Confidence

**High.** Prompt-only change with regression tests. No code logic modified. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced correctness guidance with acceptance criteria compliance procedures, including mapping across code changes and handling of untested items.

* **Tests**
  * Added regression tests validating acceptance criteria compliance documentation is present and complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->