### PR TITLE
Deliver 001 execution evidence hardening

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,20 @@
+name: Verify
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+          rustup default stable
+
+      - name: Run repo gate
+        run: ./scripts/verify.sh

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/docs/plans/001-execution-evidence-hardening.html
+++ b/docs/plans/001-execution-evidence-hardening.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>001 Execution Evidence Hardening</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #101418;
+        --muted: #59636f;
+        --line: #d8dee6;
+        --panel: #f7f9fb;
+        --accent: #075e54;
+        --danger: #8f251e;
+      }
+      body {
+        margin: 0;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: var(--ink);
+        background: #fff;
+      }
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 48px 28px 80px;
+      }
+      h1 {
+        margin: 0;
+        font-size: 42px;
+        line-height: 1.06;
+      }
+      h2 {
+        margin: 40px 0 12px;
+        font-size: 22px;
+      }
+      p, li {
+        color: var(--muted);
+        line-height: 1.55;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.95em;
+      }
+      .lede {
+        max-width: 820px;
+        font-size: 20px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 1px;
+        border: 1px solid var(--line);
+        background: var(--line);
+      }
+      .cell {
+        background: var(--panel);
+        padding: 18px;
+      }
+      .cell strong {
+        display: block;
+        color: var(--ink);
+        margin-bottom: 8px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th, td {
+        border-top: 1px solid var(--line);
+        padding: 11px 8px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        color: var(--muted);
+      }
+      .accent {
+        color: var(--accent);
+      }
+      .danger {
+        color: var(--danger);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p class="accent">BACKLOG 001 / EXECUTOR CONTRACT</p>
+      <h1>Make Cerberus safe before it can become automatic review infrastructure.</h1>
+      <p class="lede">Deliver hosted verification, trusted substrate binary selection, strict artifact cross-link validation, and adversarial fixtures. This is a hardening slice, not GitHub posting or reviewer-quality work.</p>
+
+      <section class="grid" aria-label="quality system">
+        <div class="cell"><strong>Outcome</strong><p>Cerberus cannot execute a substrate binary selected from hostile parent state or accept malformed artifacts that would later be posted.</p></div>
+        <div class="cell"><strong>Standards</strong><p>Small Rust surfaces, behavior tests over implementation tests, strict artifact admission, no weakened gates.</p></div>
+        <div class="cell"><strong>Proof</strong><p>Failing-then-passing adversarial unit tests, <code>./scripts/verify.sh</code>, and a GitHub Actions workflow running the same gate.</p></div>
+        <div class="cell"><strong>Stop If</strong><p>CI needs secrets, resolver hardening breaks explicit fixture paths, or artifact strictness rejects valid current fixtures.</p></div>
+      </section>
+
+      <h2>Verification System</h2>
+      <table>
+        <tbody>
+          <tr><th>Claim</th><td>Cerberus refuses hostile binary resolution and malformed artifact graphs, and the repo gate runs on PRs.</td></tr>
+          <tr><th>Falsifier</th><td>A fake <code>opencode</code> earlier in parent <code>PATH</code> executes; an unknown <code>finding_id</code> or fix id passes; two artifact candidates are accepted; PRs lack hosted verification.</td></tr>
+          <tr><th>Driver</th><td>Rust unit tests, fixture harness smoke, <code>./scripts/verify.sh</code>, GitHub Actions <code>verify.yml</code>.</td></tr>
+          <tr><th>Evidence</th><td><code>target/cerberus/*</code>, workflow check URL, failing-then-passing test names.</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Execution Sequence</h2>
+      <ol>
+        <li>Add the hosted verification workflow.</li>
+        <li>Write adversarial tests for resolver, artifact cross-links, and multi-candidate extraction.</li>
+        <li>Harden resolver, validation, and extraction.</li>
+        <li>Update <code>spec.md</code> threat model and mark backlog 001 shipped/done only if all oracles pass.</li>
+        <li>Run the gate, open PR, and get fresh review.</li>
+      </ol>
+
+      <h2>Non-Goals</h2>
+      <p>No <code>review-pr</code>, GitHub posting, base/runtime context tiers, Daedalus receipt bundles, or model/harness evaluation matrix in this slice.</p>
+    </main>
+  </body>
+</html>

--- a/fixtures/harness/invalid-orphan-suggested-fix.txt
+++ b/fixtures/harness/invalid-orphan-suggested-fix.txt
@@ -1,0 +1,47 @@
+Cerberus invalid fixture transcript: top-level suggested fix is orphaned.
+
+-----BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----
+{
+  "schema_version": "cerberus.review_artifact.v1",
+  "artifact_id": "{{artifact_id}}",
+  "request_id": "{{request_id}}",
+  "request_digest": "{{request_digest}}",
+  "lifecycle_state": "completed",
+  "verdict": "WARN",
+  "context_capabilities": {{context_capabilities}},
+  "summary": {
+    "title": "Invalid artifact",
+    "body": "This fixture should fail validation.",
+    "analysis": "The top-level suggested fix is not attached to any finding or comment.",
+    "residual_risk": []
+  },
+  "findings": [],
+  "comments": [],
+  "suggested_fixes": [
+    {
+      "id": "fix-orphan",
+      "applicability": "needs_review",
+      "format": "instructions",
+      "edits": [],
+      "diff": null
+    }
+  ],
+  "citations": [],
+  "receipts": [],
+  "run": {
+    "engine_version": "cerberus-fixture",
+    "config_digest": "sha256:fixture",
+    "started_at": "{{now}}",
+    "finished_at": "{{now}}",
+    "duration_ms": 1,
+    "cost_usd": null,
+    "coverage": {
+      "files_reviewed": [
+        "src/ratio.rs"
+      ],
+      "files_with_findings": []
+    }
+  },
+  "errors": []
+}
+-----END CERBERUS_REVIEW_ARTIFACT_V1-----

--- a/fixtures/harness/invalid-unknown-finding-id.txt
+++ b/fixtures/harness/invalid-unknown-finding-id.txt
@@ -1,0 +1,74 @@
+Cerberus invalid fixture transcript: comment references an unknown finding.
+
+-----BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----
+{
+  "schema_version": "cerberus.review_artifact.v1",
+  "artifact_id": "{{artifact_id}}",
+  "request_id": "{{request_id}}",
+  "request_digest": "{{request_digest}}",
+  "lifecycle_state": "completed",
+  "verdict": "WARN",
+  "context_capabilities": {{context_capabilities}},
+  "summary": {
+    "title": "Invalid artifact",
+    "body": "This fixture should fail validation.",
+    "analysis": "The comment points at a missing finding.",
+    "residual_risk": []
+  },
+  "findings": [
+    {
+      "id": "finding-001",
+      "severity": "major",
+      "category": "correctness",
+      "title": "Anchored finding",
+      "description": "Valid finding used to keep the rest of the artifact plausible.",
+      "evidence": "The changed hunk is available.",
+      "confidence": 0.8,
+      "anchors": [
+        {
+          "kind": "inline",
+          "path": "src/ratio.rs",
+          "line": 3
+        }
+      ],
+      "citations": [],
+      "suggested_fixes": []
+    }
+  ],
+  "comments": [
+    {
+      "id": "comment-001",
+      "kind": "inline",
+      "intent": "finding",
+      "finding_id": "missing-finding",
+      "body": "This comment references a finding id that does not exist.",
+      "anchor": {
+        "kind": "inline",
+        "path": "src/ratio.rs",
+        "line": 3
+      },
+      "suggested_fixes": []
+    }
+  ],
+  "suggested_fixes": [],
+  "citations": [],
+  "receipts": [],
+  "run": {
+    "engine_version": "cerberus-fixture",
+    "config_digest": "sha256:fixture",
+    "started_at": "{{now}}",
+    "finished_at": "{{now}}",
+    "duration_ms": 1,
+    "cost_usd": null,
+    "coverage": {
+      "files_reviewed": [
+        "src/ratio.rs"
+      ],
+      "files_with_findings": [
+        "src/ratio.rs"
+      ]
+    }
+  },
+  "errors": []
+}
+-----END CERBERUS_REVIEW_ARTIFACT_V1-----

--- a/fixtures/harness/invalid-unknown-suggested-fix.txt
+++ b/fixtures/harness/invalid-unknown-suggested-fix.txt
@@ -1,0 +1,62 @@
+Cerberus invalid fixture transcript: finding references an unknown suggested fix.
+
+-----BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----
+{
+  "schema_version": "cerberus.review_artifact.v1",
+  "artifact_id": "{{artifact_id}}",
+  "request_id": "{{request_id}}",
+  "request_digest": "{{request_digest}}",
+  "lifecycle_state": "completed",
+  "verdict": "WARN",
+  "context_capabilities": {{context_capabilities}},
+  "summary": {
+    "title": "Invalid artifact",
+    "body": "This fixture should fail validation.",
+    "analysis": "The finding points at a missing suggested fix.",
+    "residual_risk": []
+  },
+  "findings": [
+    {
+      "id": "finding-001",
+      "severity": "major",
+      "category": "correctness",
+      "title": "Bad fix reference",
+      "description": "The suggested fix id is not present in the top-level fix list.",
+      "evidence": "The changed hunk is available.",
+      "confidence": 0.8,
+      "anchors": [
+        {
+          "kind": "inline",
+          "path": "src/ratio.rs",
+          "line": 3
+        }
+      ],
+      "citations": [],
+      "suggested_fixes": [
+        "missing-fix"
+      ]
+    }
+  ],
+  "comments": [],
+  "suggested_fixes": [],
+  "citations": [],
+  "receipts": [],
+  "run": {
+    "engine_version": "cerberus-fixture",
+    "config_digest": "sha256:fixture",
+    "started_at": "{{now}}",
+    "finished_at": "{{now}}",
+    "duration_ms": 1,
+    "cost_usd": null,
+    "coverage": {
+      "files_reviewed": [
+        "src/ratio.rs"
+      ],
+      "files_with_findings": [
+        "src/ratio.rs"
+      ]
+    }
+  },
+  "errors": []
+}
+-----END CERBERUS_REVIEW_ARTIFACT_V1-----

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -17,6 +17,69 @@ grep -Eq '^  pr([[:space:]]|$)' target/cerberus-request-help.txt
 rm -rf target/cerberus
 mkdir -p target/cerberus
 
+expect_review_failure() {
+  local name="$1"
+  local fixture="$2"
+
+  if cargo run --locked -- review \
+    --request fixtures/requests/diff-only.json \
+    --harness fixture \
+    --fixture-output "$fixture" \
+    --out "target/cerberus/${name}-artifact.json" \
+    --execution-plan "target/cerberus/${name}-execution_plan.json" \
+    --transcript "target/cerberus/${name}-transcript.txt" \
+    > "target/cerberus/${name}.stdout" \
+    2> "target/cerberus/${name}.stderr"; then
+    echo "expected fixture review to fail: ${name}" >&2
+    exit 1
+  fi
+}
+
+cat fixtures/harness/pass-review.txt fixtures/harness/pass-review.txt \
+  > target/cerberus/invalid-duplicate-artifacts.txt
+artifact_json="$(awk '
+  /-----BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----/ { inside = 1; next }
+  /-----END CERBERUS_REVIEW_ARTIFACT_V1-----/ { inside = 0 }
+  inside { print }
+' fixtures/harness/pass-review.txt)"
+{
+  cat fixtures/harness/pass-review.txt
+  printf '\n<CERBERUS_REVIEW_ARTIFACT_V1>\n%s\n</CERBERUS_REVIEW_ARTIFACT_V1>\n' "$artifact_json"
+} > target/cerberus/invalid-duplicate-marker-xml-artifacts.txt
+{
+  cat fixtures/harness/pass-review.txt
+  printf '\n%s\n' "$artifact_json"
+} > target/cerberus/invalid-duplicate-marker-raw-artifacts.txt
+{
+  printf '<CERBERUS_REVIEW_ARTIFACT_V1>\n%s\n</CERBERUS_REVIEW_ARTIFACT_V1>\n' "$artifact_json"
+  printf '<CERBERUS_REVIEW_ARTIFACT_V1>\n%s\n</CERBERUS_REVIEW_ARTIFACT_V1>\n' "$artifact_json"
+} > target/cerberus/invalid-duplicate-xml-artifacts.txt
+{
+  printf '<CERBERUS_REVIEW_ARTIFACT_V1>\n%s\n</CERBERUS_REVIEW_ARTIFACT_V1>\n' "$artifact_json"
+  printf '%s\n' "$artifact_json"
+} > target/cerberus/invalid-duplicate-xml-raw-artifacts.txt
+printf '%s\n%s\n' "$artifact_json" "$artifact_json" \
+  > target/cerberus/invalid-duplicate-raw-artifacts.txt
+expect_review_failure duplicate-artifacts target/cerberus/invalid-duplicate-artifacts.txt
+expect_review_failure duplicate-marker-xml-artifacts target/cerberus/invalid-duplicate-marker-xml-artifacts.txt
+expect_review_failure duplicate-marker-raw-artifacts target/cerberus/invalid-duplicate-marker-raw-artifacts.txt
+expect_review_failure duplicate-xml-artifacts target/cerberus/invalid-duplicate-xml-artifacts.txt
+expect_review_failure duplicate-xml-raw-artifacts target/cerberus/invalid-duplicate-xml-raw-artifacts.txt
+expect_review_failure duplicate-raw-artifacts target/cerberus/invalid-duplicate-raw-artifacts.txt
+expect_review_failure unknown-finding-id fixtures/harness/invalid-unknown-finding-id.txt
+expect_review_failure unknown-suggested-fix fixtures/harness/invalid-unknown-suggested-fix.txt
+expect_review_failure orphan-suggested-fix fixtures/harness/invalid-orphan-suggested-fix.txt
+
+grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-artifacts.stderr
+grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-marker-xml-artifacts.stderr
+grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-marker-raw-artifacts.stderr
+grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-xml-artifacts.stderr
+grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-xml-raw-artifacts.stderr
+grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-raw-artifacts.stderr
+grep -q 'references unknown finding id' target/cerberus/unknown-finding-id.stderr
+grep -q 'references unknown suggested fix id' target/cerberus/unknown-suggested-fix.stderr
+grep -q 'top-level suggested fix is not attached' target/cerberus/orphan-suggested-fix.stderr
+
 tmp_repo="$(mktemp -d)"
 trap 'rm -rf "$tmp_repo"' EXIT
 git -C "$tmp_repo" init -q

--- a/spec.md
+++ b/spec.md
@@ -163,11 +163,14 @@ The harness must:
 - write request and prompt material to private files, not argv;
 - scrub inherited environment variables by default;
 - pass only explicitly allowed provider keys and runtime variables;
+- resolve substrate binaries only from explicit absolute paths or the
+  harness-owned trusted search path, never from the parent process `PATH`;
 - use an isolated session/profile path where practical;
 - bound wall time and captured output;
 - kill child processes on timeout;
 - capture stdout/stderr as receipts;
-- require exactly one marked `ReviewArtifact.v1` block in agent output;
+- require exactly one `ReviewArtifact.v1` candidate across marker, XML wrapper,
+  and raw JSON fallback formats;
 - validate the artifact against the request digest and capabilities.
 
 OpenCode invocation should start from this posture:
@@ -230,12 +233,17 @@ Do not start by building:
 Safety footguns to test:
 
 - prompt or diff material appearing in argv;
+- hostile parent `PATH` selecting a different OpenCode or OMP binary than the
+  child process would receive;
 - ambient `GH_TOKEN`, SSH agent, cloud credentials, or repo `.env` entering
   the child env;
 - unbounded stdout/stderr;
 - orphan child processes after timeout;
-- invalid, multiple, or missing artifact marker blocks;
+- invalid, multiple, or missing artifact candidates across marker, XML wrapper,
+  and raw JSON fallback formats;
 - artifact claims beyond declared context capabilities.
+- artifact comments, findings, citations, and suggested fixes referencing
+  unknown IDs or leaving top-level fixes unattached to a finding or comment.
 
 ## CLI Surface
 

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -166,8 +166,9 @@ impl ReviewHarness {
             workspace_mode: workspace.mode().to_string(),
         };
 
+        let trusted_search_path = trusted_executable_search_path();
         let start = Instant::now();
-        let executable = resolve_executable(&binary).unwrap_or(binary);
+        let executable = resolve_executable_in(&binary, &trusted_search_path)?;
         let mut command = Command::new(&executable);
         command
             .args(&args)
@@ -177,7 +178,7 @@ impl ReviewHarness {
         for (key, value) in allowed_child_env(&request.policy.allowed_env) {
             command.env(key, value);
         }
-        command.env("PATH", controlled_path());
+        command.env("PATH", join_search_path(&trusted_search_path));
         command.env("HOME", &child_home);
         command.env("XDG_CACHE_HOME", &child_cache);
         command.env("XDG_CONFIG_HOME", &child_config);
@@ -508,38 +509,80 @@ fn allowed_child_env(allowed_env: &[String]) -> BTreeMap<String, String> {
         .collect()
 }
 
-fn controlled_path() -> String {
+fn trusted_executable_search_path() -> Vec<PathBuf> {
     let mut paths = vec![
-        "/usr/bin".to_string(),
-        "/bin".to_string(),
-        "/usr/sbin".to_string(),
-        "/sbin".to_string(),
+        PathBuf::from("/usr/bin"),
+        PathBuf::from("/bin"),
+        PathBuf::from("/usr/sbin"),
+        PathBuf::from("/sbin"),
     ];
     for candidate in ["/opt/homebrew/bin", "/usr/local/bin"] {
         if Path::new(candidate).is_dir() {
-            paths.push(candidate.to_string());
+            paths.push(PathBuf::from(candidate));
         }
     }
     if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
         for relative in [".bun/bin", ".opencode/bin", ".local/bin"] {
             let candidate = home.join(relative);
             if candidate.is_dir() {
-                paths.push(candidate.display().to_string());
+                paths.push(candidate);
             }
         }
     }
-    paths.join(":")
+    paths
 }
 
-fn resolve_executable(binary: &str) -> Option<String> {
-    if binary.contains('/') {
-        return Some(binary.to_string());
+fn join_search_path(paths: &[PathBuf]) -> String {
+    std::env::join_paths(paths)
+        .map(|joined| joined.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| {
+            paths
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(":")
+        })
+}
+
+fn resolve_executable_in(binary: &str, search_paths: &[PathBuf]) -> Result<PathBuf> {
+    let path = Path::new(binary);
+    if path.is_absolute() {
+        if is_executable_file(path) {
+            return Ok(path.to_path_buf());
+        }
+        return Err(anyhow!(
+            "absolute harness binary is not executable: {}",
+            path.display()
+        ));
     }
-    let paths = std::env::var_os("PATH")?;
-    std::env::split_paths(&paths)
+    if binary.contains('/') || binary.contains('\\') {
+        return Err(anyhow!(
+            "harness binary must be an absolute path or a bare name from the trusted search path: {binary}"
+        ));
+    }
+    search_paths
+        .iter()
         .map(|path| path.join(binary))
-        .find(|path| path.is_file())
-        .map(|path| path.display().to_string())
+        .find(|candidate| is_executable_file(candidate))
+        .ok_or_else(|| {
+            anyhow!(
+                "harness binary {binary:?} was not found in trusted search path: {}",
+                join_search_path(search_paths)
+            )
+        })
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
 }
 
 #[cfg(unix)]
@@ -716,65 +759,102 @@ fn unix_timestamp_string() -> String {
 }
 
 pub fn extract_marked_artifact(transcript: &str) -> Result<ReviewArtifact> {
-    let marked_json = extract_json_between_markers(transcript, ARTIFACT_BEGIN, ARTIFACT_END)
-        .or_else(|| extract_xml_wrapped_artifact_json(transcript))
-        .or_else(|| extract_unmarked_artifact_json(transcript));
-    let Some(json) = marked_json else {
+    let mut candidates = Vec::new();
+    let marker_candidates =
+        extract_json_between_markers(transcript, ARTIFACT_BEGIN, ARTIFACT_END, "marker");
+    let xml_candidates = extract_json_between_markers(
+        transcript,
+        "<CERBERUS_REVIEW_ARTIFACT_V1>",
+        "</CERBERUS_REVIEW_ARTIFACT_V1>",
+        "xml",
+    );
+    let explicit_spans = marker_candidates
+        .iter()
+        .chain(xml_candidates.iter())
+        .map(|candidate| (candidate.start, candidate.end))
+        .collect::<Vec<_>>();
+    let raw_candidates = extract_unmarked_artifact_json(transcript, &explicit_spans);
+    let marker_count = marker_candidates.len();
+    let xml_count = xml_candidates.len();
+    let raw_count = raw_candidates.len();
+    candidates.extend(marker_candidates);
+    candidates.extend(xml_candidates);
+    candidates.extend(raw_candidates);
+
+    if candidates.len() != 1 {
         let begin_count = transcript.matches(ARTIFACT_BEGIN).count();
         let end_count = transcript.matches(ARTIFACT_END).count();
         let xml_begin_count = transcript.matches("<CERBERUS_REVIEW_ARTIFACT_V1>").count();
         let xml_end_count = transcript.matches("</CERBERUS_REVIEW_ARTIFACT_V1>").count();
         return Err(anyhow!(
-            "expected exactly one artifact block, found {begin_count} begin markers, {end_count} end markers, {xml_begin_count} xml begin markers, and {xml_end_count} xml end markers"
+            "expected exactly one ReviewArtifact.v1 candidate, found {marker_count} marker, {xml_count} xml, and {raw_count} raw candidates ({begin_count} begin markers, {end_count} end markers, {xml_begin_count} xml begin markers, {xml_end_count} xml end markers)"
         ));
-    };
-    serde_json::from_str(&json).context("parse ReviewArtifact.v1 block")
-}
-
-fn extract_json_between_markers(transcript: &str, begin: &str, end: &str) -> Option<String> {
-    let start = transcript.find(begin)? + begin.len();
-    let remainder = &transcript[start..];
-    let finish = remainder.find(end)?;
-    let candidate = strip_markdown_json_fence(&remainder[..finish]);
-    if candidate.is_empty() {
-        None
-    } else {
-        Some(candidate.to_string())
     }
+    serde_json::from_str(&candidates.remove(0).json).context("parse ReviewArtifact.v1 block")
 }
 
-fn extract_xml_wrapped_artifact_json(transcript: &str) -> Option<String> {
-    let candidate = extract_json_between_markers(
-        transcript,
-        "<CERBERUS_REVIEW_ARTIFACT_V1>",
-        "</CERBERUS_REVIEW_ARTIFACT_V1>",
-    )?;
-    let parsed = serde_json::from_str::<ReviewArtifact>(&candidate).ok()?;
-    if parsed.schema_version == REVIEW_ARTIFACT_SCHEMA {
-        Some(candidate)
-    } else {
-        None
+#[derive(Debug)]
+struct ArtifactCandidate {
+    json: String,
+    start: usize,
+    end: usize,
+}
+
+fn extract_json_between_markers(
+    transcript: &str,
+    begin: &str,
+    end: &str,
+    _format: &'static str,
+) -> Vec<ArtifactCandidate> {
+    let mut candidates = Vec::new();
+    let mut cursor = 0;
+    while let Some(relative_start) = transcript[cursor..].find(begin) {
+        let block_start = cursor + relative_start;
+        let content_start = block_start + begin.len();
+        let Some(relative_end) = transcript[content_start..].find(end) else {
+            break;
+        };
+        let content_end = content_start + relative_end;
+        let block_end = content_end + end.len();
+        let candidate = strip_markdown_json_fence(&transcript[content_start..content_end]);
+        if !candidate.is_empty() {
+            candidates.push(ArtifactCandidate {
+                json: candidate.to_string(),
+                start: block_start,
+                end: block_end,
+            });
+        }
+        cursor = block_end;
     }
+    candidates
 }
 
-fn extract_unmarked_artifact_json(transcript: &str) -> Option<String> {
-    let schema_index = transcript.find(REVIEW_ARTIFACT_SCHEMA)?;
-    let mut starts: Vec<usize> = transcript[..schema_index]
-        .match_indices('{')
-        .map(|(index, _)| index)
-        .collect();
-    starts.reverse();
-    for start in starts {
+fn extract_unmarked_artifact_json(
+    transcript: &str,
+    excluded_spans: &[(usize, usize)],
+) -> Vec<ArtifactCandidate> {
+    let mut candidates = Vec::new();
+    for (start, _) in transcript.match_indices('{') {
+        if excluded_spans
+            .iter()
+            .any(|(span_start, span_end)| start >= *span_start && start < *span_end)
+        {
+            continue;
+        }
         let slice = &transcript[start..];
         let mut deserializer = serde_json::Deserializer::from_str(slice);
         let Ok(value) = Value::deserialize(&mut deserializer) else {
             continue;
         };
         if value.get("schema_version").and_then(Value::as_str) == Some(REVIEW_ARTIFACT_SCHEMA) {
-            return Some(value.to_string());
+            candidates.push(ArtifactCandidate {
+                json: value.to_string(),
+                start,
+                end: start,
+            });
         }
     }
-    None
+    candidates
 }
 
 fn strip_markdown_json_fence(raw: &str) -> &str {
@@ -878,11 +958,64 @@ mod tests {
 
     #[test]
     fn rejects_multiple_marker_blocks() {
+        let artifact = minimal_artifact_json();
         let transcript = format!(
-            "{begin}{{}}{end}\n{begin}{{}}{end}",
+            "{begin}{artifact}{end}\n{begin}{artifact}{end}",
             begin = ARTIFACT_BEGIN,
+            artifact = artifact,
             end = ARTIFACT_END
         );
+        assert!(extract_marked_artifact(&transcript).is_err());
+    }
+
+    #[test]
+    fn rejects_marker_and_xml_artifact_candidates_together() {
+        let artifact = minimal_artifact_json();
+        let transcript = format!(
+            "{begin}{artifact}{end}\n<CERBERUS_REVIEW_ARTIFACT_V1>{artifact}</CERBERUS_REVIEW_ARTIFACT_V1>",
+            begin = ARTIFACT_BEGIN,
+            artifact = artifact,
+            end = ARTIFACT_END
+        );
+        assert!(extract_marked_artifact(&transcript).is_err());
+    }
+
+    #[test]
+    fn rejects_marker_and_raw_artifact_candidates_together() {
+        let artifact = minimal_artifact_json();
+        let transcript = format!(
+            "{begin}{artifact}{end}\n{artifact}",
+            begin = ARTIFACT_BEGIN,
+            artifact = artifact,
+            end = ARTIFACT_END
+        );
+        assert!(extract_marked_artifact(&transcript).is_err());
+    }
+
+    #[test]
+    fn rejects_multiple_xml_artifact_candidates() {
+        let artifact = minimal_artifact_json();
+        let transcript = format!(
+            "<CERBERUS_REVIEW_ARTIFACT_V1>{artifact}</CERBERUS_REVIEW_ARTIFACT_V1>\n<CERBERUS_REVIEW_ARTIFACT_V1>{artifact}</CERBERUS_REVIEW_ARTIFACT_V1>",
+            artifact = artifact
+        );
+        assert!(extract_marked_artifact(&transcript).is_err());
+    }
+
+    #[test]
+    fn rejects_xml_and_raw_artifact_candidates_together() {
+        let artifact = minimal_artifact_json();
+        let transcript = format!(
+            "<CERBERUS_REVIEW_ARTIFACT_V1>{artifact}</CERBERUS_REVIEW_ARTIFACT_V1>\n{artifact}",
+            artifact = artifact
+        );
+        assert!(extract_marked_artifact(&transcript).is_err());
+    }
+
+    #[test]
+    fn rejects_multiple_raw_artifact_candidates() {
+        let artifact = minimal_artifact_json();
+        let transcript = format!("first\n{artifact}\nsecond\n{artifact}", artifact = artifact);
         assert!(extract_marked_artifact(&transcript).is_err());
     }
 
@@ -961,6 +1094,41 @@ mod tests {
         assert!(!text.contains("\"type\":\"text\""));
         assert_eq!(extract_marked_artifact(&text).unwrap().request_id, "req-1");
     }
+
+    #[test]
+    fn bare_substrate_binary_resolves_only_from_trusted_search_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let hostile_dir = temp.path().join("hostile-bin");
+        let trusted_dir = temp.path().join("trusted-bin");
+        fs::create_dir(&hostile_dir).unwrap();
+        fs::create_dir(&trusted_dir).unwrap();
+        let binary_name = "cerberus-test-opencode";
+        let hostile_binary = hostile_dir.join(binary_name);
+        let trusted_binary = trusted_dir.join(binary_name);
+        fs::write(&hostile_binary, "#!/bin/sh\nexit 1\n").unwrap();
+        fs::write(&trusted_binary, "#!/bin/sh\nexit 0\n").unwrap();
+        set_executable(&hostile_binary);
+        set_executable(&trusted_binary);
+
+        let resolved = resolve_executable_in(binary_name, &[trusted_dir]).unwrap();
+
+        assert_eq!(resolved, trusted_binary);
+    }
+
+    #[test]
+    fn relative_substrate_binary_paths_are_rejected() {
+        assert!(resolve_executable_in("./opencode", &[]).is_err());
+    }
+
+    #[cfg(unix)]
+    fn set_executable(path: &Path) {
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(not(unix))]
+    fn set_executable(_path: &Path) {}
 
     #[test]
     fn opencode_artifact_scan_falls_back_to_transcript_without_text_events() {

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -153,9 +153,12 @@ impl ReviewHarness {
             },
         )?;
 
+        let trusted_search_path = trusted_executable_search_path();
+        let executable = resolve_executable_in(&binary, &trusted_search_path)?;
+
         let plan = ExecutionPlan {
             harness: plan_harness.to_string(),
-            command: binary.clone(),
+            command: executable.display().to_string(),
             args: redact_prompt_path(&args),
             cwd: workspace.path().display().to_string(),
             timeout_ms: self.timeout.as_millis() as u64,
@@ -166,9 +169,7 @@ impl ReviewHarness {
             workspace_mode: workspace.mode().to_string(),
         };
 
-        let trusted_search_path = trusted_executable_search_path();
         let start = Instant::now();
-        let executable = resolve_executable_in(&binary, &trusted_search_path)?;
         let mut command = Command::new(&executable);
         command
             .args(&args)
@@ -540,9 +541,15 @@ fn join_search_path(paths: &[PathBuf]) -> String {
                 .iter()
                 .map(|path| path.display().to_string())
                 .collect::<Vec<_>>()
-                .join(":")
+                .join(PATH_LIST_SEPARATOR)
         })
 }
+
+#[cfg(windows)]
+const PATH_LIST_SEPARATOR: &str = ";";
+
+#[cfg(not(windows))]
+const PATH_LIST_SEPARATOR: &str = ":";
 
 fn resolve_executable_in(binary: &str, search_paths: &[PathBuf]) -> Result<PathBuf> {
     let path = Path::new(binary);

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -410,7 +410,11 @@ mod tests {
             suggested_fixes: Vec::new(),
         });
 
-        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+        assert!(matches!(
+            validate_artifact_for_request(&artifact, &request),
+            Err(ValidationError::UnknownFindingReference { scope, finding_id })
+                if scope == "comment c-1" && finding_id == "missing-finding"
+        ));
     }
 
     #[test]
@@ -421,7 +425,13 @@ mod tests {
             .findings
             .push(anchored_finding_with_fix("f-1", "missing-fix"));
 
-        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+        assert!(matches!(
+            validate_artifact_for_request(&artifact, &request),
+            Err(ValidationError::UnknownSuggestedFixReference {
+                scope,
+                suggested_fix_id,
+            }) if scope == "finding f-1" && suggested_fix_id == "missing-fix"
+        ));
     }
 
     #[test]
@@ -439,7 +449,13 @@ mod tests {
             suggested_fixes: vec!["missing-fix".to_string()],
         });
 
-        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+        assert!(matches!(
+            validate_artifact_for_request(&artifact, &request),
+            Err(ValidationError::UnknownSuggestedFixReference {
+                scope,
+                suggested_fix_id,
+            }) if scope == "comment c-1" && suggested_fix_id == "missing-fix"
+        ));
     }
 
     #[test]
@@ -450,7 +466,11 @@ mod tests {
             .suggested_fixes
             .push(suggested_fix("fix-1", Some("missing-finding".to_string())));
 
-        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+        assert!(matches!(
+            validate_artifact_for_request(&artifact, &request),
+            Err(ValidationError::UnknownFindingReference { scope, finding_id })
+                if scope == "suggested fix fix-1" && finding_id == "missing-finding"
+        ));
     }
 
     #[test]
@@ -459,7 +479,10 @@ mod tests {
         let mut artifact = artifact_for(&request);
         artifact.suggested_fixes.push(suggested_fix("fix-1", None));
 
-        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+        assert!(matches!(
+            validate_artifact_for_request(&artifact, &request),
+            Err(ValidationError::OrphanSuggestedFix(id)) if id == "fix-1"
+        ));
     }
 
     fn inline_anchor() -> Anchor {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -40,6 +40,15 @@ pub enum ValidationError {
     FindingMissingAnchor(String),
     #[error("finding references unknown citation id: {0}")]
     UnknownCitation(String),
+    #[error("{scope} references unknown finding id: {finding_id}")]
+    UnknownFindingReference { scope: String, finding_id: String },
+    #[error("{scope} references unknown suggested fix id: {suggested_fix_id}")]
+    UnknownSuggestedFixReference {
+        scope: String,
+        suggested_fix_id: String,
+    },
+    #[error("top-level suggested fix is not attached to any finding or comment: {0}")]
+    OrphanSuggestedFix(String),
     #[error("citation {0} references unknown finding id {1}")]
     CitationReferencesUnknownFinding(String, String),
     #[error("url citation {0} is missing observed_at")]
@@ -128,6 +137,12 @@ pub fn validate_artifact_for_request(
         .iter()
         .map(|citation| citation.id.as_str())
         .collect();
+    let suggested_fix_ids: HashSet<&str> = artifact
+        .suggested_fixes
+        .iter()
+        .map(|fix| fix.id.as_str())
+        .collect();
+    let mut referenced_fix_ids: HashSet<&str> = HashSet::new();
 
     for finding in &artifact.findings {
         if finding.anchors.is_empty() {
@@ -140,6 +155,15 @@ pub fn validate_artifact_for_request(
             if !citation_ids.contains(citation_id.as_str()) {
                 return Err(ValidationError::UnknownCitation(citation_id.clone()));
             }
+        }
+        for suggested_fix_id in &finding.suggested_fixes {
+            if !suggested_fix_ids.contains(suggested_fix_id.as_str()) {
+                return Err(ValidationError::UnknownSuggestedFixReference {
+                    scope: format!("finding {}", finding.id),
+                    suggested_fix_id: suggested_fix_id.clone(),
+                });
+            }
+            referenced_fix_ids.insert(suggested_fix_id.as_str());
         }
         if request.policy.external_research == ExternalResearchPolicy::RequireCitations
             && finding.citations.is_empty()
@@ -155,6 +179,23 @@ pub fn validate_artifact_for_request(
             return Err(ValidationError::InlineCommentAnchorMismatch);
         }
         validate_anchor(&comment.anchor, &changed_paths)?;
+        if let Some(finding_id) = &comment.finding_id {
+            if !finding_ids.contains(finding_id.as_str()) {
+                return Err(ValidationError::UnknownFindingReference {
+                    scope: format!("comment {}", comment.id),
+                    finding_id: finding_id.clone(),
+                });
+            }
+        }
+        for suggested_fix_id in &comment.suggested_fixes {
+            if !suggested_fix_ids.contains(suggested_fix_id.as_str()) {
+                return Err(ValidationError::UnknownSuggestedFixReference {
+                    scope: format!("comment {}", comment.id),
+                    suggested_fix_id: suggested_fix_id.clone(),
+                });
+            }
+            referenced_fix_ids.insert(suggested_fix_id.as_str());
+        }
     }
 
     let citations_by_id: HashMap<&str, _> = artifact
@@ -175,6 +216,20 @@ pub fn validate_artifact_for_request(
                     finding_id.clone(),
                 ));
             }
+        }
+    }
+
+    for fix in &artifact.suggested_fixes {
+        if let Some(finding_id) = &fix.finding_id {
+            if !finding_ids.contains(finding_id.as_str()) {
+                return Err(ValidationError::UnknownFindingReference {
+                    scope: format!("suggested fix {}", fix.id),
+                    finding_id: finding_id.clone(),
+                });
+            }
+        }
+        if fix.finding_id.is_none() && !referenced_fix_ids.contains(fix.id.as_str()) {
+            return Err(ValidationError::OrphanSuggestedFix(fix.id.clone()));
         }
     }
 
@@ -338,5 +393,109 @@ mod tests {
             validate_artifact_for_request(&artifact, &request),
             Err(ValidationError::FindingMissingAnchor(id)) if id == "f-1"
         ));
+    }
+
+    #[test]
+    fn rejects_comment_with_unknown_finding_id() {
+        let request = request();
+        let mut artifact = artifact_for(&request);
+        artifact.comments.push(Comment {
+            id: "c-1".to_string(),
+            kind: CommentKind::Inline,
+            intent: CommentIntent::Finding,
+            finding_id: Some("missing-finding".to_string()),
+            body: "This comment points at a finding that does not exist.".to_string(),
+            anchor: inline_anchor(),
+            dedupe_key: None,
+            suggested_fixes: Vec::new(),
+        });
+
+        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+    }
+
+    #[test]
+    fn rejects_finding_with_unknown_suggested_fix() {
+        let request = request();
+        let mut artifact = artifact_for(&request);
+        artifact
+            .findings
+            .push(anchored_finding_with_fix("f-1", "missing-fix"));
+
+        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+    }
+
+    #[test]
+    fn rejects_comment_with_unknown_suggested_fix() {
+        let request = request();
+        let mut artifact = artifact_for(&request);
+        artifact.comments.push(Comment {
+            id: "c-1".to_string(),
+            kind: CommentKind::Inline,
+            intent: CommentIntent::Finding,
+            finding_id: None,
+            body: "This comment points at a fix that does not exist.".to_string(),
+            anchor: inline_anchor(),
+            dedupe_key: None,
+            suggested_fixes: vec!["missing-fix".to_string()],
+        });
+
+        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+    }
+
+    #[test]
+    fn rejects_suggested_fix_with_unknown_finding_id() {
+        let request = request();
+        let mut artifact = artifact_for(&request);
+        artifact
+            .suggested_fixes
+            .push(suggested_fix("fix-1", Some("missing-finding".to_string())));
+
+        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+    }
+
+    #[test]
+    fn rejects_orphan_top_level_suggested_fix() {
+        let request = request();
+        let mut artifact = artifact_for(&request);
+        artifact.suggested_fixes.push(suggested_fix("fix-1", None));
+
+        assert!(validate_artifact_for_request(&artifact, &request).is_err());
+    }
+
+    fn inline_anchor() -> Anchor {
+        Anchor {
+            kind: AnchorKind::Inline,
+            path: Some("src/lib.rs".to_string()),
+            line: Some(1),
+            start_line: None,
+            end_line: None,
+            hunk_digest: None,
+        }
+    }
+
+    fn anchored_finding_with_fix(id: &str, suggested_fix: &str) -> Finding {
+        Finding {
+            id: id.to_string(),
+            severity: Severity::Major,
+            category: "correctness".to_string(),
+            title: "bad fix reference".to_string(),
+            description: "references a fix that does not exist".to_string(),
+            evidence: "diff".to_string(),
+            confidence: 0.9,
+            anchors: vec![inline_anchor()],
+            citations: Vec::new(),
+            suggested_fixes: vec![suggested_fix.to_string()],
+        }
+    }
+
+    fn suggested_fix(id: &str, finding_id: Option<String>) -> SuggestedFix {
+        SuggestedFix {
+            id: id.to_string(),
+            finding_id,
+            applicability: FixApplicability::NeedsReview,
+            format: FixFormat::Instructions,
+            edits: Vec::new(),
+            diff: None,
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add hosted `Verify` workflow that runs `./scripts/verify.sh` on PRs and pushes
- resolve OpenCode/OMP executables through absolute executable paths or the harness-owned trusted search path, never parent `PATH`
- reject duplicate `ReviewArtifact.v1` candidates across marker/XML/raw formats plus unknown finding/fix references and orphan top-level fixes
- add adversarial fixture coverage for malformed artifacts in the repo gate

## Verification
- `cargo fmt && ./scripts/verify.sh`
- Gate evidence included 41 Rust tests, CLI help smoke, fixture review/render, fake OpenCode/OMP runs, and expected-failure CLI fixtures for duplicate marker+marker, marker+xml, marker+raw, xml+xml, xml+raw, raw+raw, unknown finding id, unknown suggested fix id, and orphan suggested fix.

## Review
- Fresh critic initially returned `BLOCKING: yes` on workflow push scope and incomplete duplicate-format gate proof.
- Fixed workflow to run on every push and added all pairwise duplicate-format CLI failure cases.
- Final focused re-review returned `BLOCKING: no`.

Backlog: `001-execution-evidence-hardening`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved validation of review artifacts by detecting unknown finding/suggested-fix references and orphaned suggested fixes.
  * Hardened artifact parsing to accept only exactly one valid artifact candidate per run (marker, XML, or raw JSON).

* **Documentation**
  * Published execution-evidence hardening plan and tightened runtime/safety requirements.

* **Bug Fixes**
  * Restricted substrate binary resolution to trusted paths and rejected unsafe PATH/relative binaries.

* **Tests / Chores**
  * Added verification workflow and expanded negative fixtures to cover new validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->