### PR TITLE
Groom Cerberus strategy backlog

### DIFF
--- a/backlog.d/001-execution-evidence-hardening.md
+++ b/backlog.d/001-execution-evidence-hardening.md
@@ -1,0 +1,56 @@
+# Harden execution and evidence admission before automatic review
+
+Priority: P0 | Status: ready | Estimate: L
+
+## Goal
+
+Make Cerberus safe to run as a primary review agent by enforcing the local gate
+in CI, removing parent-`PATH` executable selection risk, and rejecting
+semantically inconsistent review artifacts.
+
+## Oracle
+
+- [ ] A GitHub workflow runs `./scripts/verify.sh` on pull requests and pushes.
+- [ ] Harness execution resolves OpenCode/OMP binaries from an explicit trusted
+  search policy or absolute paths, not the parent process `PATH`.
+- [ ] Artifact validation rejects unknown `finding_id` links, unknown
+  `suggested_fixes` references, orphan top-level fixes, and duplicate
+  artifact blocks across all accepted extraction formats.
+- [ ] Adversarial fixture tests prove the gate fails for each case above.
+
+## Verification System
+
+- Claim: Cerberus cannot be tricked into executing an unexpected substrate
+  binary or accepting malformed cross-linked review artifacts, and the repo
+  gate runs in hosted CI.
+- Falsifier: a hostile `PATH` fixture selects a fake `opencode`; a comment or
+  fix references a missing finding and passes validation; a transcript with
+  two artifact candidates is accepted; a PR can merge without the repo gate.
+- Driver: `./scripts/verify.sh` locally and the GitHub Actions workflow on a
+  pull request.
+- Grader: Rust unit tests, fixture harness smoke, CI check result, and a saved
+  failure transcript for adversarial artifact extraction.
+- Evidence packet: `target/cerberus/*`, GitHub workflow URL, and failing-then-
+  passing test names.
+- Cadence: every PR touching harness, validation, prompt, request acquisition,
+  or CI.
+
+## Children
+
+1. Add `.github/workflows/verify.yml` that runs `./scripts/verify.sh`.
+2. Replace parent-`PATH` lookup with a controlled resolver and tests for hostile
+   `PATH` substitution.
+3. Strengthen artifact cross-reference validation for findings, comments,
+   citations, and suggested fixes.
+4. Make artifact extraction strict about multiple candidates across marker,
+   XML, and raw JSON fallback modes.
+5. Add one adversarial fixture per falsifier and document the threat model in
+   `spec.md`.
+
+## Notes
+
+**Why:** The security lane confirmed no `.github` workflow exists, while
+`src/harness.rs` resolves binaries from the parent `PATH` before child env
+sanitization and `src/validation.rs` does not yet cross-check all comment/fix
+IDs. This is the best next pickup because it protects every later posting or
+automation path.

--- a/backlog.d/002-closed-loop-review-delivery.md
+++ b/backlog.d/002-closed-loop-review-delivery.md
@@ -1,0 +1,57 @@
+# Deliver closed-loop PR review output
+
+Priority: P0 | Status: pending | Estimate: XL
+
+## Goal
+
+Let an operator run one Cerberus command for a pull request and get validated,
+idempotent review output in GitHub while preserving the caller-neutral artifact.
+
+## Oracle
+
+- [ ] `cerberus review-pr --number <n> --repo <owner/name>` acquires the PR,
+  runs the configured harness, writes request/artifact/markdown/execution
+  receipts, and exits non-zero only for untrusted or failed review states.
+- [ ] A dry-run mode shows the exact GitHub check/review/comment operations
+  without writing to GitHub.
+- [ ] A posting mode creates or updates a per-head-SHA Cerberus check summary
+  and review comments without duplicating prior output.
+- [ ] Inline comments map only to changed PR lines; unmappable comments fall
+  back to contextual summary output.
+
+## Verification System
+
+- Claim: Cerberus can close the loop from GitHub PR context to useful GitHub
+  review output without making GitHub the core product boundary.
+- Falsifier: repeated runs duplicate comments; stale artifacts post to a new
+  head SHA; inline anchors outside the diff are posted; dry-run output differs
+  from real posting; a failed harness run posts a PASS check.
+- Driver: local `cerberus review-pr --dry-run` fixture, integration tests with
+  captured `gh api`/GitHub API fixtures, and one live self-review PR smoke when
+  credentials are intentionally allowed.
+- Grader: generated artifact validation, posting-plan snapshot, GitHub check
+  state, and idempotency marker inspection.
+- Evidence packet: `target/cerberus/review-pr/*`, GitHub PR URL, check-run URL,
+  and posting transcript with token values redacted.
+- Cadence: every change to request acquisition, rendering, posting, or artifact
+  schema.
+
+## Children
+
+1. Add `review-pr` as orchestration over existing `request pr` and `review`.
+2. Define a `PostPlan.v1` from `ReviewArtifact.v1` to GitHub check/review
+   operations.
+3. Implement dry-run rendering for checks, PR review body, inline comments, and
+   contextual comments.
+4. Implement idempotent GitHub posting with per-head-SHA markers and stale-run
+   protection.
+5. Add a live self-review smoke documented in README, gated behind explicit
+   token allowlisting.
+
+## Notes
+
+**Why:** The product/operator lane found the largest usefulness gap: Cerberus
+can generate artifacts, but normal operators still need manual glue to turn a
+review artifact into GitHub feedback. GitHub docs distinguish PR review
+comments and Checks annotations, with Checks annotations capped per request, so
+posting needs a deliberate projection layer instead of a Markdown dump.

