### PR TITLE
Reshape 013: make the credential worthless (scoped ephemeral key)

### DIFF
--- a/backlog.d/013-container-runtime-untrusted-isolation.md
+++ b/backlog.d/013-container-runtime-untrusted-isolation.md
@@ -1,35 +1,35 @@
-# Container runtime for untrusted-PR review isolation
+# Isolate untrusted-PR review: scoped ephemeral credential + light container
 
 Priority: P1 · Status: ready · Estimate: L · Shape: docs/plans/013-container-isolation.html
 
 ## Goal
-Let a fully-capable Cerberus agent review UNTRUSTED third-party PRs without the model credential ever being obtainable or exfiltrable — by keeping the key out of the container, not by trusting an egress filter.
+Let a fully-capable Cerberus agent review UNTRUSTED third-party PRs safely by breaking the lethal trifecta at the cheapest leg — make the model credential *worthless* (per-review, capped, revoked) rather than hiding a powerful one — with a lightweight container for non-credential damage.
 
 ## Non-Goals
 - Not a hosted multi-tenant service (local/CI spawns a container behind the same kernel).
-- Not for trusted self-review (that stays on the local/worktree harness; key-in-env is fine for our own code).
-- Never sell any key-in-container or local path as "untrusted-safe."
+- Not for trusted self-review (that stays on the local/worktree harness).
+- Never call the local/un-scoped path "untrusted-safe."
 
 ## Oracle
-- [ ] A `--harness container-opencode` review runs in Docker on an internal network with the disposable tree mounted as a `.git`-less `git archive` extract (NOT a linked worktree), host checkout never mounted.
-- [ ] `printenv` inside the container shows NO `OPENROUTER_API_KEY`; the model call still succeeds via a key-injecting sidecar that holds the key.
-- [ ] No in-container resolver: zero outbound UDP/53; only sidecar/model egress in the network log.
-- [ ] A red-team fixture FAMILY (DNS exfil, endpoint-as-sink, output-encoding, file-write, worktree-escape) all fail to surface the key; the key value + transforms appear in no output/artifact/written file.
-- [ ] Host checkout digest unchanged after the run; a normal review still yields a valid `ReviewArtifact.v1`.
+- [ ] Each untrusted review mints a per-review OpenRouter key with a USD `limit` (provisioning API), injects it, and `DELETE`s it on teardown.
+- [ ] **Steal-and-replay:** a key captured mid-run FAILS after teardown (401 revoked / 402 over-cap); the minted key GET returns 404/disabled.
+- [ ] **Crash safety:** killing the run mid-review leaves no usable key — an orphan-key sweeper revokes review-tagged keys on the next run.
+- [ ] The container blocks non-model egress (`curl evil.com` fails), mounts a `.git`-less `git archive` tree (not a worktree), never mounts the host checkout; host digest unchanged.
+- [ ] A normal review still yields a valid `ReviewArtifact.v1`; `verify.sh` green (container path skipped without Docker).
 
 ## Verification System
-- Claim: a prompt-injected agent on an untrusted PR cannot obtain or exfiltrate the model credential by any vector, because it is never in the container.
-- Falsifier: any red-team fixture surfaces the key; the key is found in container env/fs; the mounted tree has `.git`; the host checkout mutates; a clean review can't produce a valid artifact.
-- Driver: the red-team family through `--harness container-opencode` with network capture + in-container key-absence probe + output key-scan.
-- Grader: network log (no UDP/53, only model egress) + key-absence probe + key-scan (literal & transforms) + host-tree digest + artifact validation. One canned fixture is insufficient — grow the family on each near-miss.
-- Evidence packet: network capture, fixture family, key-absence probe, container execution plan under `target/cerberus/container-*`.
-- Cadence: gated in `verify.sh` when Docker present; on every change to the container/proxy/mount path.
-- Gaps/waiver: "untrusted-safe" attaches only to key-out + no-resolver + clone-not-worktree (M1+M2); M3 egress-allowlist/scrub is depth. The model-domain pin must track the provider's hosts.
+- Claim: a prompt-injected agent on an untrusted PR cannot obtain a credential worth stealing or reach a non-model host; any credential it captures is capped and revoked by run-end.
+- Falsifier: the minted key outlives the run; the key has no cap; a stolen key still works post-run; the agent reaches a non-model host; the host checkout mutates; a clean review can't produce a valid artifact.
+- Driver: steal-and-replay probe + crash-injection (kill mid-run → sweeper revokes) + red-team container family with egress capture.
+- Grader: post-run the minted key is dead (API) and was capped; egress log model-only; host-tree digest unchanged; artifact validates.
+- Evidence packet: key create/delete transcript, steal-and-replay result, crash-sweeper log, egress capture under `target/cerberus/container-*`.
+- Cadence: key-lifecycle tests always; container red-team gated on Docker in `verify.sh`; on every change to the credential/sandbox path.
+- Gaps/waiver: residual = a stolen key usable for seconds up to the cap until DELETE; accepted. Provisioning key is secret-zero (host-side). Provider lock-in → option B (key-out proxy) fallback.
 
 ## Children
