### PR TITLE
fix: harden persisted verdict finding payload validation

### DIFF
--- a/cerberus-elixir/lib/cerberus/store.ex
+++ b/cerberus-elixir/lib/cerberus/store.ex
@@ -63,6 +63,8 @@ defmodule Cerberus.Store do
     {"findings_json", "ALTER TABLE verdicts ADD COLUMN findings_json TEXT NOT NULL DEFAULT '[]'"}
   ]
   @known_tables ~w(events review_costs review_runs verdicts)
+  # Persisted findings stay schema-light on purpose: flat JSON objects only, bounded by byte size.
+  @max_findings_json_bytes 65_536
 
   def start_link(opts) do
     {name, opts} = Keyword.pop(opts, :name)
@@ -588,7 +590,7 @@ defmodule Cerberus.Store do
   defp normalize_findings(findings) when is_list(findings) do
     {normalized, dropped} =
       Enum.reduce(findings, {[], 0}, fn finding, {acc, dropped} ->
-        case normalize_finding(finding) do
+        case normalize_finding_for_read(finding) do
           {:ok, normalized_finding} -> {[normalized_finding | acc], dropped}
           :drop -> {acc, dropped + 1}
         end
@@ -608,18 +610,18 @@ defmodule Cerberus.Store do
     []
   end
 
-  defp normalize_finding(%_{} = finding), do: finding |> Map.from_struct() |> normalize_finding()
+  defp normalize_finding_for_read(%_{} = finding),
+    do: finding |> Map.from_struct() |> normalize_finding_for_read()
 
-  defp normalize_finding(finding) when is_map(finding) do
-    normalized =
-      finding
-      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-      |> Map.new()
-
-    if map_size(normalized) == 0, do: :drop, else: {:ok, normalized}
+  defp normalize_finding_for_read(finding) when is_map(finding) do
+    case normalize_finding_map(finding) do
+      {:ok, normalized} when map_size(normalized) > 0 -> {:ok, normalized}
+      {:ok, _normalized} -> :drop
+      {:error, _reason} -> :drop
+    end
   end
 
-  defp normalize_finding(_), do: :drop
+  defp normalize_finding_for_read(_), do: :drop
 
   defp parse_cost_row([
          reviewer,
@@ -698,7 +700,8 @@ defmodule Cerberus.Store do
 
   defp prepare_verdict_binding(attrs) do
     with {:ok, findings} <- validate_findings(Map.get(attrs, :findings, [])),
-         {:ok, findings_json} <- Jason.encode(findings) do
+         {:ok, findings_json} <- Jason.encode(findings),
+         :ok <- validate_findings_json_size(findings_json) do
       {:ok,
        [
          attrs[:review_run_id],
@@ -719,8 +722,71 @@ defmodule Cerberus.Store do
     end
   end
 
-  defp validate_findings(findings) when is_list(findings), do: {:ok, normalize_findings(findings)}
+  defp validate_findings(findings) when is_list(findings) do
+    findings
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {finding, index}, {:ok, acc} ->
+      case validate_finding_for_write(finding) do
+        {:ok, normalized_finding} -> {:cont, {:ok, [normalized_finding | acc]}}
+        {:error, reason} -> {:halt, {:error, {:invalid_finding, index, reason}}}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      error -> error
+    end
+  end
+
   defp validate_findings(_findings), do: {:error, :not_a_list}
+
+  defp validate_finding_for_write(%_{} = finding),
+    do: finding |> Map.from_struct() |> validate_finding_for_write()
+
+  defp validate_finding_for_write(finding) when is_map(finding) do
+    case normalize_finding_map(finding) do
+      {:ok, normalized} when map_size(normalized) > 0 -> {:ok, normalized}
+      {:ok, _normalized} -> {:error, :empty_finding}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp validate_finding_for_write(_), do: {:error, :not_a_map}
+
+  defp normalize_finding_map(finding) do
+    Enum.reduce_while(finding, {:ok, %{}}, fn
+      {_key, nil}, {:ok, acc} ->
+        {:cont, {:ok, acc}}
+
+      {key, value}, {:ok, acc} ->
+        with {:ok, normalized_key} <- normalize_finding_key(key),
+             {:ok, normalized_value} <- validate_finding_value(normalized_key, value) do
+          {:cont, {:ok, Map.put(acc, normalized_key, normalized_value)}}
+        else
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+    end)
+  end
+
+  defp normalize_finding_key(key) when is_binary(key) and key != "", do: {:ok, key}
+
+  defp normalize_finding_key(key) when is_atom(key),
+    do: key |> Atom.to_string() |> normalize_finding_key()
+
+  defp normalize_finding_key(_), do: {:error, :invalid_key}
+
+  defp validate_finding_value(_key, value)
+       when is_binary(value) or is_boolean(value) or is_integer(value) or is_float(value),
+       do: {:ok, value}
+
+  defp validate_finding_value(key, _value), do: {:error, {:non_scalar_value, key}}
+
+  defp validate_findings_json_size(findings_json)
+       when byte_size(findings_json) <= @max_findings_json_bytes,
+       do: :ok
+
+  defp validate_findings_json_size(findings_json) do
+    {:error, {:payload_too_large, byte_size(findings_json), @max_findings_json_bytes}}
+  end
 
   defp verdict_insert_sql do
     """

--- a/cerberus-elixir/test/cerberus/store_review_run_test.exs
+++ b/cerberus-elixir/test/cerberus/store_review_run_test.exs
@@ -4,6 +4,8 @@ defmodule Cerberus.StoreReviewRunTest do
   alias Cerberus.Store
   alias Cerberus.Verdict.Finding
 
+  @max_findings_json_bytes 65_536
+
   defp with_raw_db(database_path, fun) do
     {:ok, conn} = Exqlite.Sqlite3.open(database_path)
 
@@ -24,6 +26,27 @@ defmodule Cerberus.StoreReviewRunTest do
     {:ok, store} = Store.start_link(database_path: db_path)
     on_exit(fn -> File.rm(db_path) end)
     %{store: store, db_path: db_path}
+  end
+
+  defp persisted_finding(attrs) do
+    Map.merge(
+      %{
+        severity: "major",
+        category: "correctness",
+        file: "lib/foo.ex",
+        line: 12,
+        title: "Nil guard missing",
+        description: "The code dereferences a maybe-nil value.",
+        suggestion: "Guard the value before dereferencing."
+      },
+      attrs
+    )
+  end
+
+  defp encoded_findings_size(findings) do
+    findings
+    |> Jason.encode!()
+    |> byte_size()
   end
 
   describe "create_review_run/2" do
@@ -153,10 +176,10 @@ defmodule Cerberus.StoreReviewRunTest do
       assert {:ok, []} = Store.review_run_verdicts(store, 99999)
     end
 
-    test "drops invalid findings before storing", %{store: store} do
+    test "rejects malformed findings before storing", %{store: store} do
       id = Store.create_review_run(store, %{repo: "org/repo", pr_number: 42, head_sha: "abc123"})
 
-      assert :ok =
+      assert {:error, {:invalid_findings, {:invalid_finding, 1, {:non_scalar_value, "metadata"}}}} =
                Store.insert_verdict(store, %{
                  review_run_id: id,
                  reviewer: "trace",
@@ -165,31 +188,17 @@ defmodule Cerberus.StoreReviewRunTest do
                  confidence: 0.4,
                  summary: "Mixed findings",
                  findings: [
-                   %{
+                   persisted_finding(%{
                      severity: "minor",
-                     category: "correctness",
-                     file: "lib/foo.ex",
                      line: 9,
                      title: "Guard missing",
                      description: "Add a guard clause."
-                   },
-                   nil,
-                   123
+                   }),
+                   persisted_finding(%{metadata: %{nested: true}})
                  ]
                })
 
-      assert {:ok, [stored]} = Store.review_run_verdicts(store, id)
-
-      assert stored.findings == [
-               %{
-                 "severity" => "minor",
-                 "category" => "correctness",
-                 "file" => "lib/foo.ex",
-                 "line" => 9,
-                 "title" => "Guard missing",
-                 "description" => "Add a guard clause."
-               }
-             ]
+      assert {:ok, []} = Store.review_run_verdicts(store, id)
     end
 
     test "normalizes struct findings before storing", %{store: store} do
@@ -231,10 +240,65 @@ defmodule Cerberus.StoreReviewRunTest do
              ]
     end
 
+    test "rejects findings payloads that exceed the byte limit", %{store: store} do
+      id = Store.create_review_run(store, %{repo: "org/repo", pr_number: 42, head_sha: "abc123"})
+
+      base_finding = persisted_finding(%{description: ""})
+      padding = @max_findings_json_bytes - encoded_findings_size([base_finding])
+
+      oversized_finding =
+        persisted_finding(%{
+          description: String.duplicate("x", padding + 1)
+        })
+
+      assert {:error, {:invalid_findings, {:payload_too_large, size, @max_findings_json_bytes}}} =
+               Store.insert_verdict(store, %{
+                 review_run_id: id,
+                 reviewer: "trace",
+                 perspective: "correctness",
+                 verdict: "WARN",
+                 confidence: 0.4,
+                 summary: "Oversized findings payload",
+                 findings: [oversized_finding]
+               })
+
+      assert size == encoded_findings_size([oversized_finding])
+      assert {:ok, []} = Store.review_run_verdicts(store, id)
+    end
+
+    test "accepts findings payloads at the byte limit", %{store: store} do
+      id = Store.create_review_run(store, %{repo: "org/repo", pr_number: 42, head_sha: "abc123"})
+
+      base_finding = persisted_finding(%{description: ""})
+      padding = @max_findings_json_bytes - encoded_findings_size([base_finding])
+
+      limit_finding = persisted_finding(%{description: String.duplicate("x", padding)})
+
+      assert encoded_findings_size([limit_finding]) == @max_findings_json_bytes
+
+      assert :ok =
+               Store.insert_verdict(store, %{
+                 review_run_id: id,
+                 reviewer: "trace",
+                 perspective: "correctness",
+                 verdict: "WARN",
+                 confidence: 0.4,
+                 summary: "Boundary findings payload",
+                 findings: [limit_finding]
+               })
+
+      assert {:ok, [stored]} = Store.review_run_verdicts(store, id)
+      assert stored.summary == "Boundary findings payload"
+
+      assert stored.findings == [
+               Map.new(limit_finding, fn {key, value} -> {Atom.to_string(key), value} end)
+             ]
+    end
+
     test "batch verdict inserts are atomic when one payload is invalid", %{store: store} do
       id = Store.create_review_run(store, %{repo: "org/repo", pr_number: 42, head_sha: "abc123"})
 
-      assert {:error, {:invalid_findings, _}} =
+      assert {:error, {:invalid_findings, {:invalid_finding, 0, {:non_scalar_value, "raw"}}}} =
                Store.insert_verdicts(store, [
                  %{
                    review_run_id: id,
@@ -303,10 +367,10 @@ defmodule Cerberus.StoreReviewRunTest do
       assert {:ok, []} = Store.review_run_verdicts(store, id)
     end
 
-    test "returns an error when findings cannot be JSON encoded", %{store: store} do
+    test "returns an error when findings contain non-scalar values", %{store: store} do
       id = Store.create_review_run(store, %{repo: "org/repo", pr_number: 42, head_sha: "abc123"})
 
-      assert {:error, {:invalid_findings, _}} =
+      assert {:error, {:invalid_findings, {:invalid_finding, 0, {:non_scalar_value, "raw"}}}} =
                Store.insert_verdict(store, %{
                  review_run_id: id,
                  reviewer: "trace",
@@ -359,13 +423,31 @@ defmodule Cerberus.StoreReviewRunTest do
             """
             INSERT INTO verdicts
               (review_run_id, reviewer, verdict, perspective, confidence, summary, findings_json)
-            VALUES (#{id}, 'trace', 'WARN', 'correctness', 0.3, 'Malformed findings payload', '[null, 123, {}]')
+            VALUES (
+              #{id},
+              'trace',
+              'WARN',
+              'correctness',
+              0.3,
+              'Malformed findings payload',
+              '[null, 123, {}, {\"severity\":\"minor\",\"category\":\"correctness\",\"file\":\"lib/foo.ex\",\"line\":9,\"title\":\"Valid\",\"description\":\"kept\"}, {\"severity\":\"minor\",\"metadata\":{\"nested\":true}}]'
+            )
             """
           )
       end)
 
       assert {:ok, [stored]} = Store.review_run_verdicts(store, id)
-      assert stored.findings == []
+
+      assert stored.findings == [
+               %{
+                 "severity" => "minor",
+                 "category" => "correctness",
+                 "file" => "lib/foo.ex",
+                 "line" => 9,
+                 "title" => "Valid",
+                 "description" => "kept"
+               }
+             ]
     end
 
     test "normalizes integer and invalid confidence values on the read path", %{

--- a/docs/walkthroughs/issue-437-persisted-findings-hardening.md
+++ b/docs/walkthroughs/issue-437-persisted-findings-hardening.md
@@ -1,0 +1,76 @@
+# Issue #437 Walkthrough: Harden Persisted Verdict Finding Payloads
+
+## Reviewer Evidence
+
+- Core claim: `Cerberus.Store` now enforces a persistence-safe findings contract on write and rejects oversized `findings_json` payloads before they reach SQLite.
+- Primary artifact: focused Elixir persistence tests plus the full repository validation gate.
+- Persistent verification:
+  - `cd cerberus-elixir && mix test test/store_test.exs test/cerberus/store_review_run_test.exs test/cerberus/pipeline_test.exs`
+  - `make validate`
+
+## Walkthrough
+
+### What was missing before
+
+- The store normalized reviewer findings, but it accepted any non-empty map shape and only failed later if JSON encoding exploded.
+- Nested maps and other non-scalar values could survive normalization and become persisted storage shape by accident.
+- There was no byte cap on `findings_json`, so a very large reviewer payload could still be written into SQLite.
+
+### What changed on this branch
+
+- `Cerberus.Store` now validates persisted findings as flat JSON objects with stringable keys and scalar values.
+- Write-time persistence rejects malformed findings with a precise `{:invalid_findings, ...}` error instead of silently dropping bad entries.
+- `findings_json` now has an application-level byte limit (`65_536`) enforced before insert.
+- The read path stays defensive: malformed legacy rows normalize down to safe findings instead of crashing review-run reads.
+- Focused tests now cover malformed payload rejection, oversize rejection, exact boundary acceptance, and defensive read normalization.
+
+### What is true after
+
+- Direct store callers cannot persist nested or non-scalar finding payloads accidentally.
+- Oversized reviewer findings fail at the store boundary before SQLite write time.
+- Previously persisted malformed rows are still survivable on the read path.
+- The pipeline path remains green because validated reviewer findings still serialize cleanly through the store.
+
+## Execution Proof
+
+### Focused Elixir verification
+
+```text
+$ cd cerberus-elixir && mix test test/store_test.exs test/cerberus/store_review_run_test.exs test/cerberus/pipeline_test.exs
+39 tests, 0 failures
+```
+
+### Full repository gate
+
+```text
+$ make validate
+✓ All validation checks passed
+```
+
+## Before / After Shape
+
+### Before
+
+```mermaid
+graph TD
+  A["reviewer/store caller findings"] --> B["drop nils + keep any non-empty map"]
+  B --> C["Jason.encode/1 or SQLite write"]
+  C --> D["nested or oversized payload can slip through"]
+```
+
+### After
+
+```mermaid
+graph TD
+  A["reviewer/store caller findings"] --> B["validate flat persisted finding contract"]
+  B --> C["enforce findings_json byte cap"]
+  C --> D["persist safe payload"]
+  E["legacy malformed row"] --> F["defensive read normalization"]
+  F --> D
+```
+
+## Why the new shape is better
+
+- Semantic reviewer validation stays where it belongs, in `Cerberus.Verdict`, while the store owns persistence safety.
+- The store contract is strict without hardcoding the full current reviewer schema.
+- Fail-fast write errors are better than silent data-shape drift inside an audit table.


### PR DESCRIPTION
## Why This Matters
Cerberus started persisting reviewer verdict details in `#418`, but the store boundary still accepted overly loose finding payloads. This lane hardens the storage contract for persisted reviewer findings so malformed or oversized `findings_json` payloads fail before they hit SQLite, while keeping semantic reviewer validation owned by `Cerberus.Verdict`.

Issue: closes #437

## Trade-offs / Risks
This intentionally narrows the persistence contract to flat JSON-object findings with scalar values only. That is stricter than the previous "any non-empty map" behavior, so direct store callers that were depending on nested payloads will now fail fast instead of silently persisting unstable shape. That is the right trade because `verdicts` is audit data, not an arbitrary blob store.

## Intent Reference
Issue #437 now defines the intent explicitly: semantic validation stays at the reviewer/verdict boundary, while the store enforces persistence safety and bounded size. This PR implements that split without hardcoding today's full reviewer schema.

Source: https://github.com/misty-step/cerberus/issues/437

## Changes
- Added a persistence-specific findings validator in `Cerberus.Store` for write-time payloads.
- Enforced a `65_536` byte cap on encoded `findings_json` before insert.
- Kept the read path defensive by normalizing malformed persisted rows down to safe findings.
- Added focused Elixir coverage for malformed payload rejection, oversize rejection, exact boundary acceptance, and read-path normalization.
- Added a walkthrough artifact for the lane.

## Alternatives Considered
- Do nothing: rejected because the store would keep accepting malformed or very large payloads as an accidental contract.
- Reuse the full reviewer `Finding` schema in the store: rejected because persistence safety is a different concern and the issue explicitly asked to avoid over-coupling storage to today's reviewer output shape.
- Add a SQLite schema migration with DB-level size enforcement: rejected for this lane because application-level validation closes the bug without introducing migration churn.

## Acceptance Criteria
- [x] Given a verdict payload containing a non-flat or otherwise non-persistable finding value, when `Cerberus.Store.insert_verdict/2` runs, then it returns `{:error, {:invalid_findings, ...}}` and writes no row.
- [x] Given a verdict payload whose encoded `findings_json` exceeds the store byte limit, when `Cerberus.Store.insert_verdict/2` runs, then it returns `{:error, {:invalid_findings, {:payload_too_large, ...}}}` and writes no row.
- [x] Given a verdict payload at the accepted size boundary, when `Cerberus.Store.insert_verdict/2` runs, then the row persists and loads back successfully.
- [x] Given malformed persisted `findings_json` already present in SQLite, when `Cerberus.Store.review_run_verdicts/2` reads it, then the store returns a safe normalized findings list instead of crashing.

## Manual QA
1. `cd cerberus-elixir && mix test test/store_test.exs test/cerberus/store_review_run_test.exs test/cerberus/pipeline_test.exs`
   Expected: `39 tests, 0 failures`
2. `make validate`
   Expected: `1955 passed, 1 skipped`, `320 tests, 0 failures`, and `✓ All validation checks passed`

## Walkthrough
Artifact: https://github.com/misty-step/cerberus/blob/cx/437-harden-persisted-findings-r1/docs/walkthroughs/issue-437-persisted-findings-hardening.md

Persistent verification protecting the demonstrated path:
- `cd cerberus-elixir && mix test test/store_test.exs test/cerberus/store_review_run_test.exs test/cerberus/pipeline_test.exs`
- `make validate`

## What Changed
Base branch shape:
```mermaid
graph TD
  A["reviewer/store caller findings"] --> B["drop nils + keep any non-empty map"]
  B --> C["Jason.encode/1 or SQLite write"]
  C --> D["nested or oversized payload can slip through"]
```

PR branch shape:
```mermaid
graph TD
  A["reviewer/store caller findings"] --> B["validate flat persisted finding contract"]
  B --> C["enforce findings_json byte cap"]
  C --> D["persist safe payload"]
  E["legacy malformed row"] --> F["defensive read normalization"]
  F --> D
```

Storage boundary sequence:
```mermaid
sequenceDiagram
  participant P as Pipeline or store caller
  participant S as Cerberus.Store
  participant DB as SQLite verdicts table
  P->>S: insert_verdict(s) with findings
  S->>S: normalize keys + validate scalar values
  S->>S: encode findings_json + check byte cap
  alt valid and bounded
    S->>DB: INSERT verdict row
  else malformed or oversized
    S-->>P: {:error, {:invalid_findings, ...}}
  end
```

Why the new shape is better: the store now owns persistence safety directly, the reviewer contract stays semantically focused, and audit rows stop drifting into accidental nested-blob territory.

## Before / After
Before: the store would accept any non-empty map payload, so nested structures or oversized finding blobs could become persisted storage shape accidentally.

After: the store only persists flat scalar finding maps within a hard byte cap, and malformed legacy rows are reduced to safe read results instead of crashing callers.

## Test Coverage
- `cerberus-elixir/test/cerberus/store_review_run_test.exs`
- `cerberus-elixir/test/store_test.exs`
- `cerberus-elixir/test/cerberus/pipeline_test.exs`

Coverage notes: the new behavior is locked at the store boundary and exercised through the pipeline persistence path. I did not add new Python coverage because the change is entirely inside the Elixir store.

## Merge Confidence
High.

Strongest evidence:
- focused persistence suite passed on the final rebased head
- repo-wide `make validate` passed on the final rebased head
- self-review verdict: Ousterhout `Ship`, Carmack `Ship`, Grug `Ship`

Residual risk:
- any external direct caller that was persisting nested finding payloads will now receive explicit store errors; that is intentional contract tightening rather than an accidental regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enforced a 65,536-byte limit on findings payloads to prevent oversized data from reaching the database; payloads exceeding this limit are now rejected at write time.
  * Strengthened findings validation to ensure findings follow a consistent structure with stringable keys and scalar values; malformed findings are now caught and rejected early.

* **Documentation**
  * Added walkthrough documentation detailing findings payload hardening and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->