--- a/backlog.d/003-base-and-runtime-context.md
+++ b/backlog.d/003-base-and-runtime-context.md
@@ -1,0 +1,50 @@
+# Add base checkout and runtime context tiers
+
+Priority: P1 | Status: pending | Estimate: L
+
+## Goal
+
+Let Cerberus use richer available context by supporting base+head workspace
+comparison and explicit local/runtime probes without overstating evidence.
+
+## Oracle
+
+- [ ] `ReviewRequest.v1` producers can include both base and head workspaces
+  when the caller supplies safe paths or refs.
+- [ ] The harness creates isolated disposable workspaces for both base and
+  head and records `repo_base: true` only when base inspection is available.
+- [ ] Runtime targets execute only when policy explicitly allows them, with
+  bounded env, cwd, timeout, and transcript capture.
+- [ ] Artifacts that claim base or runtime evidence without matching request
+  capabilities fail validation.
+
+## Verification System
+
+- Claim: Cerberus can compare base and head context and run allowed probes
+  while preserving capability truth.
+- Falsifier: a diff-only request produces `repo_base: true`; a runtime command
+  runs without explicit policy; runtime output leaks unallowed env; a base
+  workspace mutation touches the user's checkout.
+- Driver: `./scripts/verify.sh` plus fixture requests for diff-only,
+  repo-head, base+head, and local-runtime modes.
+- Grader: execution plans, artifact capabilities, runtime transcripts, and
+  validation failures for overstated capabilities.
+- Evidence packet: `target/cerberus/context-tiers/*`.
+- Cadence: before enabling runtime-aware review in a caller or poster.
+
+## Children
+
+1. Add `--base-workspace`/`--base-ref` acquisition for git-range and PR
+   requests.
+2. Extend `RunWorkspace` to manage base and head worktrees safely.
+3. Add explicit local runtime policy fields and a minimal command probe runner.
+4. Teach prompts to compare base/head and cite runtime evidence only when
+   capability flags allow it.
+5. Add fixture coverage for all context tiers.
+
+## Notes
+
+**Why:** The spec already defines `repo_base_and_head`, `local_runtime`, and
+`remote_runtime`, but the shipped implementation only proves diff and
+repo-head review. This closes the highest-value evidence gap without turning
+Cerberus into a hosted platform.

