### PR TITLE
docs(vision): wire ADR 0003 into the contract/judgment boundary

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -44,7 +44,11 @@ These are load-bearing. Implementation may change underneath them; these do not.
 - **Rust owns the contract; the substrate owns judgment.** Rust owns contracts,
   capability boundaries, execution receipts, artifact validation, and rendering.
   The agent substrate (OpenCode default, OMP fallback, fixture for tests) owns
-  reviewer reasoning and any runtime lane design.
+  reviewer reasoning and any runtime lane design. The line between what Rust may
+  enforce (oracle-checkable contracts, safety, posting, citation resolution) and
+  what only the model + evals may judge (faithfulness) is **ADR 0003**; review
+  *quality* is earned by harness engineering and measured by evals, never by
+  deterministic heuristics.
 - **Evidence discipline.** Every finding cites a concrete anchor: a diff hunk,
   an inspected file, command/test/log output, or an external URL with an
   observation time. Model memory alone is never evidence.


### PR DESCRIPTION
VISION already nailed it (trust = measured low false-confident rate; substrate owns judgment) — just wiring the ADR 0003 pointer in. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture vision to clarify the separation between contract enforcement (Rust/safety/publishing) and evaluation judgment, with reference to ADR 0003
  * Refined how review quality is earned and measured through harness engineering and evaluations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->