### PR TITLE
fix: harden deploy-sprite.sh restart logic

### DIFF
--- a/cerberus-elixir/deploy-sprite.sh
+++ b/cerberus-elixir/deploy-sprite.sh
@@ -104,8 +104,10 @@ start_app() {
 
 restart_app() {
   log "Restarting Cerberus API"
+  # shellcheck disable=SC2016  # $_MIX expanded by inner sh, not outer
   sprite -s "$SPRITE_NAME" exec -- sh -c '
-    # Pattern must match the nohup command below; bracket trick prevents self-match
+    # Bracket trick prevents pkill matching itself; $_MIX variable prevents
+    # matching the parent sh -c whose command line contains the nohup text
     pkill -f "[m]ix run --no-halt" 2>/dev/null || true
     for _ in 1 2 3 4 5; do
       pgrep -f "[m]ix run --no-halt" > /dev/null || break
@@ -118,7 +120,8 @@ restart_app() {
     fi
     . /home/sprite/.cerberus-env
     cd /home/sprite/cerberus-elixir
-    nohup sh -c "MIX_ENV=prod elixir --sname cerberus -S mix run --no-halt" \
+    _MIX=mix
+    nohup sh -c "MIX_ENV=prod elixir --sname cerberus -S $_MIX run --no-halt" \
       > /home/sprite/cerberus.log 2>&1 &
   '
   log "Restart initiated"

--- a/tests/test_deploy_infra.py
+++ b/tests/test_deploy_infra.py
@@ -145,3 +145,14 @@ class TestDeployScriptRestart:
     def test_escalates_to_sigkill(self) -> None:
         """Must SIGKILL if graceful shutdown fails after polling."""
         assert "pkill -9" in self.restart_body
+
+    def test_nohup_obfuscates_pattern(self) -> None:
+        """nohup line must not contain literal 'mix run' to prevent parent sh -c match."""
+        # The outer sh -c command line is visible to pkill -f; if the nohup
+        # line contains 'mix run --no-halt' literally, pkill kills the parent
+        nohup_start = self.restart_body.index("nohup")
+        nohup_line = self.restart_body[nohup_start : self.restart_body.index("\n", nohup_start)]
+        assert "mix run" not in nohup_line, (
+            "nohup command must obfuscate 'mix run' (e.g. via variable) "
+            "to prevent pkill matching the parent sh -c process"
+        )


### PR DESCRIPTION
## Why This Matters

`restart_app()` in `deploy-sprite.sh` has two bugs that can cause deployment failures:
1. **pkill self-match**: `pkill -f "mix run"` matches the `sh -c` wrapper that contains "mix run --no-halt" in its command string, potentially killing the restart script itself
2. **No termination verification**: Fixed `sleep 2` doesn't confirm the old process died, risking port conflicts when the new instance starts

Both were flagged by Codex (P1) and CodeRabbit (major) on PR #423 but left unaddressed.

Closes #427

## Trade-offs / Risks

- More specific pattern (`mix run --no-halt` vs `mix run`) could miss processes started with different flags — accepted because we only want to kill what we're about to re-launch
- SIGKILL escalation after 5s poll is aggressive — accepted because a hung BEAM node blocking port 8080 is worse than a hard kill

## Intent Reference

Fix the two restart bugs identified in PR #423 review findings. ACs: self-exclusion pattern for pkill, poll for termination instead of fixed sleep.

## Changes

- `cerberus-elixir/deploy-sprite.sh`: Replace bare `pkill -f "mix run"` with bracket trick `[m]ix run --no-halt`, replace `sleep 2` with bounded `pgrep` poll loop + SIGKILL escalation
- `tests/test_deploy_infra.py`: Add `TestDeployScriptRestart` contract tests (5 assertions)

## Alternatives Considered

- **Do nothing**: Leaves self-match bug that can kill the restart script in production
- **PID file tracking**: More complex, requires persistent state, overkill for a single-process restart
- **Bracket trick only (no poll)**: Fixes self-match but leaves the termination race — both bugs should be fixed together

## Acceptance Criteria

- [x] `restart_app` uses a self-exclusion pattern for pkill (`[m]ix` bracket trick)
- [x] `restart_app` polls for termination instead of fixed sleep (pgrep loop)

## Manual QA

```bash
# Verify the bracket trick is in place
grep '\[m\]ix' cerberus-elixir/deploy-sprite.sh

# Verify pgrep polling
grep 'pgrep' cerberus-elixir/deploy-sprite.sh

# Run contract tests
python3 -m pytest tests/test_deploy_infra.py::TestDeployScriptRestart -v
```

## What Changed

```mermaid
flowchart LR
    subgraph Before
        A[pkill -f 'mix run'] --> B[sleep 2] --> C[nohup start]
    end
```

```mermaid
flowchart LR
    subgraph After
        A2["pkill -f '[m]ix run --no-halt'"] --> B2{pgrep poll x5}
        B2 -->|dead| C2[nohup start]
        B2 -->|alive| D2[SIGKILL] --> C2
    end
```

The new flow is deterministic: the process is confirmed dead (gracefully or forcefully) before starting the replacement.

## Test Coverage

- `tests/test_deploy_infra.py::TestDeployScriptRestart` — 5 contract assertions covering self-exclusion pattern, no bare pkill, pgrep polling, no fixed sleep, SIGKILL escalation

## Merge Confidence

**High** — minimal diff (3 lines changed in shell, 5 contract tests added), well-understood Unix idioms, triad review passed unanimously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown/restart reliability: better detection of running instances, graceful termination with escalation if needed, and more robust process start to avoid unintended matches.

* **Tests**
  * Added tests verifying the deployment restart behavior and ensuring the new shutdown/start checks are present and effective.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->