--- a/backlog.d/004-review-kernel-boundary.md
+++ b/backlog.d/004-review-kernel-boundary.md
@@ -1,0 +1,51 @@
+# Deepen the review kernel boundary
+
+Priority: P1 | Status: pending | Estimate: L
+
+## Goal
+
+Keep Cerberus easy to extend by separating the typed review kernel from CLI,
+substrate adapter options, prompt schema prose, and request-source plumbing.
+
+## Oracle
+
+- [ ] A typed `ReviewKernel::review(request, run_policy) -> ReviewRun` owns the
+  common execution path.
+- [ ] OpenCode and OMP substrate options live behind adapter configs rather
+  than leaking into the CLI and core harness interface.
+- [ ] Prompt schema instructions are generated from or checked against Rust
+  schema/validation fixtures.
+- [ ] Adding a new request source or substrate does not require editing
+  unrelated prompt or CLI code beyond registration.
+
+## Verification System
+
+- Claim: Cerberus has a deep review kernel with a small interface and
+  substrate/source details behind adapters.
+- Falsifier: adding a new substrate requires changing prompt schema prose;
+  CLI flags leak into kernel structs; a schema change can compile while prompt
+  fixtures still describe the old artifact shape.
+- Driver: Rust tests for kernel API, prompt/schema golden tests, and a small
+  fake substrate adapter.
+- Grader: public API diff, compile-time type coverage, fixture output, and
+  `./scripts/verify.sh`.
+- Evidence packet: API docs or rustdoc snippet, prompt golden fixture, and
+  adapter test output.
+- Cadence: before adding a second production caller or new substrate.
+
+## Children
+
+1. Introduce `ReviewKernel`, `RunPolicy`, and `ReviewRun` types.
+2. Move OpenCode/OMP-specific fields behind adapter config structs.
+3. Add prompt/schema golden tests that fail when `ReviewArtifact.v1` contract
+   prose drifts from Rust types.
+4. Replace raw request metadata blobs with typed provenance where current
+   callers need stable behavior.
+5. Update CLI to become a thin caller of the kernel.
+
+## Notes
+
+**Why:** The architecture lane found the core idea is deep, but substrate knobs,
+prompt schema instructions, and provenance strings still leak across module
+boundaries. This matters before closed-loop delivery adds more callers and
+projection paths.

--- a/backlog.d/005-upstream-evaluation-receipts.md
+++ b/backlog.d/005-upstream-evaluation-receipts.md
@@ -1,0 +1,48 @@
+# Emit upstream evaluation-ready receipts
+
+Priority: P2 | Status: pending | Estimate: M
+
+## Goal
+
+Let Daedalus or another laboratory score real Cerberus runs without making
+Cerberus own model or harness evaluation.
+
+## Oracle
+
+- [ ] Each review run can emit a stable receipt bundle with request digest,
+  artifact digest, harness, model, latency, cost when available, capability
+  tier, transcript URI, and validation outcome.
+- [ ] Receipt bundles are redacted and deterministic enough for replay or
+  scoring.
+- [ ] A documented handoff format lets upstream labs compare harness/model
+  candidates without changing Cerberus runtime behavior.
+
+## Verification System
+
+- Claim: Cerberus records enough structured evidence for external evaluators
+  to score review quality, cost, latency, and degraded behavior.
+- Falsifier: receipt bundles include secrets or private prompt paths; two runs
+  with the same request cannot be matched by digest; model/cost/latency fields
+  are missing from real OpenCode runs where the transcript includes them.
+- Driver: fixture review, fake OpenCode/OMP review, and one optional real
+  OpenCode smoke with explicit env allowlisting.
+- Grader: JSON schema validation, redaction checks, and Daedalus import dry-run
+  when available.
+- Evidence packet: `target/cerberus/receipts/*.json`.
+- Cadence: whenever harness receipt shape changes.
+
+## Children
+
+1. Define `ReviewReceiptBundle.v1` separate from `ReviewArtifact.v1`.
+2. Add redaction tests for request files, prompt paths, env names, and
+   transcript excerpts.
+3. Parse available model/cost/usage metadata from OpenCode JSON events without
+   depending on it for artifact validation.
+4. Document Daedalus handoff expectations and import assumptions.
+
+## Notes
+
+**Why:** The accepted spec keeps model/harness evaluation outside Cerberus, but
+ADR 0002 says Cerberus should record enough receipts for evaluators to score
+runs. This is deliberately P2 until execution hardening and delivery loops are
+in place.

