### PR TITLE
test: render-level regression tests for finding dedup ACs (#299)

### DIFF
--- a/tests/test_render_verdict_comment.py
+++ b/tests/test_render_verdict_comment.py
@@ -634,8 +634,8 @@ def test_render_same_title_different_lines_stay_separate() -> None:
         marker="<!-- test -->",
     )
     fix_section = comment.split("### Fix Order", 1)[1].split("###", 1)[0]
-    assert "1. " in fix_section
-    assert "2. " in fix_section, "Same title on different lines must remain separate"
+    numbered_lines = [ln for ln in fix_section.splitlines() if re.match(r"\s*\d+\.\s", ln)]
+    assert len(numbered_lines) == 2, f"Expected 2 separate fix items, got {len(numbered_lines)}"
 
 
 def test_render_merged_finding_shows_highest_severity() -> None:


### PR DESCRIPTION
## Why This Matters

Issue #299 describes how duplicate findings across reviewers create review fatigue. The dedup implementation (`group_findings` + `is_equivalent_finding` in `findings.py`) was already shipped, but the acceptance criteria lacked **render-level regression tests** — tests that verify the merged output actually appears correctly in Fix Order and Key Findings sections of the verdict comment.

Without these tests, the dedup logic could regress silently at the render boundary even if the unit-level `group_findings` tests still pass.

Closes #299.

## Trade-offs / Risks

- **Test-only PR**: Zero production code changes. Risk is near-zero.
- Section extraction via `comment.split("### Fix Order")` is fragile to heading changes — a known pattern debt shared with existing tests. Not addressed here to keep scope minimal.

## Intent Reference

From #299 Intent Contract:
> - The aggregate verdict comment presents one top-level issue for equivalent findings reported by multiple reviewers.
> - The merged issue keeps the highest severity and shows reviewer agreement instead of conflicting severity labels.
> - Dedupe is conservative: only same-file, same-category, nearby-line findings with strong wording overlap collapse.

## Changes

- `tests/test_render_verdict_comment.py`: 3 new render-level regression tests + `import re` + `import severity_icon`

## Acceptance Criteria

- [x] AC1: Two reviewers, same root cause, nearby lines, different titles → Fix Order shows 1 merged entry with both reviewers
- [x] AC2: Same title on nearby but distinct lines → separate entries (exercises `findings.py:182-190`)
- [x] AC3: Disagreeing severities → merged finding renders with highest severity icon
- [x] AC4: Both merge and non-merge paths have regression tests at the render level

## Manual QA

```bash
cd cerberus
python3 -m pytest tests/test_render_verdict_comment.py -v -k "test_render_fix_order_merges or test_render_same_title or test_render_merged_finding"
# Expected: 3 passed
```

## What Changed

```mermaid
graph LR
    A[group_findings] --> B[collect_issue_groups]
    B --> C[format_fix_order_lines]
    B --> D[format_key_findings_lines]
    C --> E[render_comment]
    D --> E
    E --> F[verdict PR comment]
    style F fill:#f9f,stroke:#333
```

Three new tests verify the rendered output at node F, closing the coverage gap between unit tests at node A and the user-visible PR comment.

## Test Coverage

- `findings.py`: 98% (unchanged)
- `render_verdict_comment.py`: 94% (unchanged)
- New tests: `test_render_fix_order_merges_equivalent_findings`, `test_render_same_title_different_lines_stay_separate`, `test_render_merged_finding_shows_highest_severity`

## Merge Confidence

**High**. Test-only change, 1876 tests pass, lint clean, triad review unanimous Ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for verdict comment rendering, including consolidation of nearby duplicate findings into a single Fix Order entry and preservation of separate entries for same-title findings on distinct lines.
  * Added tests ensuring merged entries show the highest severity and correct severity indicators.
  * Expanded tests for fileless findings, wave summaries, reviewer wave labels, and comment formatting edge cases.

* **Chores**
  * No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->