-1. **M1 harness:** `container-opencode` substrate (docker run, internal network, `.git`-less tree mount, host not mounted), failing closed; the red-team fixture family; pinned Dockerfile (opencode + git + rg + ast-grep).
-2. **M2 key-out (floor):** key-injecting sidecar (key never in container) + no in-container resolver. Earns the untrusted-capable label.
-3. **M3 depth:** domain egress-allowlist at the sidecar + structural artifact-field validation (entropy/length) + backstop scrub for any other secrets.
+1. **M1 scoped-key lifecycle (floor):** mint-cap-use-revoke + crash-safe teardown (`Drop`/finally) + orphan-key sweeper + the steal-and-replay probe. Testable without a container.
+2. **M2 lightweight container (depth):** `container-opencode` substrate — `.git`-less archive mount, host not mounted, non-model egress blocked, internal network; red-team fixture family (DNS/endpoint/output/file-write/worktree-escape) for non-credential damage.
+3. **M3 optional upgrades:** key-out proxy (B, providers without scoped keys) or managed sandbox (D, microVM-grade) behind the same seam — no schema change.
 
 ## Notes
-**Why:** surfaced by the tracer-bullet (PR #466) critique; shaped 2026-06-22. A security critic dismantled the first design (egress-allowlist + key in container): DNS bypasses a CONNECT proxy, and the one allowlisted host (the model API) is itself an exfil sink while the agent holds the key — so egress filtering is ~zero protection for untrusted code; a transform-denylist output scrub is unwinnable; the mounted `git worktree` is a live handle to the host `.git` (verified). Hence **key-out is the floor, not optional**. Trusted self-review is unaffected (stays local). Full design + alternatives + red-team verification in the linked HTML plan.
+**Why:** shaped over two adversarial rounds (2026-06-22/23). Round 1 critic killed the egress-allowlist + key-in-container design (DNS bypasses a CONNECT proxy; the allowlisted model endpoint is itself an exfil sink while the agent holds a valuable key; transform-denylist scrub is unwinnable; a `git worktree` mount is a host `.git` handle). Round 2 (premise challenge + research) reframed via the lethal trifecta (Willison): break the *value* leg with a scoped ephemeral key — Anthropic's production pattern for Claude Code sandboxing — which dissolves the round-1 attacks (a worthless key isn't worth tunneling, and can't outspend its cap before revocation). Grounded: OpenRouter provisioning API supports per-key USD cap + DELETE but NO TTL, so revocation must be crash-safe. Key-out proxy demoted to an option; tool-execution split (C) is the north-star architecture. Trusted self-review unaffected. Full design + design-space table in the linked HTML plan.

--- a/docs/plans/013-container-isolation.html
+++ b/docs/plans/013-container-isolation.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Cerberus Plan 013: Container Isolation for Untrusted PRs</title>
+  <title>Cerberus Plan 013: Isolating Untrusted-PR Review</title>
   <style>
     body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #151515; background: #fff; }
     main { width: min(84rem, calc(100% - 3rem)); margin: 0 auto; padding: 2rem 0 4rem; }
     header { display: grid; grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.55fr); gap: 2rem; align-items: end; border-bottom: 1px solid #d8dde3; padding-bottom: 1.5rem; }
-    h1 { margin: 0; font-size: clamp(2.3rem, 4.5vw, 4.5rem); line-height: 0.97; }
+    h1 { margin: 0; font-size: clamp(2.2rem, 4.3vw, 4.2rem); line-height: 0.98; }
     h2 { margin: 0 0 0.75rem; font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; }
     h3 { margin: 1.5rem 0 0.5rem; font-size: 1.05rem; }
     p, li { line-height: 1.5; }
@@ -34,111 +34,107 @@
   <main>
     <header>
       <section>
-        <p class="muted">Backlog 013 / Container Isolation · the security boundary for untrusted-PR review · <strong>rewritten after adversarial critique</strong></p>
-        <h1>For untrusted code, the key must never enter the container.</h1>
-        <p>Reviewing a consumer's untrusted third-party PR means the diff is attacker-controlled and can prompt-inject the agent's shell. The hard, counter-intuitive result a security critic forced: <strong>an egress allowlist does not protect the credential while the key is in the container</strong> — DNS bypasses a CONNECT proxy, and the one host you must allow (the model API) is itself a read/write exfil sink when the agent holds the key. So the boundary is <em>credential-out-of-container</em>, with network and output controls as defense-in-depth. Cerberus ships this as a reference profile behind the substrate seam; trusted self-review stays on the local harness.</p>
+        <p class="muted">Backlog 013 / Isolating Untrusted-PR Review · v3 — reframed via the lethal-trifecta lens</p>
+        <h1>Make the credential worthless, then keep a light box.</h1>
+        <p>Reviewing a consumer's untrusted PR is the <strong>lethal trifecta</strong> (Willison, 2025): untrusted content + a valuable reachable secret + an egress path. Break <em>any</em> leg and you're safe. Two earlier drafts attacked the secret-leg the hard way (perfectly hide a long-lived key behind a proxy). This one breaks the <em>value</em> of the secret instead — the cheapest robust win, and exactly what Anthropic ships for Claude Code sandboxing: short-lived, narrowly-scoped credentials so theft has near-zero blast radius. A modest container then handles non-credential damage.</p>
       </section>
       <aside class="panel">
         <h2>Chosen Design</h2>
-        <p><strong>Floor (untrusted-capable):</strong> a key-injecting reverse proxy outside the container — OpenCode reaches the model through it; <strong>the key never enters the container</strong>. Plus: no in-container resolver, internal Docker network (proxy is the only route), and a <code>.git</code>-less throwaway tree (not a linked worktree).</p>
-        <p><strong>Defense-in-depth:</strong> domain egress-allowlist at the proxy + structural validation of emitted artifact fields. Not the boundary — layers on it.</p>
-        <p><strong>Unchanged:</strong> public schema; trusted self-review keeps the local/worktree harness (key-in-env is fine for our own code).</p>
+        <p><strong>Floor — scoped ephemeral key.</strong> Cerberus mints a per-review OpenRouter key capped at ~$0.50 via the provisioning API, hands it to the agent (in-container is fine), and <code>DELETE</code>s it after — crash-safe teardown + an orphan-key sweeper.</p>
+        <p><strong>Depth — lightweight container.</strong> <code>.git</code>-less tree mount, host checkout not mounted, non-model egress blocked. Stops the <em>other</em> damage a worthless key doesn't cover.</p>
+        <p><strong>Demoted to options:</strong> the key-out proxy, managed sandbox, self-microVM. <strong>North star:</strong> the tool-execution split (C).</p>
       </aside>
     </header>
 
+    <div class="win">
+      <strong>Why this dissolves the critic's worst findings.</strong> The previous critique killed "egress-allowlist + key in container" because DNS tunnels a CONNECT proxy and the one allowed host (the model API) is itself an exfil sink <em>while the agent holds a valuable key</em>. Make the key worth <em>cents for seconds</em> and both attacks stop mattering: there is nothing worth tunneling out, and a key sent to the model API can't outspend its cap before revocation. We stop trying to win an un-winnable "hide a powerful secret from a shell" game.
+    </div>
+
     <div class="flag">
-      <strong>Why "egress allowlist + key in container" is false security (the critic's core finding).</strong>
-      <ul style="margin:0.4rem 0 0">
-        <li><b>DNS tunnel:</b> a CONNECT proxy governs only TCP the agent routes through it. The agent encodes the key into DNS QNAMEs (<code>&lt;hexkey&gt;.evil.com</code>) and the resolver leaks it — the proxy never sees it.</li>
-        <li><b>The allowed endpoint is the sink:</b> with the key in hand, the agent makes a <em>legitimate</em> HTTPS call to the model API carrying the key in the prompt, then reads it back from the attacker's own account using the <em>same stolen key</em>. The one host the allowlist must permit is itself an exfil channel.</li>
-        <li><b>Output scrub is unwinnable as a denylist:</b> <code>rev</code>, <code>gzip|base64</code>, char-split across two findings, or just <code>echo $KEY &gt; fix.patch</code> all defeat a transform-matcher. (Verified: no value-scrub exists today, only <code>redact_prompt_path</code>.)</li>
-      </ul>
-      <p style="margin-bottom:0">Conclusion: only <em>removing the key from the container</em> closes "use the key to attack the key's own API." Everything else is depth.</p>
+      <strong>The one thing to get exactly right (grounded).</strong> OpenRouter keys have a per-key USD <em>cap</em> and programmatic <code>DELETE</code>, but <strong>no native TTL</strong> (confirmed: provisioning Management API, 2026-06-23). So "worthless if stolen" rests on the cap <em>plus reliable revocation</em>: the orchestrator must delete the key even if the review crashes (a teardown guard <em>and</em> a sweeper that revokes orphaned review keys on the next run). The <em>provisioning</em> key becomes secret-zero — it stays host-side and never enters the container.
     </div>
 
     <section class="grid">
-      <article class="cell"><h2>Premise resolved</h2><p>VISION: consumers own the substrate → Cerberus ships a <em>reference</em> container profile behind the seam (swappable) and owns the credential primitive. Trusted vs untrusted is a real split: only the key-out container is "untrusted-capable".</p></article>
-      <article class="cell"><h2>Acceptance</h2><p>A <strong>red-team fixture family</strong> (DNS exfil, endpoint-as-sink, output encodings, file-write, worktree escape) all fail to surface the key; a normal container review still yields a valid artifact.</p></article>
-      <article class="cell"><h2>Verify</h2><p>Assert: the key is <em>absent</em> from the container; zero UDP/53 and zero non-proxy egress; mounted tree has no <code>.git</code>; host checkout digest unchanged; artifact valid.</p></article>
-      <article class="cell em"><h2>Stop / waiver</h2><p>Nothing markets the local or key-in-container path as "safe for untrusted." The "untrusted-safe" label attaches only to key-out + no-resolver + clone-not-worktree, proven by the fuzzed fixture family.</p></article>
+      <article class="cell"><h2>Premise resolved</h2><p>Don't hide an absolute secret — remove its value. Cerberus owns the credential lifecycle (mint/scope/revoke) + a reference container behind the substrate seam. Trusted self-review stays on the local harness, unchanged.</p></article>
+      <article class="cell"><h2>Acceptance</h2><p>After a review, the minted key is revoked and was capped; a red-team family proves a stolen key is dead and that the agent reached no non-model host and could not touch the host checkout.</p></article>
+      <article class="cell"><h2>Verify</h2><p>Steal-and-replay probe: exfiltrate the key during the run, try to use it after — must fail (revoked / over-cap). Plus egress log + host-tree digest + artifact validity.</p></article>
+      <article class="cell em"><h2>Stop / waiver</h2><p>If a future provider lacks scoped keys, fall back to the key-out proxy (option B). Never call the local/un-scoped path "untrusted-safe."</p></article>
     </section>
 
     <section class="two">
       <article>
-        <h2>Change Shape (phased)</h2>
-        <ul>
-          <li><b>M1 — harness + red-team fixtures + isolated tree.</b> Add a <code>container-opencode</code> substrate (new <code>CommandSubstrateConfig</code> variant) wrapping <code>opencode run</code> in <code>docker run</code> on an <em>internal</em> network. Mount a <strong><code>.git</code>-less throwaway tree</strong> (<code>git archive | tar -x</code> of the head SHA), never a linked <code>git worktree</code>; host checkout never mounted. Pinned <code>Dockerfile</code> (opencode + git + ripgrep + ast-grep). Build the <b>red-team fixture family</b> — the proof loop — first, with the substrate failing closed (no model access yet).</li>
-          <li><b>M2 — key-out reverse proxy (the floor).</b> A sidecar holds the key; OpenCode points at it (provider base-URL + a trusted CA, or a container-scoped dummy token) and the sidecar injects real auth and forwards to the model. <strong>No <code>OPENROUTER_API_KEY</code> in the container env.</strong> No in-container resolver (static <code>/etc/hosts</code> → sidecar; <code>--dns</code> none). This is what makes the substrate untrusted-capable.</li>
-          <li><b>M3 — defense-in-depth.</b> Sidecar egress-allowlists the model domain only (belt over the key-out boundary); structural validation of emitted artifact fields (length/grammar/entropy reject, not a secret-denylist); value-scrub of any other <code>allowed_env</code> secrets as backstop.</li>
-        </ul>
-        <p class="muted" style="margin:0.5rem 0 0">Trusted self-review is untouched — it stays on the local/worktree harness where key-in-env is acceptable.</p>
+        <h2>Design space (by trifecta leg broken)</h2>
+        <table>
+          <tr><th>Design</th><th>Leg</th><th>Verdict</th></tr>
+          <tr><td><b>A · Scoped ephemeral key</b> (cap + delete)</td><td>value</td><td><b>Floor.</b> Simplest; kills DNS/endpoint-sink attacks; matches Anthropic prod. ✗ no TTL → crash-safe teardown.</td></tr>
+          <tr><td><b>+ lightweight container</b></td><td>content/egress</td><td><b>Depth.</b> <code>.git</code>-less mount, host unmounted, non-model egress blocked — covers non-key damage. Cheap.</td></tr>
+          <tr><td>B · Key-out broker proxy</td><td>access</td><td>Option. Key truly absent; provider-agnostic. ✗ TLS/CA proxy to build+secure. Use only if no scoped keys.</td></tr>
+          <tr><td>C · Tool-execution split (model trusted-side)</td><td>access+egress</td><td><b>North star.</b> Breaks two legs; nothing to steal in the box. ✗ abandons OpenCode-as-monolith — biggest rebuild.</td></tr>
+          <tr><td>D · Managed sandbox (E2B/Modal/Daytona)</td><td>egress</td><td>Option. microVM-grade + egress allowlists, less infra. ✗ untrusted code egresses to a 3rd party; still needs A inside.</td></tr>
+          <tr><td>E · Self-microVM (Firecracker/Fly)</td><td>—</td><td>Option. Stronger isolation unit. ✗ needs KVM, not macOS-native; orthogonal to the credential.</td></tr>
+        </table>
       </article>
       <article>
-        <h2>Alternatives</h2>
-        <table>
-          <tr><th>Path</th><th>Why it fails / verdict</th></tr>
-          <tr><td><b>Key-out container + depth (chosen)</b></td><td>Only design that survives the critic: no key to steal, no resolver to tunnel, no host-handle mount. <b>Choose.</b></td></tr>
-          <tr><td>Egress-allowlist, key in container</td><td>The original plan. DNS bypass + endpoint-as-sink make it ~zero protection for untrusted. <b>Reject as a boundary; keep allowlist as depth.</b></td></tr>
-          <tr><td>Lazy: diff-only for untrusted (deny bash/web)</td><td>Crippled agent, safe but low-value. <b>The honest fallback when no key-out substrate is available — and better than false security.</b></td></tr>
-          <tr><td>Cloud microVM (Sprites / Fly) per review</td><td>Stronger isolation than a container, still needs key-out (same endpoint-sink logic). Hosting dependency. <b>Defer; seam allows it.</b></td></tr>
-          <tr><td><em>Invert: never review untrusted code</em></td><td>Rejects the consumer use case (Bitterblossom/Olympus exist to review others' PRs). <b>Reject.</b></td></tr>
-        </table>
+        <h2>Change Shape (phased)</h2>
+        <ul>
+          <li><b>M1 — scoped-key lifecycle (the floor).</b> Mint a per-review OpenRouter key with <code>limit</code> via the provisioning API; inject it; <code>DELETE</code> on teardown with a crash-safe guard; an <b>orphan-key sweeper</b> revokes keys left by crashed runs. The <b>steal-and-replay probe</b> proves a leaked key is dead after the run. Testable <em>without</em> a container.</li>
+          <li><b>M2 — lightweight container (depth).</b> <code>container-opencode</code> substrate: <code>docker run</code> on an internal network, <code>.git</code>-less <code>git archive</code> tree mounted, host checkout never mounted, non-model egress blocked. Covers the damage a worthless key doesn't (other secrets, SSRF, trashing). Red-team family: DNS/endpoint/output/file-write/worktree-escape.</li>
+          <li><b>M3 — optional upgrades.</b> Key-out proxy (B) for providers without scoped keys; managed sandbox (D) for microVM-grade isolation; both behind the same seam, no schema change.</li>
+        </ul>
+        <p class="muted" style="margin:0.5rem 0 0">Trusted self-review (our own code) keeps the local/worktree harness; this is the untrusted path only.</p>
       </article>
     </section>
 
     <h3>Oracle — executable definition of done</h3>
-<pre>## 1. Plumbing: a key-out container review still works
-cargo run -- review --request fixtures/requests/diff-only.json --harness container-opencode ...
-# exit 0; artifact valid; `printenv` inside the container shows NO OPENROUTER_API_KEY; the model call still succeeds via the sidecar.
+<pre>## 1. Scoped-key lifecycle (the floor)
+# review mints a key with a USD cap, uses it, DELETEs it.
+# STEAL-AND-REPLAY: capture the key mid-run, then after teardown:
+curl -H "Authorization: Bearer $STOLEN" https://openrouter.ai/api/v1/chat/completions ...
+#   -> must FAIL (401 revoked / 402 over-cap). The minted key GET returns 404/disabled.
+# CRASH SAFETY: kill the run mid-review -> the orphan sweeper revokes the key on the next run.
 
-## 2. Red-team family: every exfil attempt fails (THE test)
-for f in fixtures/requests/redteam-{dns,endpoint-sink,encode-output,file-write,worktree-escape}.json; do
-  cargo run -- review --request "$f" --harness container-opencode ... ; done
-#   - sidecar/network logs: zero non-model egress AND zero outbound UDP/53
-#   - key value + transforms appear in NO output/artifact/written file
-#   - the key is not present in the container at all (nothing to encode)
-#   - mounted tree has no .git; host checkout digest unchanged
+## 2. Container depth
+cargo run -- review --request fixtures/requests/redteam-*.json --harness container-opencode ...
+#   - non-model egress (curl evil.com) fails; mounted tree has no .git; host checkout digest unchanged.
 
-## 3. ./scripts/verify.sh green; container path skipped when Docker is absent (like the live-review smoke).</pre>
+## 3. Clean review still works + ./scripts/verify.sh green (container path skipped when Docker absent).</pre>
 
     <h3>Verification System</h3>
     <div class="panel">
-      <p><b>Claim:</b> a prompt-injected agent reviewing an untrusted PR in the container cannot obtain or exfiltrate the model credential by any vector, because the credential is never in the container; a normal review still produces a valid artifact.</p>
-      <p><b>Falsifier:</b> any red-team fixture surfaces the key (network, DNS, endpoint-sink, output, written file); OR the key is found in the container env/fs; OR the mounted tree carries <code>.git</code>; OR the host checkout mutates; OR a clean review can't produce a valid artifact.</p>
-      <p><b>Driver:</b> the red-team fixture family through <code>--harness container-opencode</code>, with network capture (no UDP/53, only model egress) + an in-container key-absence probe + an output key-scan.</p>
-      <p><b>Grader:</b> network log + key-absence probe + key-scan (literal & transforms) + host-tree digest + artifact validation. A single canned fixture is insufficient — the family must include encoding/DNS/endpoint variants and grow on each near-miss.</p>
-      <p><b>Evidence packet:</b> network capture, the fixture family, the key-absence probe output, and the container execution plan, under <code>target/cerberus/container-*</code>.</p>
-      <p><b>Cadence:</b> gated in <code>verify.sh</code> when Docker is present; on every change to the container/proxy/mount path.</p>
-      <p><b>Gaps / waiver:</b> the "untrusted-safe" claim attaches ONLY to M2+M1 (key-out + no-resolver + clone-not-worktree). M3 is depth. The model-domain pin must track the provider's real hosts.</p>
+      <p><b>Claim:</b> a prompt-injected agent on an untrusted PR cannot obtain a credential worth stealing or reach a non-model host; any credential it does capture is capped and revoked by run-end.</p>
+      <p><b>Falsifier:</b> the minted key outlives the run (teardown/sweeper failed); the key has no cap; a stolen key still works after the run; the agent reaches a non-model host; the host checkout mutates; a clean review can't produce a valid artifact.</p>
+      <p><b>Driver:</b> the steal-and-replay probe + a crash-injection (kill mid-run, assert sweeper revokes) + the red-team container family with egress capture.</p>
+      <p><b>Grader:</b> post-run the minted key is dead (API confirms) and was capped; egress log shows model-only; host-tree digest unchanged; artifact validates.</p>
+      <p><b>Evidence packet:</b> the key create/delete API transcript, the steal-and-replay result, the crash-sweeper log, egress capture, under <code>target/cerberus/container-*</code>.</p>
+      <p><b>Cadence:</b> the key-lifecycle tests always; the container red-team gated on Docker in <code>verify.sh</code>; on every change to the credential/sandbox path.</p>
+      <p><b>Gaps / waiver:</b> residual = a stolen key is usable for seconds up to the cap until <code>DELETE</code> lands; accepted. The provisioning key is secret-zero (host-side). Provider lock-in on scoped keys → option B is the fallback.</p>
     </div>
 
     <h3>Milestones</h3>
-    <div class="phase"><b>M1 · Harness</b><div>Red-team fixture family + <code>container-opencode</code> plumbing (internal network, <code>.git</code>-less tree mount, host not mounted), failing closed. The proof loop, first. <em>Critic on fixture realism + escape vectors.</em></div></div>
-    <div class="phase"><b>M2 · Key-out</b><div>Key-injecting sidecar (key never in container) + no in-container resolver. The floor that earns the "untrusted-capable" label. <em>Gate: key-absence probe + zero-UDP/53.</em></div></div>
-    <div class="phase"><b>M3 · Depth</b><div>Domain egress-allowlist at the sidecar + structural artifact-field validation + backstop scrub. Layers on the boundary; never sold as the boundary.</div></div>
+    <div class="phase"><b>M1 · Scoped key</b><div>Mint-cap-use-revoke lifecycle + crash-safe teardown + orphan sweeper + steal-and-replay probe. The floor; no container needed. <em>Gate: a leaked key is dead after the run.</em></div></div>
+    <div class="phase"><b>M2 · Light box</b><div><code>container-opencode</code> with <code>.git</code>-less mount, host unmounted, non-model egress blocked; red-team family. Covers non-credential damage. <em>Gate: curl-evil fails, host untouched.</em></div></div>
+    <div class="phase"><b>M3 · Upgrades</b><div>Optional: key-out proxy (B) / managed sandbox (D) behind the seam, when a threat model or provider demands it.</div></div>
 
     <h3>Risks + Rollout</h3>
     <table>
       <tr><th>Risk</th><th>Mitigation</th></tr>
-      <tr><td>DNS-tunnel exfil around the proxy</td><td>No resolver in the container (static <code>/etc/hosts</code> → sidecar, <code>--dns</code> none); assert zero outbound UDP/53 in evidence. (Moot for the key once it's out, but blocks tunneling of any in-container secret.)</td></tr>
-      <tr><td>Endpoint-as-sink (use the model API to leak the key)</td><td>Key-out: the container never holds the key, so it cannot put it in a model request. This is the whole point of M2.</td></tr>
-      <tr><td>Output exfil by encoding / written file</td><td>No key in the container to emit; structural artifact-field validation (entropy/length reject) catches any high-entropy emission; backstop scrub for other secrets.</td></tr>
-      <tr><td>Mounted tree is a host-<code>.git</code> handle (hooks, path leak, host-side <code>git</code> on a poisonable path)</td><td>Mount a <code>git archive</code>-extracted tree with no <code>.git</code>; never a linked worktree; never run host git against a container-writable path.</td></tr>
-      <tr><td>Docker socket / metadata IP / IPv6 reachable</td><td>Never mount <code>docker.sock</code>; internal network with no gateway; disable IPv6 on the network; pin the only route to the sidecar.</td></tr>
-      <tr><td>"Passes the fixture" ≠ secure</td><td>Fixture <em>family</em> + grow-on-near-miss; the untrusted label requires the family green, not one diff. Document M1/M3-alone as NOT untrusted-safe.</td></tr>
-      <tr><td>Docker absent; sidecar/CA complexity</td><td>Substrate is one option behind the seam; <code>verify.sh</code> skips it without Docker; diff-only is the honest fallback over false security.</td></tr>
-      <tr><td><b>Rollback</b></td><td>New substrate variant + sidecar + fixtures; no schema or default-path change. Drop the variant to revert; trusted self-review unaffected.</td></tr>
+      <tr><td>No key TTL → an orphaned key lingers after a crash</td><td>Teardown guard (revoke in a <code>finally</code>/<code>Drop</code>) <em>and</em> a sweeper that lists+revokes review-tagged keys older than N minutes on each run. This is THE thing to get right.</td></tr>
+      <tr><td>Provisioning key (secret-zero) leaks</td><td>It never enters the container; stored host-side like any deploy secret; rotate independently.</td></tr>
+      <tr><td>Worthless-key residual (cap × revoke window)</td><td>Cap ~$0.50, delete ASAP; document the seconds-of-cents residual as accepted.</td></tr>
+      <tr><td>Scoped key doesn't stop non-credential damage (SSRF, other secrets, trashing)</td><td>That's M2's job — non-model egress block + fs isolation + <code>.git</code>-less mount.</td></tr>
+      <tr><td>Provider lock-in (relies on OpenRouter provisioning API)</td><td>Behind the substrate seam; option B (key-out proxy) is the provider-agnostic fallback.</td></tr>
+      <tr><td><b>Rollback</b></td><td>Credential-lifecycle is additive; container is a new substrate variant; no schema/default change. Trusted self-review unaffected.</td></tr>
     </table>
 
-    <h3>Adversarial Review (run during shaping; folded in)</h3>
-    <p class="muted">A fresh-context security critic dismantled the original "egress-allowlist + key-in-container" design: DNS bypasses the proxy; the allowlisted model endpoint is itself an exfil sink while the agent holds the key; a transform-denylist scrub is unwinnable; the mounted <code>git worktree</code> is a live handle to the host <code>.git</code> (verified). The plan was rewritten so key-out is the floor (not optional), the mount is a <code>.git</code>-less clone, the resolver is removed, and acceptance is a red-team family. Residual focus for <code>/deliver</code>: the sidecar TLS/CA story (base-URL override vs trusted CA injection) and confirming OpenCode honors a custom provider base-URL; verify Docker "internal network" truly has no egress but the sidecar.</p>
+    <h3>Adversarial Review (two rounds, folded in)</h3>
+    <p class="muted">Round 1 (security critic) killed the egress-allowlist+key-in-container design (DNS bypass, endpoint-as-sink, unwinnable scrub, worktree-as-host-handle). Round 2 (research + premise challenge) showed the deeper fix is to break the <em>value</em> leg of the lethal trifecta — a scoped ephemeral key — which retires most of the round-1 machinery. Residual focus for <code>/deliver</code>: prove crash-safe revocation under <code>SIGKILL</code>/host crash (not just clean exit); confirm OpenRouter's per-key cap is enforced server-side promptly; decide whether M2's container is worth it before any consumer is live, or whether M1 + diff-only-on-no-container suffices to start.</p>
 
     <h3>Premise Source</h3>
-    <p class="muted">Operator session 2026-06-22: picked 013, chose "shape properly first." The exfil vector was first surfaced by the tracer-bullet (PR #466) critique. No durable transcript stored — explicit waiver. Grounding:</p>
+    <p class="muted">Operator session 2026-06-22/23: shaped 013, then challenged the premise ("is this the best shape?"). Grounded by research (OpenRouter provisioning API; OpenCode baseURL; Willison lethal-trifecta; Anthropic Claude-Code sandboxing). No durable transcript stored — explicit waiver. Grounding:</p>
     <ul class="muted">
       <li><code>sha256:eebd05db29f7dcdab5b3000f82ac69483112e62b275ec3af5b838c6741ea2009 spec.md</code></li>
       <li><code>sha256:b4b7d9891294696abdb9196a17274e9a882966da94ae8a95eb35ad4da39481b6 VISION.md</code></li>
-      <li><code>sha256:69415276a3c55f3cdd01284188113706d7d0256ba8d4dc9ff182ee2a27cb6cb1 backlog.d/013-container-runtime-untrusted-isolation.md</code></li>
+      <li>https://www.anthropic.com/engineering/claude-code-sandboxing (2025-10-20) · https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/ · https://openrouter.ai/docs/guides/overview/auth/management-api-keys</li>
     </ul>
   </main>
 </body>


### PR DESCRIPTION
Premise challenge outcome. Supersedes the key-out-proxy shape: break the lethal trifecta's *value* leg with a per-review scoped/capped/revoked OpenRouter key (Anthropic's pattern), + a light container for non-credential damage. Key-out proxy demoted to an option. Plan: docs/plans/013-container-isolation.html. Backlog only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)