--- a/docs/plans/cerberus-groom-2026-06-20.html
+++ b/docs/plans/cerberus-groom-2026-06-20.html
@@ -118,7 +118,7 @@
           <tr><td>Architecture</td><td>Complete</td><td><code>src/harness.rs</code>, <code>src/prompt.rs</code>, architecture lane</td><td>004 review kernel boundary</td></tr>
           <tr><td>Security/reliability</td><td>Complete</td><td><code>src/harness.rs</code>, <code>src/validation.rs</code>, no <code>.github</code></td><td>001 execution hardening</td></tr>
           <tr><td>Context model</td><td>Partial</td><td><code>spec.md</code> defines richer tiers than implementation</td><td>003 base/runtime context</td></tr>
-          <tr><td>External exemplars</td><td>Partial</td><td>GitHub PR reviews/checks docs, reviewdog, OpenCode docs</td><td>002 posting projection design</td></tr>
+          <tr><td>External exemplars</td><td>Partial</td><td>GitHub PR reviews/checks docs, reviewdog, OpenCode docs</td><td>002 closed-loop delivery</td></tr>
           <tr><td>Evaluation</td><td>Complete enough</td><td>ADR 0002 keeps eval ownership upstream</td><td>005 eval-ready receipts</td></tr>
         </tbody>
       </table>

