### PR TITLE
docs: API contract reference and README update for API dispatch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The action dispatches a review via `POST /api/reviews`, polls until completion, 
 |-------|----------|---------|-------------|
 | `api-key` | yes | - | Cerberus API authentication key |
 | `cerberus-url` | yes | - | API base URL (e.g., `https://cerberus.fly.dev`) |
-| `model` | no | `''` | Model override for all reviewers |
+| `model` | no | `''` | Reserved; accepted but not yet wired to reviewer selection |
 | `timeout` | no | `600` | Max seconds to wait for review completion |
 | `poll-interval` | no | `5` | Seconds between status polls |
 | `fail-on-verdict` | no | `true` | Exit 1 if aggregated verdict is FAIL |

--- a/cerberus-elixir/README.md
+++ b/cerberus-elixir/README.md
@@ -6,7 +6,7 @@ results to GitHub.
 
 ## Architecture
 
-```
+```text
 Cerberus.Supervisor (one_for_one)
   ├── Cerberus.Config            — hot-reload persona/model config from defaults/config.yml
   ├── Cerberus.Store             — SQLite persistence (review runs, costs, events)

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -12,7 +12,7 @@ Local development: `http://localhost:4000`
 
 All endpoints except `/api/health` require a Bearer token.
 
-```
+```text
 Authorization: Bearer <CERBERUS_API_KEY>
 ```
 
@@ -123,7 +123,7 @@ Liveness probe. No authentication required.
 
 ## Status Lifecycle
 
-```
+```text
 queued ──> running ──> completed
                   └──> failed
 ```


### PR DESCRIPTION
## Why This Matters

The Elixir engine is now the primary execution path (PRs #410, #417, #420 built the full pipeline), but docs still only described the GHA matrix mode. New users had no way to discover the API dispatch path — the simpler, faster integration — without reading source code.

Closes #415.

## Trade-offs / Risks

- Labels GHA matrix as "legacy" which may concern existing users. Mitigated by keeping full matrix docs intact (just folded behind `<details>`).
- API contract documents current stored verdict shape (`findings_count`, not full `findings[]`). If the stored shape changes, the contract doc needs updating.

## Intent Reference

From #415: "README documents the GHA matrix pipeline mode only. The API dispatch mode (thin action → Elixir API) is undocumented. No API contract reference exists."

## Changes

- **New**: `docs/api-contract.md` — Full HTTP API reference (endpoints, auth, request/response schemas, status lifecycle, error codes, polling pattern, env vars)
- **Updated**: `README.md` — API dispatch as primary quick start; GHA matrix mode moved to legacy `<details>` fold; reorganized sections for dual-mode clarity
- **Updated**: `cerberus-elixir/README.md` — Reflects actual state (supervision tree, API endpoints, pipeline steps, reviewer tools, DI seams) instead of "stops at app boundary"

## Alternatives Considered

1. **Do nothing**: Users continue reading source to discover API mode. Unacceptable for an OSS project.
2. **Single README update only**: No dedicated API reference. Would bloat README and make it harder for API integrators to find what they need.
3. **OpenAPI spec**: More rigorous but overkill for 3 endpoints. Can add later if the API surface grows.

## Acceptance Criteria

From #415:
- [x] [doc] API contract covers all endpoints with example requests/responses
- [x] [doc] README quick start uses `api/action.yml` with `cerberus-url` pointing to hosted instance
- [x] [doc] Status lifecycle documented with state diagram

## Manual QA

```bash
# Verify docs render correctly
cat docs/api-contract.md   # check JSON examples, tables
cat README.md               # check quick start YAML, links
cat cerberus-elixir/README.md  # check supervision tree, env vars

# Verify no test regressions
make test   # 1873 passed, 1 skipped

# Verify links resolve
ls docs/api-contract.md     # exists
```

## What Changed

```mermaid
graph LR
    subgraph Before
        README[README.md] -->|only path| GHA[GHA Matrix Quick Start]
        ElixirREADME[cerberus-elixir/README.md] -->|stale| Stub["Stops at app boundary"]
    end
```

```mermaid
graph LR
    subgraph After
        README[README.md] -->|primary| API[API Dispatch Quick Start]
        README -->|legacy fold| GHA[GHA Matrix]
        README -->|link| Contract[docs/api-contract.md]
        ElixirREADME[cerberus-elixir/README.md] -->|accurate| Full[Full Engine Docs]
        ElixirREADME -->|link| Contract
    end
```

The new structure gives each audience a clear entry point: consumers see API dispatch first, power users unfold GHA matrix, contributors read the Elixir README, and integrators reference the API contract.

## Test Coverage

Docs-only change. Existing test `test_readme_quick_start_uses_cerberus_openrouter_secret_name` still passes (README retains the legacy secret reference).

## Merge Confidence

**High**. Docs-only, all 1873 tests pass, triad review (Ousterhout/Carmack/Grug) unanimous Ship. All schemas verified against source code. No behavioral changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a primary API-dispatch workflow with full example and inputs/outputs (api-key, url, model, timeout, poll-interval, fail-on-verdict).
  * Added a detailed HTTP API contract (endpoints, auth, polling, verdict structure).
  * Reworked README: “How It Works”, reviewer table, operating-mode descriptions (API dispatch vs GHA matrix), secrets handling, and non-GHA run instructions.
  * Expanded architecture, setup, running, and testing guidance in language-specific README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->