--- a/docs/plans/cerberus-groom-2026-06-20.html
+++ b/docs/plans/cerberus-groom-2026-06-20.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cerberus Strategic Groom - 2026-06-20</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #111315;
+        --muted: #5c6470;
+        --line: #d8dde3;
+        --panel: #f6f8fa;
+        --accent: #0d6b57;
+        --warn: #8a4b00;
+      }
+      body {
+        margin: 0;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: var(--ink);
+        background: #ffffff;
+      }
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 48px 28px 72px;
+      }
+      h1 {
+        font-size: 42px;
+        line-height: 1.05;
+        margin: 0 0 18px;
+      }
+      h2 {
+        font-size: 22px;
+        margin: 42px 0 12px;
+      }
+      p {
+        line-height: 1.55;
+        color: var(--muted);
+      }
+      .lede {
+        font-size: 20px;
+        max-width: 820px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 14px;
+        margin-top: 24px;
+      }
+      .card {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 18px;
+        background: var(--panel);
+      }
+      .card strong {
+        display: block;
+        margin-bottom: 6px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 14px;
+      }
+      th, td {
+        border-top: 1px solid var(--line);
+        padding: 10px 8px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        color: var(--muted);
+        font-weight: 600;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.95em;
+      }
+      .accent {
+        color: var(--accent);
+      }
+      .warn {
+        color: var(--warn);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Cerberus should become a closed-loop reviewer only after execution hardening.</h1>
+      <p class="lede">The shipped Rust core proves request acquisition, isolated OpenCode execution, artifact validation, and rendering. The strategic gap is now production trust: enforce the gate, harden executable and artifact admission, then project artifacts into GitHub review surfaces.</p>
+
+      <section class="grid">
+        <div class="card">
+          <strong>Best Next Pickup</strong>
+          <span class="accent">001 Execution & Evidence Hardening</span>
+          <p>It protects every future posting path by closing CI, binary resolution, and artifact integrity gaps.</p>
+        </div>
+        <div class="card">
+          <strong>Second Move</strong>
+          <span>002 Closed-Loop Review Delivery</span>
+          <p>Add <code>review-pr</code>, dry-run posting plans, GitHub checks/reviews, and idempotency.</p>
+        </div>
+        <div class="card">
+          <strong>Strategic Boundary</strong>
+          <span>No eval lab, no event plane</span>
+          <p>Cerberus emits artifacts and receipts. Daedalus evaluates. Bitterblossom or thin callers can trigger.</p>
+        </div>
+      </section>
+
+      <h2>Source Matrix</h2>
+      <table>
+        <thead>
+          <tr><th>Surface</th><th>Status</th><th>Evidence</th><th>Backlog Move</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Product/operator</td><td>Complete</td><td><code>README.md</code>, <code>spec.md</code>, product lane</td><td>002 closed-loop delivery</td></tr>
+          <tr><td>Architecture</td><td>Complete</td><td><code>src/harness.rs</code>, <code>src/prompt.rs</code>, architecture lane</td><td>004 review kernel boundary</td></tr>
+          <tr><td>Security/reliability</td><td>Complete</td><td><code>src/harness.rs</code>, <code>src/validation.rs</code>, no <code>.github</code></td><td>001 execution hardening</td></tr>
+          <tr><td>Context model</td><td>Partial</td><td><code>spec.md</code> defines richer tiers than implementation</td><td>003 base/runtime context</td></tr>
+          <tr><td>External exemplars</td><td>Partial</td><td>GitHub PR reviews/checks docs, reviewdog, OpenCode docs</td><td>002 posting projection design</td></tr>
+          <tr><td>Evaluation</td><td>Complete enough</td><td>ADR 0002 keeps eval ownership upstream</td><td>005 eval-ready receipts</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Sequence</h2>
+      <table>
+        <tbody>
+          <tr><th>Now</th><td>Harden execution and evidence admission. Add hosted CI before more automation.</td></tr>
+          <tr><th>Next</th><td>Ship closed-loop PR review delivery with dry-run first, then idempotent GitHub posting.</td></tr>
+          <tr><th>Later</th><td>Add base/runtime context tiers, deepen the kernel boundary, and emit upstream evaluation receipts.</td></tr>
+          <tr><th>Do Not Do Yet</th><td>Do not build a hosted platform, model leaderboard, or static reviewer roster inside Cerberus.</td></tr>
+        </tbody>
+      </table>
+    </main>
+  </body>
+</html>

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,61 @@
+# Cerberus Vision
+
+Status: active product north star.
+
+## Audience
+
+Cerberus is for operators who want a dependable AI code review agent they can
+run from arbitrary review contexts: a local branch, a GitHub pull request, a
+task-system diff, a hosted worker, or a future event plane.
+
+## Job To Be Done
+
+Given a change and whatever context is safely available, Cerberus should
+produce a trustworthy review artifact and, when asked, project that artifact
+into the operator's normal review surface without overstating evidence.
+
+## Category
+
+Cerberus is a Rust review runner and artifact contract. It is not a benchmark
+lab, event plane, hosted multi-tenant service, or static reviewer swarm.
+
+## Standards
+
+- Context truth is non-negotiable: every artifact records what Cerberus could
+  actually inspect.
+- The stable seam is `ReviewRequest.v1 -> ReviewArtifact.v1`.
+- Rust owns contracts, capability boundaries, execution receipts, validation,
+  and rendering.
+- Agent substrates own reviewer judgment and any runtime lane/subagent design.
+- OpenCode is the default production-oriented substrate; OMP remains a local
+  fallback behind the same harness contract.
+- Verification must catch likely publication and execution failures before
+  Cerberus becomes an automatic reviewer.
+
+## Non-Goals
+
+- No first-party model leaderboard in Cerberus.
+- No hardcoded reviewer personas in Rust.
+- No GitHub-only product boundary.
+- No ambient credential inheritance.
+- No direct provider orchestration unless a future ADR proves the substrate
+  boundary cannot support the needed capability.
+
+## Strategic Bets
+
+1. A strict review artifact is more valuable than a clever reviewer transcript.
+2. A single excellent master reviewer with dynamic substrate lanes beats a
+   static reviewer roster embedded into product code.
+3. A caller-neutral artifact plus small projection adapters will age better
+   than a GitHub-native core.
+4. Upstream labs such as Daedalus should evaluate models and harnesses;
+   Cerberus should emit enough receipts for those labs to score real runs.
+
+## Six To Twelve Month Target
+
+Cerberus is the default code review agent for Misty Step repositories. A
+single command or thin caller can review a PR, run inside an isolated review
+workspace, produce a validated artifact, publish GitHub checks/reviews with
+idempotent markers, and preserve receipts for later evaluation. Operators can
+see what context was used, what was skipped, what cost/time was incurred, and
+why each comment exists.


### PR DESCRIPTION
## Summary
- add a durable Cerberus product vision
- add the 2026-06-20 strategic groom plan artifact
- seed five epic-shaped backlog items for execution hardening, closed-loop delivery, richer context, kernel boundaries, and upstream eval receipts

## Verification
- ./scripts/verify.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Cerberus vision documentation covering standards, workflows, non-goals, and target timelines.
  * Added strategic groom roadmap (2026-06-20) with milestones and a source matrix.
  * Added five backlog specifications for execution-evidence hardening, closed-loop GitHub review delivery, base/runtime context, deeper review-kernel boundary, and deterministic upstream receipt bundles (including evidence packet and verification oracles).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->