### PR TITLE
feat(016): emit review to a file + validate-and-re-ask; delete the marker parser

### DIFF
--- a/backlog.d/017-remove-dead-empty-diff-cwd-fallback.md
+++ b/backlog.d/017-remove-dead-empty-diff-cwd-fallback.md
@@ -1,0 +1,21 @@
+# Remove the dead empty-diff fallback workspace and its cwd plumbing
+
+Priority: P3 · Status: pending · Estimate: S
+
+## Goal
+Delete the `fallback_empty_diff` workspace branch (and the `cwd`/`RunPolicy.cwd`/`--cwd` plumbing that exists only to feed it) so the review harness can never write `review-artifact.json` into a real checkout.
+
+## Why
+Backlog 016 moved emission to a file the agent writes inside `workspace.path()`. For a non-empty diff the workspace is always a private temp dir (worktree or `temp/packet`), but the `fallback_empty_diff` branch sets the workspace to the caller's real `cwd` (`RunWorkspace::prepare`, harness.rs). With file emission, that path would drop `review-artifact.json` into the real directory. It is unreachable today — `validate_request` rejects an empty diff in `review()` and `review_pr()` before the kernel runs — but it is a latent footgun for any library caller of `ReviewKernel::review` that skips validation, and the `cwd` plumbing (kernel `RunPolicy.cwd`, the `--cwd` CLI flag, the `fallback_cwd` param threaded through both substrate fns) now exists only to serve this dead branch.
+
+## Non-Goals
+- Do not change behavior for any reachable (non-empty-diff) request.
+- Keep `--cwd` only if a real consumer needs it; otherwise delete it with the rest.
+
+## Oracle
+- [ ] The empty-diff case routes to a private temp dir (or is rejected outright), never the real cwd; a unit test calling the kernel directly with an empty diff proves no file lands outside a tempdir.
+- [ ] `fallback_cwd` / `RunPolicy.cwd` / `--cwd` are removed if they have no other consumer (or a stated reason to keep each).
+- [ ] `./scripts/verify.sh` green; no behavior change for diff-bearing requests.
+
+## Notes
+Surfaced by the 016 diverse-provider review (fresh-context critic, non-blocking). Fail-closed today, so this is hardening + a small deletion, not a bug fix.

--- a/fixtures/bin/fake-omp
+++ b/fixtures/bin/fake-omp
@@ -48,10 +48,13 @@ test -n "$request_digest"
 
 capabilities='{"diff":true,"repo_head":false,"repo_base":false,"local_runtime":false,"remote_runtime":false,"external_research":"forbid"}'
 
+# Emit the review by writing the artifact file in the workspace, exactly as the
+# prompt now instructs a real agent to. The harness reads it back; nothing on
+# stdout is parsed for the artifact.
 sed \
   -e "s/{{request_id}}/fixture-diff-only-001/g" \
   -e "s#{{request_digest}}#$request_digest#g" \
   -e "s#{{context_capabilities}}#$capabilities#g" \
   -e "s/{{artifact_id}}/artifact-fake-omp/g" \
   -e "s/{{now}}/0/g" \
-  "$template"
+  "$template" > "$workdir/review-artifact.json"

--- a/fixtures/bin/fake-opencode
+++ b/fixtures/bin/fake-opencode
@@ -18,6 +18,7 @@ template="$repo_root/fixtures/harness/valid-review.txt"
 original_args="$*"
 request_file=""
 workdir=""
+session_id=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     run)
@@ -35,6 +36,10 @@ while [[ $# -gt 0 ]]; do
       request_file="${2:-}"
       shift 2
       ;;
+    --session)
+      session_id="${2:-}"
+      shift 2
+      ;;
     --model|--attach|--agent)
       shift 2
       ;;
@@ -48,7 +53,15 @@ test -n "$request_file"
 test -s "$request_file"
 test -n "$workdir"
 
+# The initial run carries the request digest in its argv message; the re-ask
+# continuation does not, so persist it in the workspace and read it back.
+digest_sidecar="$workdir/.cerberus-fake-request-digest"
 request_digest="$(printf '%s\n' "$original_args" | sed -n 's/.*Request digest: \(sha256:[a-f0-9]*\).*/\1/p' | head -1)"
+if [[ -n "$request_digest" ]]; then
+  printf '%s' "$request_digest" > "$digest_sidecar"
+elif [[ -f "$digest_sidecar" ]]; then
+  request_digest="$(cat "$digest_sidecar")"
+fi
 test -n "$request_digest"
 request_id="$(sed -n 's/.*"request_id": "\([^"]*\)".*/\1/p' "$request_file" | head -1)"
 test -n "$request_id"
@@ -119,37 +132,26 @@ print(json.dumps(payload, separators=(",", ":")))
 PY
 )"
 
-rendered="$(mktemp)"
-trap 'rm -f "$rendered"' EXIT
+# Emit the review by writing the artifact file in the workspace, exactly as the
+# prompt instructs a real agent to. Nothing on stdout is parsed for the artifact;
+# stdout only carries the session id (for the re-ask) and telemetry.
+#
+# Optional re-ask drill: with CERBERUS_FAKE_OPENCODE_FIRST_INVALID=1 the initial
+# emission writes a deliberately-wrong request_digest (which fails validation),
+# and the session-continued re-ask writes the correct one. This exercises the
+# validate-and-re-ask loop end to end against the real OpenCode session surface.
+artifact_digest="$request_digest"
+if [[ "${CERBERUS_FAKE_OPENCODE_FIRST_INVALID:-}" == "1" && -z "$session_id" ]]; then
+  artifact_digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
+fi
 
 sed \
   -e "s/{{request_id}}/$request_id/g" \
-  -e "s#{{request_digest}}#$request_digest#g" \
+  -e "s#{{request_digest}}#$artifact_digest#g" \
   -e "s#{{context_capabilities}}#$capabilities#g" \
   -e "s/{{artifact_id}}/artifact-fake-opencode/g" \
   -e "s/{{now}}/0/g" \
-  "$template" > "$rendered"
+  "$template" > "$workdir/review-artifact.json"
 
-python3 - "$rendered" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as fh:
-    body = fh.read()
-
-print(json.dumps({
-    "type": "metadata",
-    "model": "fake/opencode-reviewer",
-    "usage": {
-        "prompt_tokens": 123,
-        "completion_tokens": 45,
-        "cost_usd": 0.0042,
-    },
-}))
-print(json.dumps({
-    "type": "text",
-    "part": {
-        "text": body,
-    },
-}))
-PY
+printf '%s\n' '{"type":"step_start","sessionID":"ses_fake_opencode"}'
+printf '%s\n' '{"type":"metadata","sessionID":"ses_fake_opencode","model":"fake/opencode-reviewer","usage":{"prompt_tokens":123,"completion_tokens":45,"cost_usd":0.0042}}'

--- a/fixtures/harness/invalid-orphan-suggested-fix.txt
+++ b/fixtures/harness/invalid-orphan-suggested-fix.txt
@@ -1,6 +1,3 @@
-Cerberus invalid fixture transcript: top-level suggested fix is orphaned.
-
------BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----
 {
   "schema_version": "cerberus.review_artifact.v1",
   "artifact_id": "{{artifact_id}}",
@@ -44,4 +41,3 @@ Cerberus invalid fixture transcript: top-level suggested fix is orphaned.
   },
   "errors": []
 }
------END CERBERUS_REVIEW_ARTIFACT_V1-----

--- a/fixtures/harness/invalid-unknown-finding-id.txt
+++ b/fixtures/harness/invalid-unknown-finding-id.txt
@@ -1,6 +1,3 @@
-Cerberus invalid fixture transcript: comment references an unknown finding.
-
------BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----
 {
   "schema_version": "cerberus.review_artifact.v1",
   "artifact_id": "{{artifact_id}}",
@@ -71,4 +68,3 @@ Cerberus invalid fixture transcript: comment references an unknown finding.
   },
   "errors": []
 }
------END CERBERUS_REVIEW_ARTIFACT_V1-----

--- a/fixtures/harness/invalid-unknown-suggested-fix.txt
+++ b/fixtures/harness/invalid-unknown-suggested-fix.txt
@@ -1,6 +1,3 @@
-Cerberus invalid fixture transcript: finding references an unknown suggested fix.
-
------BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----
 {
   "schema_version": "cerberus.review_artifact.v1",
   "artifact_id": "{{artifact_id}}",
@@ -59,4 +56,3 @@ Cerberus invalid fixture transcript: finding references an unknown suggested fix
   },
   "errors": []
 }
------END CERBERUS_REVIEW_ARTIFACT_V1-----

--- a/fixtures/harness/pass-review.txt
+++ b/fixtures/harness/pass-review.txt
@@ -1,6 +1,3 @@
-review transcript
-
------BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----
 {
   "schema_version": "cerberus.review_artifact.v1",
   "artifact_id": "{{artifact_id}}",
@@ -50,4 +47,3 @@ review transcript
   },
   "errors": []
 }
------END CERBERUS_REVIEW_ARTIFACT_V1-----

--- a/fixtures/harness/valid-review.txt
+++ b/fixtures/harness/valid-review.txt
@@ -1,6 +1,3 @@
-Cerberus fixture transcript.
-
------BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----
 {
   "schema_version": "cerberus.review_artifact.v1",
   "artifact_id": "{{artifact_id}}",
@@ -103,4 +100,3 @@ Cerberus fixture transcript.
   },
   "errors": []
 }
------END CERBERUS_REVIEW_ARTIFACT_V1-----

--- a/fixtures/requests/diff-only-reask.json
+++ b/fixtures/requests/diff-only-reask.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "cerberus.review_request.v1",
+  "request_id": "fixture-diff-only-reask-001",
+  "source": {
+    "kind": "fixture",
+    "external_id": "fixture-reask-001",
+    "repo": "example/fixture",
+    "metadata": {}
+  },
+  "change": {
+    "title": "Avoid divide by zero in ratio helper",
+    "description": "Adds a guard for zero denominators.",
+    "base_ref": "main",
+    "head_ref": "fix/ratio-zero",
+    "head_sha": "0123456789abcdef",
+    "diff": {
+      "format": "unified",
+      "body": "diff --git a/src/ratio.rs b/src/ratio.rs\nindex 1111111..2222222 100644\n--- a/src/ratio.rs\n+++ b/src/ratio.rs\n@@ -1,3 +1,6 @@\n pub fn ratio(numerator: f64, denominator: f64) -> f64 {\n+    if denominator == 0.0 {\n+        return 0.0;\n+    }\n     numerator / denominator\n }\n"
+    },
+    "files": [
+      {
+        "path": "src/ratio.rs",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 0
+      }
+    ]
+  },
+  "context": {
+    "summary": "Fixture request that exercises the validate-and-re-ask loop.",
+    "acceptance": [
+      "Reviewer must not claim to have run tests or inspected surrounding repo files."
+    ],
+    "instructions": [
+      "Review only from the diff."
+    ],
+    "artifacts": [],
+    "metadata": {}
+  },
+  "policy": {
+    "allow_degraded": true,
+    "timeout_ms": 120000,
+    "external_research": "forbid",
+    "render_targets": [
+      "json",
+      "markdown"
+    ],
+    "allowed_env": [
+      "CERBERUS_FAKE_OPENCODE_FIRST_INVALID"
+    ]
+  }
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -48,60 +48,53 @@ expect_review_failure() {
   fi
 }
 
-cat fixtures/harness/pass-review.txt fixtures/harness/pass-review.txt \
-  > target/cerberus/invalid-duplicate-artifacts.txt
-artifact_json="$(awk '
-  /-----BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----/ { inside = 1; next }
-  /-----END CERBERUS_REVIEW_ARTIFACT_V1-----/ { inside = 0 }
-  inside { print }
-' fixtures/harness/pass-review.txt)"
-{
-  cat fixtures/harness/pass-review.txt
-  printf '\n<CERBERUS_REVIEW_ARTIFACT_V1>\n%s\n</CERBERUS_REVIEW_ARTIFACT_V1>\n' "$artifact_json"
-} > target/cerberus/invalid-duplicate-marker-xml-artifacts.txt
-{
-  cat fixtures/harness/pass-review.txt
-  printf '\n%s\n' "$artifact_json"
-} > target/cerberus/invalid-duplicate-marker-raw-artifacts.txt
-{
-  printf '<CERBERUS_REVIEW_ARTIFACT_V1>\n%s\n</CERBERUS_REVIEW_ARTIFACT_V1>\n' "$artifact_json"
-  printf '<CERBERUS_REVIEW_ARTIFACT_V1>\n%s\n</CERBERUS_REVIEW_ARTIFACT_V1>\n' "$artifact_json"
-} > target/cerberus/invalid-duplicate-xml-artifacts.txt
-{
-  printf '<CERBERUS_REVIEW_ARTIFACT_V1>\n%s\n</CERBERUS_REVIEW_ARTIFACT_V1>\n' "$artifact_json"
-  printf '%s\n' "$artifact_json"
-} > target/cerberus/invalid-duplicate-xml-raw-artifacts.txt
-printf '%s\n%s\n' "$artifact_json" "$artifact_json" \
-  > target/cerberus/invalid-duplicate-raw-artifacts.txt
+# The agent now emits one artifact file, so the old marker/XML/raw "duplicate
+# candidate" cases no longer have a parser to defeat — a file holds exactly one
+# artifact. The meaningful adversarial floor is the validator: an emission that
+# parses but overstates context or dangles a reference must still be rejected.
+# Fixtures are bare ReviewArtifact.v1 JSON templates; the fixture substrate
+# writes them to the out-path and reads them back, then validation runs.
 sed 's#{{context_capabilities}}#{"diff":true,"repo_head":false,"repo_base":true,"local_runtime":false,"remote_runtime":false,"external_research":"forbid"}#' \
   fixtures/harness/pass-review.txt \
   > target/cerberus/invalid-overstated-base.txt
 sed 's#{{context_capabilities}}#{"diff":true,"repo_head":false,"repo_base":false,"local_runtime":true,"remote_runtime":false,"external_research":"forbid"}#' \
   fixtures/harness/pass-review.txt \
   > target/cerberus/invalid-overstated-runtime.txt
-expect_review_failure duplicate-artifacts target/cerberus/invalid-duplicate-artifacts.txt
-expect_review_failure duplicate-marker-xml-artifacts target/cerberus/invalid-duplicate-marker-xml-artifacts.txt
-expect_review_failure duplicate-marker-raw-artifacts target/cerberus/invalid-duplicate-marker-raw-artifacts.txt
-expect_review_failure duplicate-xml-artifacts target/cerberus/invalid-duplicate-xml-artifacts.txt
-expect_review_failure duplicate-xml-raw-artifacts target/cerberus/invalid-duplicate-xml-raw-artifacts.txt
-expect_review_failure duplicate-raw-artifacts target/cerberus/invalid-duplicate-raw-artifacts.txt
 expect_review_failure overstated-base target/cerberus/invalid-overstated-base.txt
 expect_review_failure overstated-runtime target/cerberus/invalid-overstated-runtime.txt
 expect_review_failure unknown-finding-id fixtures/harness/invalid-unknown-finding-id.txt
 expect_review_failure unknown-suggested-fix fixtures/harness/invalid-unknown-suggested-fix.txt
 expect_review_failure orphan-suggested-fix fixtures/harness/invalid-orphan-suggested-fix.txt
 
-grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-artifacts.stderr
-grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-marker-xml-artifacts.stderr
-grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-marker-raw-artifacts.stderr
-grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-xml-artifacts.stderr
-grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-xml-raw-artifacts.stderr
-grep -q 'expected exactly one ReviewArtifact.v1 candidate' target/cerberus/duplicate-raw-artifacts.stderr
 grep -q 'artifact context capabilities overstate the request' target/cerberus/overstated-base.stderr
 grep -q 'artifact context capabilities overstate the request' target/cerberus/overstated-runtime.stderr
 grep -q 'references unknown finding id' target/cerberus/unknown-finding-id.stderr
 grep -q 'references unknown suggested fix id' target/cerberus/unknown-suggested-fix.stderr
 grep -q 'top-level suggested fix is not attached' target/cerberus/orphan-suggested-fix.stderr
+
+# THE re-ask test (Oracle #1): the fake agent writes an INVALID artifact (wrong
+# request digest) on its first emission, then a VALID one when the harness
+# continues its OpenCode session. The review must succeed only via the re-ask,
+# and the transcript must show the exact validation error carried back.
+GH_TOKEN=should-not-leak CERBERUS_FAKE_OPENCODE_FIRST_INVALID=1 cargo run --locked -- review \
+  --request fixtures/requests/diff-only-reask.json \
+  --harness opencode \
+  --opencode-binary "$PWD/fixtures/bin/fake-opencode" \
+  --out target/cerberus/reask-artifact.json \
+  --execution-plan target/cerberus/reask-execution_plan.json \
+  --transcript target/cerberus/reask-transcript.txt \
+  --receipt-bundle target/cerberus/receipts/reask.json
+
+test -s target/cerberus/reask-artifact.json
+grep -q '"trusted_for_posting": true' target/cerberus/receipts/reask.json
+grep -q '\[attempt: re-ask\]' target/cerberus/reask-transcript.txt
+grep -q 'artifact request digest mismatch' target/cerberus/reask-transcript.txt
+# The recovered artifact carries the correct digest, not the deliberately-wrong one.
+if grep -q 'sha256:0000000000000000000000000000000000000000000000000000000000000000' \
+  target/cerberus/reask-artifact.json; then
+  echo "re-ask accepted the invalid first emission" >&2
+  exit 1
+fi
 
 printf 'stale receipt should be removed before a failed run\n' \
   > target/cerberus/receipts/stale-before-failed-review.json

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -327,8 +327,12 @@ fn emission_failure_reason(
 }
 
 /// Capture the OpenCode session id from its JSON event stream so the re-ask can
-/// continue the same conversation. Every event carries a top-level `sessionID`;
-/// the first one is the run's root session. Only OpenCode is session-based.
+/// continue the same conversation. Every event carries a top-level `sessionID`,
+/// and the first one is the run's root session: a session must exist before it
+/// can spawn a subagent, so the root's first event always precedes any child's.
+/// If that ever did not hold, the re-ask would continue the wrong session and
+/// re-read a still-invalid file — bounded retries then fail closed, never a
+/// silent accept. Only OpenCode is session-based; omp/fixture return `None`.
 fn capture_opencode_session_id(
     substrate: CommandSubstrateConfig<'_>,
     stdout: &[u8],
@@ -601,6 +605,13 @@ impl RunWorkspace {
         set_private_permissions(&diff_path)?;
 
         if request.change.diff.body.trim().is_empty() {
+            // Degenerate path: an empty diff has nothing to review. The agent now
+            // emits its artifact into the workspace, so this fallback would write
+            // review-artifact.json into the real cwd. That is gated shut today —
+            // validate_request rejects an empty diff before any binary reaches the
+            // kernel — so it is unreachable in practice; only a library caller that
+            // skips validation could hit it. Removing the dead fallback/cwd
+            // plumbing is tracked in backlog 017.
             Ok(Self::with_packet_or_fallback(
                 fallback_cwd.to_path_buf(),
                 "fallback_empty_diff",

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -12,12 +12,23 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::digest::{request_digest, sha256_digest};
-use crate::prompt::{build_master_prompt, build_opencode_message, ARTIFACT_BEGIN, ARTIFACT_END};
+use crate::prompt::{build_master_prompt, build_opencode_message};
 use crate::schema::{
     ContextArtifact, ContextCapabilities, LifecycleState, ReceiptStatus, ReviewArtifact,
-    ReviewRequest, ReviewTelemetry, RuntimeTarget, REVIEW_ARTIFACT_SCHEMA,
+    ReviewRequest, ReviewTelemetry, RuntimeTarget,
 };
 use crate::telemetry::{omp_telemetry, opencode_telemetry};
+use crate::validation::validate_artifact_for_request;
+
+/// Filename the review agent writes its `ReviewArtifact.v1` JSON to, inside the
+/// disposable review workspace (`--dir`). The harness reads it back and parses
+/// it; there is no transcript scraping.
+const ARTIFACT_FILENAME: &str = "review-artifact.json";
+
+/// Maximum re-ask retries after an invalid or missing emission. Research puts
+/// first-retry recovery near 80% and second-retry above 99%; a third is wasted
+/// tokens. The loop is fail-closed: an artifact that never validates is an error.
+const MAX_REASK_RETRIES: usize = 2;
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum HarnessKind {
@@ -87,13 +98,20 @@ pub(crate) fn run_fixture_substrate(
     let mut child_request = request_with_workspace_paths(request, &workspace);
     let runtime_receipts =
         run_local_runtime_probes(&mut child_request, &workspace, temp.path(), timeout)?;
-    let fixture_transcript = apply_fixture_template(&raw, request, &request_digest, &capabilities)?;
+    // The fixture stands in for the agent: render its template and write the
+    // result to the same out-path a real substrate would, then read it back
+    // through the one shared parse path. No markers, no transcript scraping.
+    let emitted = apply_fixture_template(&raw, request, &request_digest, &capabilities)?;
+    let out_path = workspace.path().join(ARTIFACT_FILENAME);
+    fs::write(&out_path, emitted.as_bytes())
+        .with_context(|| format!("write fixture artifact {}", out_path.display()))?;
     let transcript = format!(
-        "{}{}",
+        "{}fixture wrote artifact to {}\n\n{}",
         runtime_probe_transcript(&runtime_receipts),
-        fixture_transcript
+        out_path.display(),
+        emitted
     );
-    let artifact = extract_marked_artifact(&transcript)?;
+    let artifact = read_artifact_file(&out_path)?;
     let plan = ExecutionPlan {
         harness: "fixture".to_string(),
         command: fixture_path.display().to_string(),
@@ -150,7 +168,11 @@ pub(crate) fn run_command_substrate(
     let mut child_request = request_with_workspace_paths(request, &workspace);
     let runtime_receipts =
         run_local_runtime_probes(&mut child_request, &workspace, temp.path(), timeout)?;
-    let prompt = build_master_prompt(&child_request, &capabilities, &request_digest)?;
+    // The agent writes its artifact here, inside the workspace it already has
+    // write access to; the harness reads it back. One unambiguous file, not a
+    // span scraped out of the transcript.
+    let out_path = workspace.path().join(ARTIFACT_FILENAME);
+    let prompt = build_master_prompt(&child_request, &capabilities, &request_digest, &out_path)?;
     let prompt_path = temp.path().join("master-prompt.md");
     fs::write(&prompt_path, prompt).context("write master prompt")?;
     set_private_permissions(&prompt_path)?;
@@ -171,6 +193,7 @@ pub(crate) fn run_command_substrate(
             cwd: workspace.path(),
             prompt_path: &prompt_path,
             request_path: &request_path,
+            out_path: &out_path,
             request,
             capabilities: &capabilities,
             request_digest: &request_digest,
@@ -197,37 +220,59 @@ pub(crate) fn run_command_substrate(
             .collect(),
     };
 
-    let start = Instant::now();
-    let mut command = Command::new(&executable);
-    command
-        .args(&args)
-        .current_dir(workspace.path())
-        .stdin(Stdio::null())
-        .env_clear();
-    for (key, value) in allowed_child_env(&request.policy.allowed_env) {
-        command.env(key, value);
-    }
-    command.env("PATH", join_search_path(&trusted_search_path));
-    command.env("HOME", &child_home);
-    command.env("XDG_CACHE_HOME", &child_cache);
-    command.env("XDG_CONFIG_HOME", &child_config);
-    command.env("XDG_DATA_HOME", &child_data);
-    configure_process_group(&mut command);
+    let spawn_attempt = |attempt_args: &[String]| -> Result<CommandOutput> {
+        let start = Instant::now();
+        let mut command = Command::new(&executable);
+        command
+            .args(attempt_args)
+            .current_dir(workspace.path())
+            .stdin(Stdio::null())
+            .env_clear();
+        for (key, value) in allowed_child_env(&request.policy.allowed_env) {
+            command.env(key, value);
+        }
+        command.env("PATH", join_search_path(&trusted_search_path));
+        command.env("HOME", &child_home);
+        command.env("XDG_CACHE_HOME", &child_cache);
+        command.env("XDG_CONFIG_HOME", &child_config);
+        command.env("XDG_DATA_HOME", &child_data);
+        configure_process_group(&mut command);
+        let mut output = run_with_timeout(command, timeout)?;
+        output.elapsed_ms = start.elapsed().as_millis();
+        Ok(output)
+    };
 
-    let output = run_with_timeout(command, timeout)
-        .with_context(|| format!("run {plan_harness} harness"))?;
-    let elapsed_ms = start.elapsed().as_millis();
-    let transcript = format!(
-        "{}exit_status: {}\nelapsed_ms: {}\n\n[stdout]\n{}\n\n[stderr]\n{}",
-        runtime_probe_transcript(&runtime_receipts),
-        output.status,
-        elapsed_ms,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let artifact_text = artifact_text_for_substrate(substrate, &output.stdout, &transcript);
+    let mut output = spawn_attempt(&args).with_context(|| format!("run {plan_harness} harness"))?;
     let telemetry = telemetry_for_substrate(substrate, &output.stdout);
-    let artifact = match extract_marked_artifact(&artifact_text) {
+    let mut transcript = runtime_probe_transcript(&runtime_receipts);
+    append_attempt_transcript(&mut transcript, "initial", None, &output);
+
+    // Read the emitted file and validate it. On a missing/invalid emission, ask
+    // the same OpenCode session to fix it, carrying the exact reason. Bounded and
+    // fail-closed: only a session can be re-asked, so omp/fixture get one shot.
+    let mut artifact_result = read_artifact_file(&out_path);
+    let mut session_id = capture_opencode_session_id(substrate, &output.stdout);
+    let mut attempt = 0;
+    while attempt < MAX_REASK_RETRIES && !is_acceptable(&artifact_result, request) {
+        let Some(session) = session_id.clone() else {
+            break;
+        };
+        let reason = emission_failure_reason(&artifact_result, request);
+        let reask_args =
+            opencode_reask_args(substrate, &session, &reason, &out_path, &request_path);
+        let Some(reask_args) = reask_args else {
+            break;
+        };
+        attempt += 1;
+        output = spawn_attempt(&reask_args).with_context(|| "run opencode re-ask")?;
+        append_attempt_transcript(&mut transcript, "re-ask", Some(&reason), &output);
+        if let Some(next) = capture_opencode_session_id(substrate, &output.stdout) {
+            session_id = Some(next);
+        }
+        artifact_result = read_artifact_file(&out_path);
+    }
+
+    let artifact = match artifact_result {
         Ok(artifact) => artifact,
         Err(err) => {
             write_failure_transcript(failure_transcript, &transcript)?;
@@ -246,15 +291,149 @@ pub(crate) fn run_command_substrate(
     })
 }
 
+/// Read and parse the artifact the agent emitted to its out-path. A missing or
+/// unparseable file is an error (the agent never produced a deliverable), which
+/// the re-ask loop treats as a reason to ask again.
+fn read_artifact_file(out_path: &Path) -> Result<ReviewArtifact> {
+    let raw = fs::read_to_string(out_path)
+        .with_context(|| format!("read emitted review artifact {}", out_path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("parse ReviewArtifact.v1 emitted at {}", out_path.display()))
+}
+
+/// An emission is acceptable only if it parsed AND validates against the request.
+fn is_acceptable(artifact_result: &Result<ReviewArtifact>, request: &ReviewRequest) -> bool {
+    artifact_result
+        .as_ref()
+        .map(|artifact| validate_artifact_for_request(artifact, request).is_ok())
+        .unwrap_or(false)
+}
+
+/// The exact reason an emission was rejected, to carry back into the re-ask so
+/// the agent fixes the real problem rather than guessing.
+fn emission_failure_reason(
+    artifact_result: &Result<ReviewArtifact>,
+    request: &ReviewRequest,
+) -> String {
+    match artifact_result {
+        Err(err) => {
+            format!("the artifact file was missing or not valid ReviewArtifact.v1 JSON ({err:#})")
+        }
+        Ok(artifact) => match validate_artifact_for_request(artifact, request) {
+            Err(err) => format!("the artifact failed validation: {err}"),
+            Ok(()) => "the artifact was accepted".to_string(),
+        },
+    }
+}
+
+/// Capture the OpenCode session id from its JSON event stream so the re-ask can
+/// continue the same conversation. Every event carries a top-level `sessionID`;
+/// the first one is the run's root session. Only OpenCode is session-based.
+fn capture_opencode_session_id(
+    substrate: CommandSubstrateConfig<'_>,
+    stdout: &[u8],
+) -> Option<String> {
+    if !matches!(substrate, CommandSubstrateConfig::Opencode(_)) {
+        return None;
+    }
+    for line in String::from_utf8_lossy(stdout).lines() {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if let Some(session) = value.get("sessionID").and_then(Value::as_str) {
+            if !session.is_empty() {
+                return Some(session.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Build the `opencode run --session <id>` re-ask command that continues the
+/// review session and asks it to rewrite the out-path. Returns `None` for
+/// substrates that cannot continue a session.
+fn opencode_reask_args(
+    substrate: CommandSubstrateConfig<'_>,
+    session: &str,
+    reason: &str,
+    out_path: &Path,
+    request_path: &Path,
+) -> Option<Vec<String>> {
+    let CommandSubstrateConfig::Opencode(config) = substrate else {
+        return None;
+    };
+    let message = format!(
+        "Your previous {filename} was rejected: {reason}. Fix exactly that problem and rewrite the COMPLETE corrected ReviewArtifact.v1 as a single raw JSON object to {out_path}, overwriting it. Write nothing else to that file — no Markdown fences, no prose.",
+        filename = ARTIFACT_FILENAME,
+        reason = reason,
+        out_path = out_path.display(),
+    );
+    let mut args = vec![
+        "run".to_string(),
+        message,
+        "--session".to_string(),
+        session.to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--dir".to_string(),
+        out_path.parent().unwrap_or(out_path).display().to_string(),
+        "--file".to_string(),
+        request_path.display().to_string(),
+    ];
+    push_opencode_optional_flags(&mut args, config);
+    Some(args)
+}
+
+/// Append the optional `--model`/`--agent`/`--attach` flags an OpenCode run
+/// carries. Shared by the initial command and the re-ask so the two cannot drift.
+fn push_opencode_optional_flags(args: &mut Vec<String>, config: &OpenCodeSubstrateConfig) {
+    for (flag, value) in [
+        ("--model", &config.model),
+        ("--agent", &config.agent),
+        ("--attach", &config.attach),
+    ] {
+        if let Some(value) = value {
+            args.push(flag.to_string());
+            args.push(value.clone());
+        }
+    }
+}
+
+/// Append one attempt's command result to the running transcript. The re-ask
+/// reason is recorded so the evidence shows the exact error that was carried
+/// back into the next turn.
+fn append_attempt_transcript(
+    transcript: &mut String,
+    label: &str,
+    reason: Option<&str>,
+    output: &CommandOutput,
+) {
+    transcript.push_str(&format!("[attempt: {label}]\n"));
+    if let Some(reason) = reason {
+        transcript.push_str(&format!("re-ask reason: {reason}\n"));
+    }
+    transcript.push_str(&format!(
+        "exit_status: {}\nelapsed_ms: {}\n\n[stdout]\n{}\n\n[stderr]\n{}\n\n",
+        output.status,
+        output.elapsed_ms,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ));
+}
+
 fn command_for_substrate(
     substrate: CommandSubstrateConfig<'_>,
     input: CommandInput<'_>,
 ) -> Result<(String, Vec<String>, &'static str, &'static str)> {
     match substrate {
         CommandSubstrateConfig::Opencode(config) => {
-            let message =
-                build_opencode_message(input.request, input.capabilities, input.request_digest)
-                    .context("build opencode message")?;
+            let message = build_opencode_message(
+                input.request,
+                input.capabilities,
+                input.request_digest,
+                input.out_path,
+            )
+            .context("build opencode message")?;
             let mut args = vec![
                 "run".to_string(),
                 message,
@@ -265,18 +444,7 @@ fn command_for_substrate(
                 "--file".to_string(),
                 input.request_path.display().to_string(),
             ];
-            if let Some(model) = &config.model {
-                args.push("--model".to_string());
-                args.push(model.clone());
-            }
-            if let Some(agent) = &config.agent {
-                args.push("--agent".to_string());
-                args.push(agent.clone());
-            }
-            if let Some(attach) = &config.attach {
-                args.push("--attach".to_string());
-                args.push(attach.clone());
-            }
+            push_opencode_optional_flags(&mut args, config);
             Ok((
                 config.binary.clone(),
                 args,
@@ -709,6 +877,7 @@ struct CommandInput<'a> {
     cwd: &'a Path,
     prompt_path: &'a Path,
     request_path: &'a Path,
+    out_path: &'a Path,
     request: &'a ReviewRequest,
     capabilities: &'a ContextCapabilities,
     request_digest: &'a str,
@@ -719,6 +888,7 @@ struct CommandOutput {
     status: String,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
+    elapsed_ms: u128,
 }
 
 fn validate_process_status_matches_artifact(status: &str, artifact: &ReviewArtifact) -> Result<()> {
@@ -766,6 +936,7 @@ fn run_with_timeout(mut command: Command, timeout: Duration) -> Result<CommandOu
                 status: status.to_string(),
                 stdout: read_capped_file(stdout_capture.path()).context("read stdout capture")?,
                 stderr: read_capped_file(stderr_capture.path()).context("read stderr capture")?,
+                elapsed_ms: 0,
             });
         }
         if start.elapsed() >= timeout {
@@ -775,6 +946,7 @@ fn run_with_timeout(mut command: Command, timeout: Duration) -> Result<CommandOu
                 status: "timeout".to_string(),
                 stdout: read_capped_file(stdout_capture.path()).context("read stdout capture")?,
                 stderr: read_capped_file(stderr_capture.path()).context("read stderr capture")?,
+                elapsed_ms: 0,
             });
         }
         std::thread::sleep(Duration::from_millis(100));
@@ -903,25 +1075,6 @@ fn kill_process_tree(child: &mut std::process::Child) {
 const OUTPUT_CAPTURE_CAP: usize = 64_000_000;
 const OUTPUT_TRUNCATION_MARKER: &[u8] = b"\n...[cerberus truncated middle]...\n";
 
-#[cfg(test)]
-fn cap_bytes(bytes: Vec<u8>) -> Vec<u8> {
-    if bytes.len() <= OUTPUT_CAPTURE_CAP {
-        return bytes;
-    }
-    let available = OUTPUT_CAPTURE_CAP.saturating_sub(OUTPUT_TRUNCATION_MARKER.len());
-    if available == 0 {
-        bytes[bytes.len() - OUTPUT_CAPTURE_CAP..].to_vec()
-    } else {
-        let head_len = available / 2;
-        let tail_len = available - head_len;
-        let mut capped = Vec::with_capacity(OUTPUT_CAPTURE_CAP);
-        capped.extend_from_slice(&bytes[..head_len]);
-        capped.extend_from_slice(OUTPUT_TRUNCATION_MARKER);
-        capped.extend_from_slice(&bytes[bytes.len() - tail_len..]);
-        capped
-    }
-}
-
 fn read_capped_file(path: &Path) -> Result<Vec<u8>> {
     let mut file = fs::File::open(path)?;
     let len = file.metadata()?.len() as usize;
@@ -951,41 +1104,6 @@ fn read_capped_file(path: &Path) -> Result<Vec<u8>> {
     file.read_exact(&mut tail)?;
     bytes.extend_from_slice(&tail);
     Ok(bytes)
-}
-
-fn artifact_text_for_substrate(
-    substrate: CommandSubstrateConfig<'_>,
-    stdout: &[u8],
-    transcript: &str,
-) -> String {
-    match substrate {
-        CommandSubstrateConfig::Opencode(_) => extract_opencode_text_events(stdout)
-            .filter(|text| !text.trim().is_empty())
-            .unwrap_or_else(|| transcript.to_string()),
-        CommandSubstrateConfig::Omp(_) => transcript.to_string(),
-    }
-}
-
-fn extract_opencode_text_events(stdout: &[u8]) -> Option<String> {
-    let raw = String::from_utf8_lossy(stdout);
-    let mut text = String::new();
-    for line in raw.lines() {
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
-            continue;
-        };
-        if value.get("type").and_then(Value::as_str) != Some("text") {
-            continue;
-        }
-        if let Some(part_text) = value.pointer("/part/text").and_then(Value::as_str) {
-            text.push_str(part_text);
-            text.push('\n');
-        }
-    }
-    if text.trim().is_empty() {
-        None
-    } else {
-        Some(text)
-    }
 }
 
 fn telemetry_for_substrate(
@@ -1055,121 +1173,6 @@ fn unix_timestamp_string() -> String {
     format!("{seconds}")
 }
 
-pub fn extract_marked_artifact(transcript: &str) -> Result<ReviewArtifact> {
-    let mut candidates = Vec::new();
-    let marker_candidates =
-        extract_json_between_markers(transcript, ARTIFACT_BEGIN, ARTIFACT_END, "marker");
-    let xml_candidates = extract_json_between_markers(
-        transcript,
-        "<CERBERUS_REVIEW_ARTIFACT_V1>",
-        "</CERBERUS_REVIEW_ARTIFACT_V1>",
-        "xml",
-    );
-    let explicit_spans = marker_candidates
-        .iter()
-        .chain(xml_candidates.iter())
-        .map(|candidate| (candidate.start, candidate.end))
-        .collect::<Vec<_>>();
-    let raw_candidates = extract_unmarked_artifact_json(transcript, &explicit_spans);
-    let marker_count = marker_candidates.len();
-    let xml_count = xml_candidates.len();
-    let raw_count = raw_candidates.len();
-    candidates.extend(marker_candidates);
-    candidates.extend(xml_candidates);
-    candidates.extend(raw_candidates);
-
-    if candidates.len() != 1 {
-        let begin_count = transcript.matches(ARTIFACT_BEGIN).count();
-        let end_count = transcript.matches(ARTIFACT_END).count();
-        let xml_begin_count = transcript.matches("<CERBERUS_REVIEW_ARTIFACT_V1>").count();
-        let xml_end_count = transcript.matches("</CERBERUS_REVIEW_ARTIFACT_V1>").count();
-        return Err(anyhow!(
-            "expected exactly one ReviewArtifact.v1 candidate, found {marker_count} marker, {xml_count} xml, and {raw_count} raw candidates ({begin_count} begin markers, {end_count} end markers, {xml_begin_count} xml begin markers, {xml_end_count} xml end markers)"
-        ));
-    }
-    serde_json::from_str(&candidates.remove(0).json).context("parse ReviewArtifact.v1 block")
-}
-
-#[derive(Debug)]
-struct ArtifactCandidate {
-    json: String,
-    start: usize,
-    end: usize,
-}
-
-fn extract_json_between_markers(
-    transcript: &str,
-    begin: &str,
-    end: &str,
-    _format: &'static str,
-) -> Vec<ArtifactCandidate> {
-    let mut candidates = Vec::new();
-    let mut cursor = 0;
-    while let Some(relative_start) = transcript[cursor..].find(begin) {
-        let block_start = cursor + relative_start;
-        let content_start = block_start + begin.len();
-        let Some(relative_end) = transcript[content_start..].find(end) else {
-            break;
-        };
-        let content_end = content_start + relative_end;
-        let block_end = content_end + end.len();
-        let candidate = strip_markdown_json_fence(&transcript[content_start..content_end]);
-        if !candidate.is_empty() {
-            candidates.push(ArtifactCandidate {
-                json: candidate.to_string(),
-                start: block_start,
-                end: block_end,
-            });
-        }
-        cursor = block_end;
-    }
-    candidates
-}
-
-fn extract_unmarked_artifact_json(
-    transcript: &str,
-    excluded_spans: &[(usize, usize)],
-) -> Vec<ArtifactCandidate> {
-    let mut candidates = Vec::new();
-    for (start, _) in transcript.match_indices('{') {
-        if excluded_spans
-            .iter()
-            .any(|(span_start, span_end)| start >= *span_start && start < *span_end)
-        {
-            continue;
-        }
-        let slice = &transcript[start..];
-        let mut deserializer = serde_json::Deserializer::from_str(slice);
-        let Ok(value) = Value::deserialize(&mut deserializer) else {
-            continue;
-        };
-        if value.get("schema_version").and_then(Value::as_str) == Some(REVIEW_ARTIFACT_SCHEMA) {
-            candidates.push(ArtifactCandidate {
-                json: value.to_string(),
-                start,
-                end: start,
-            });
-        }
-    }
-    candidates
-}
-
-fn strip_markdown_json_fence(raw: &str) -> &str {
-    let trimmed = raw.trim();
-    let Some(without_prefix) = trimmed.strip_prefix("```") else {
-        return trimmed;
-    };
-    let without_language = without_prefix
-        .strip_prefix("json")
-        .or_else(|| without_prefix.strip_prefix("JSON"))
-        .unwrap_or(without_prefix)
-        .trim_start_matches([' ', '\t', '\r', '\n']);
-    without_language
-        .strip_suffix("```")
-        .unwrap_or(without_language)
-        .trim()
-}
-
 #[cfg(unix)]
 fn set_private_permissions(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
@@ -1201,13 +1204,145 @@ fn set_private_directory_permissions(_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prompt::{ARTIFACT_BEGIN, ARTIFACT_END};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
+    fn test_request() -> ReviewRequest {
+        serde_json::from_value::<ReviewRequest>(serde_json::json!({
+            "schema_version": "cerberus.review_request.v1",
+            "request_id": "req-1",
+            "source": {"kind": "fixture", "metadata": {}},
+            "change": {
+                "title": "change",
+                "diff": {"format": "unified", "body": "diff --git a/src/lib.rs b/src/lib.rs\n"},
+                "files": []
+            },
+            "context": {},
+            "policy": {}
+        }))
+        .unwrap()
+    }
+
     #[test]
-    fn rejects_missing_marker_block() {
-        assert!(extract_marked_artifact("{}").is_err());
+    fn reads_artifact_emitted_to_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let out_path = temp.path().join(ARTIFACT_FILENAME);
+        fs::write(&out_path, minimal_artifact_json()).unwrap();
+
+        let artifact = read_artifact_file(&out_path).unwrap();
+
+        assert_eq!(artifact.request_id, "req-1");
+    }
+
+    #[test]
+    fn missing_emission_file_is_an_error() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(read_artifact_file(&temp.path().join("absent.json")).is_err());
+    }
+
+    #[test]
+    fn unparseable_emission_file_is_an_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let out_path = temp.path().join(ARTIFACT_FILENAME);
+        fs::write(&out_path, "this is not a review artifact").unwrap();
+
+        assert!(read_artifact_file(&out_path).is_err());
+    }
+
+    #[test]
+    fn captures_root_session_id_from_opencode_events() {
+        let config = test_opencode_config();
+        let stdout = b"{\"type\":\"step_start\",\"sessionID\":\"ses_root\",\"part\":{}}\n{\"type\":\"step_finish\",\"sessionID\":\"ses_root\"}\n";
+
+        let session =
+            capture_opencode_session_id(CommandSubstrateConfig::Opencode(&config), stdout);
+
+        assert_eq!(session.as_deref(), Some("ses_root"));
+    }
+
+    #[test]
+    fn omp_substrate_has_no_session_to_continue() {
+        let config = OmpSubstrateConfig {
+            binary: "omp".to_string(),
+            model: None,
+        };
+        let stdout = b"{\"type\":\"step_start\",\"sessionID\":\"ses_root\"}\n";
+
+        assert!(
+            capture_opencode_session_id(CommandSubstrateConfig::Omp(&config), stdout).is_none()
+        );
+    }
+
+    #[test]
+    fn emission_failure_reason_carries_the_validation_error() {
+        let request = test_request();
+        // Parses fine but its request_digest cannot match the request digest.
+        let artifact: ReviewArtifact = serde_json::from_str(&minimal_artifact_json()).unwrap();
+
+        let reason = emission_failure_reason(&Ok(artifact), &request);
+
+        assert!(
+            reason.contains("failed validation"),
+            "reason should name the validation failure: {reason}"
+        );
+        assert!(
+            reason.contains("request digest"),
+            "reason should carry the exact validator message: {reason}"
+        );
+    }
+
+    #[test]
+    fn emission_failure_reason_carries_the_parse_error() {
+        let request = test_request();
+        let parse_error = read_artifact_file(Path::new("/cerberus/does-not-exist.json"));
+
+        let reason = emission_failure_reason(&parse_error, &request);
+
+        assert!(
+            reason.contains("missing or not valid"),
+            "reason should explain the file was unusable: {reason}"
+        );
+    }
+
+    #[test]
+    fn opencode_reask_continues_the_session_and_names_the_out_path() {
+        let config = test_opencode_config();
+        let out_path = Path::new("/work/repo/review-artifact.json");
+        let request_path = Path::new("/tmp/cerberus/review-request.json");
+
+        let args = opencode_reask_args(
+            CommandSubstrateConfig::Opencode(&config),
+            "ses_root",
+            "the artifact failed validation: artifact request digest mismatch",
+            out_path,
+            request_path,
+        )
+        .unwrap();
+
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--session", "ses_root"]));
+        assert!(args.windows(2).any(|pair| pair == ["--format", "json"]));
+        assert!(args.windows(2).any(|pair| pair == ["--dir", "/work/repo"]));
+        let message = &args[1];
+        assert!(message.contains("/work/repo/review-artifact.json"));
+        assert!(message.contains("request digest mismatch"));
+    }
+
+    #[test]
+    fn omp_substrate_cannot_be_re_asked() {
+        let config = OmpSubstrateConfig {
+            binary: "omp".to_string(),
+            model: None,
+        };
+        assert!(opencode_reask_args(
+            CommandSubstrateConfig::Omp(&config),
+            "ses_root",
+            "reason",
+            Path::new("/work/review-artifact.json"),
+            Path::new("/tmp/request.json"),
+        )
+        .is_none());
     }
 
     #[cfg(unix)]
@@ -1284,149 +1419,6 @@ mod tests {
     }
 
     #[test]
-    fn rejects_multiple_marker_blocks() {
-        let artifact = minimal_artifact_json();
-        let transcript = format!(
-            "{begin}{artifact}{end}\n{begin}{artifact}{end}",
-            begin = ARTIFACT_BEGIN,
-            artifact = artifact,
-            end = ARTIFACT_END
-        );
-        assert!(extract_marked_artifact(&transcript).is_err());
-    }
-
-    #[test]
-    fn rejects_marker_and_xml_artifact_candidates_together() {
-        let artifact = minimal_artifact_json();
-        let transcript = format!(
-            "{begin}{artifact}{end}\n<CERBERUS_REVIEW_ARTIFACT_V1>{artifact}</CERBERUS_REVIEW_ARTIFACT_V1>",
-            begin = ARTIFACT_BEGIN,
-            artifact = artifact,
-            end = ARTIFACT_END
-        );
-        assert!(extract_marked_artifact(&transcript).is_err());
-    }
-
-    #[test]
-    fn rejects_marker_and_raw_artifact_candidates_together() {
-        let artifact = minimal_artifact_json();
-        let transcript = format!(
-            "{begin}{artifact}{end}\n{artifact}",
-            begin = ARTIFACT_BEGIN,
-            artifact = artifact,
-            end = ARTIFACT_END
-        );
-        assert!(extract_marked_artifact(&transcript).is_err());
-    }
-
-    #[test]
-    fn rejects_multiple_xml_artifact_candidates() {
-        let artifact = minimal_artifact_json();
-        let transcript = format!(
-            "<CERBERUS_REVIEW_ARTIFACT_V1>{artifact}</CERBERUS_REVIEW_ARTIFACT_V1>\n<CERBERUS_REVIEW_ARTIFACT_V1>{artifact}</CERBERUS_REVIEW_ARTIFACT_V1>",
-            artifact = artifact
-        );
-        assert!(extract_marked_artifact(&transcript).is_err());
-    }
-
-    #[test]
-    fn rejects_xml_and_raw_artifact_candidates_together() {
-        let artifact = minimal_artifact_json();
-        let transcript = format!(
-            "<CERBERUS_REVIEW_ARTIFACT_V1>{artifact}</CERBERUS_REVIEW_ARTIFACT_V1>\n{artifact}",
-            artifact = artifact
-        );
-        assert!(extract_marked_artifact(&transcript).is_err());
-    }
-
-    #[test]
-    fn rejects_multiple_raw_artifact_candidates() {
-        let artifact = minimal_artifact_json();
-        let transcript = format!("first\n{artifact}\nsecond\n{artifact}", artifact = artifact);
-        assert!(extract_marked_artifact(&transcript).is_err());
-    }
-
-    #[test]
-    fn extracts_artifact_inside_markdown_json_fence() {
-        let transcript = format!(
-            "{begin}\n```json\n{json}\n```\n{end}",
-            begin = ARTIFACT_BEGIN,
-            json = minimal_artifact_json(),
-            end = ARTIFACT_END
-        );
-        assert_eq!(
-            extract_marked_artifact(&transcript).unwrap().request_id,
-            "req-1"
-        );
-    }
-
-    #[test]
-    fn extracts_artifact_from_opencode_xml_wrapper_variant() {
-        let transcript = format!(
-            "```json\n<CERBERUS_REVIEW_ARTIFACT_V1>\n{json}\n</CERBERUS_REVIEW_ARTIFACT_V1>\n```",
-            json = minimal_artifact_json()
-        );
-        assert_eq!(
-            extract_marked_artifact(&transcript).unwrap().request_id,
-            "req-1"
-        );
-    }
-
-    #[test]
-    fn extracts_unmarked_review_artifact_json_from_prose() {
-        let transcript = format!(
-            "Here is the review.\n```json\n{json}\n```\nDone.",
-            json = minimal_artifact_json()
-        );
-        assert_eq!(
-            extract_marked_artifact(&transcript).unwrap().request_id,
-            "req-1"
-        );
-    }
-
-    #[test]
-    fn extracts_raw_review_artifact_json_after_prose_prefix() {
-        let transcript = format!(
-            "I have enough evidence.\n\n{json}",
-            json = minimal_artifact_json()
-        );
-
-        assert_eq!(
-            extract_marked_artifact(&transcript).unwrap().request_id,
-            "req-1"
-        );
-    }
-
-    #[test]
-    fn opencode_json_events_are_reduced_to_text_before_artifact_scan() {
-        let artifact = minimal_artifact_json();
-        let event = serde_json::json!({
-            "type": "text",
-            "part": {
-                "text": format!(
-                    "{begin}\n{artifact}\n{end}",
-                    begin = ARTIFACT_BEGIN,
-                    artifact = artifact,
-                    end = ARTIFACT_END
-                )
-            }
-        });
-        let stdout = format!(
-            "{{\"type\":\"start\"}}\n{}\nnot json\n",
-            serde_json::to_string(&event).unwrap()
-        );
-        let config = test_opencode_config();
-        let text = artifact_text_for_substrate(
-            CommandSubstrateConfig::Opencode(&config),
-            stdout.as_bytes(),
-            "fallback",
-        );
-        assert!(text.contains(ARTIFACT_BEGIN));
-        assert!(!text.contains("\"type\":\"text\""));
-        assert_eq!(extract_marked_artifact(&text).unwrap().request_id, "req-1");
-    }
-
-    #[test]
     fn bare_substrate_binary_resolves_only_from_trusted_search_path() {
         let temp = tempfile::tempdir().unwrap();
         let hostile_dir = temp.path().join("hostile-bin");
@@ -1460,52 +1452,6 @@ mod tests {
 
     #[cfg(not(unix))]
     fn set_executable(_path: &Path) {}
-
-    #[test]
-    fn opencode_artifact_scan_falls_back_to_transcript_without_text_events() {
-        let stdout = b"{\"type\":\"start\"}\n{\"type\":\"end\"}\n";
-        let transcript = format!(
-            "{begin}\n{artifact}\n{end}",
-            begin = ARTIFACT_BEGIN,
-            artifact = minimal_artifact_json(),
-            end = ARTIFACT_END
-        );
-
-        let config = test_opencode_config();
-        let text = artifact_text_for_substrate(
-            CommandSubstrateConfig::Opencode(&config),
-            stdout,
-            &transcript,
-        );
-
-        assert_eq!(text, transcript);
-        assert_eq!(extract_marked_artifact(&text).unwrap().request_id, "req-1");
-    }
-
-    #[test]
-    fn opencode_artifact_survives_large_stdout_tail_capture() {
-        let artifact = minimal_artifact_json();
-        let event = serde_json::json!({
-            "type": "text",
-            "part": {
-                "text": artifact
-            }
-        });
-        let mut stdout = vec![b'a'; OUTPUT_CAPTURE_CAP + 250_000];
-        stdout.extend_from_slice(b"\n");
-        stdout.extend_from_slice(serde_json::to_string(&event).unwrap().as_bytes());
-        stdout.extend_from_slice(b"\n");
-
-        let capped = cap_bytes(stdout);
-        assert!(String::from_utf8_lossy(&capped).contains("cerberus truncated middle"));
-        let config = test_opencode_config();
-        let text = artifact_text_for_substrate(
-            CommandSubstrateConfig::Opencode(&config),
-            &capped,
-            "fallback",
-        );
-        assert_eq!(extract_marked_artifact(&text).unwrap().request_id, "req-1");
-    }
 
     #[cfg(unix)]
     #[test]
@@ -1615,6 +1561,7 @@ mod tests {
                 cwd: Path::new("/work/repo"),
                 prompt_path: Path::new("/tmp/cerberus-test/master-prompt.md"),
                 request_path: Path::new("/tmp/cerberus-test/review-request.json"),
+                out_path: Path::new("/work/repo/review-artifact.json"),
                 request: &request,
                 capabilities: &capabilities,
                 request_digest: &request_digest,
@@ -1638,6 +1585,11 @@ mod tests {
         assert!(args
             .windows(2)
             .any(|pair| pair == ["--attach", "http://127.0.0.1:4096"]));
+        assert!(
+            args.iter()
+                .any(|arg| arg.contains("/work/repo/review-artifact.json")),
+            "the opencode message must name the artifact out-path"
+        );
     }
 
     fn test_opencode_config() -> OpenCodeSubstrateConfig {

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -247,28 +247,25 @@ pub(crate) fn run_command_substrate(
     let mut transcript = runtime_probe_transcript(&runtime_receipts);
     append_attempt_transcript(&mut transcript, "initial", None, &output);
 
-    // Read the emitted file and validate it. On a missing/invalid emission, ask
-    // the same OpenCode session to fix it, carrying the exact reason. Bounded and
-    // fail-closed: only a session can be re-asked, so omp/fixture get one shot.
+    // Read the emitted file and check it. While it is unacceptable, ask the same
+    // OpenCode session to fix it, carrying the exact reason. Bounded and
+    // fail-closed: only OpenCode can be re-asked (opencode_reask_args returns None
+    // otherwise), so omp/fixture get one shot and a still-bad artifact falls
+    // through to the validation gate below — never silently accepted.
     let mut artifact_result = read_artifact_file(&out_path);
-    let mut session_id = capture_opencode_session_id(substrate, &output.stdout);
     let mut attempt = 0;
-    while attempt < MAX_REASK_RETRIES && !is_acceptable(&artifact_result, request) {
-        let Some(session) = session_id.clone() else {
+    while let Err(reason) = evaluate_emission(&artifact_result, request) {
+        if attempt >= MAX_REASK_RETRIES {
             break;
-        };
-        let reason = emission_failure_reason(&artifact_result, request);
-        let reask_args =
-            opencode_reask_args(substrate, &session, &reason, &out_path, &request_path);
-        let Some(reask_args) = reask_args else {
+        }
+        let Some(reask_args) =
+            opencode_reask_args(substrate, &output.stdout, &reason, &out_path, &request_path)
+        else {
             break;
         };
         attempt += 1;
         output = spawn_attempt(&reask_args).with_context(|| "run opencode re-ask")?;
         append_attempt_transcript(&mut transcript, "re-ask", Some(&reason), &output);
-        if let Some(next) = capture_opencode_session_id(substrate, &output.stdout) {
-            session_id = Some(next);
-        }
         artifact_result = read_artifact_file(&out_path);
     }
 
@@ -301,64 +298,45 @@ fn read_artifact_file(out_path: &Path) -> Result<ReviewArtifact> {
         .with_context(|| format!("parse ReviewArtifact.v1 emitted at {}", out_path.display()))
 }
 
-/// An emission is acceptable only if it parsed AND validates against the request.
-fn is_acceptable(artifact_result: &Result<ReviewArtifact>, request: &ReviewRequest) -> bool {
-    artifact_result
-        .as_ref()
-        .map(|artifact| validate_artifact_for_request(artifact, request).is_ok())
-        .unwrap_or(false)
-}
-
-/// The exact reason an emission was rejected, to carry back into the re-ask so
-/// the agent fixes the real problem rather than guessing.
-fn emission_failure_reason(
+/// Evaluate an emitted artifact: `Ok(())` if it parsed and validates against the
+/// request, `Err(reason)` carrying the exact failure to feed back into a re-ask
+/// so the agent fixes the real problem rather than guessing.
+fn evaluate_emission(
     artifact_result: &Result<ReviewArtifact>,
     request: &ReviewRequest,
-) -> String {
-    match artifact_result {
-        Err(err) => {
-            format!("the artifact file was missing or not valid ReviewArtifact.v1 JSON ({err:#})")
-        }
-        Ok(artifact) => match validate_artifact_for_request(artifact, request) {
-            Err(err) => format!("the artifact failed validation: {err}"),
-            Ok(()) => "the artifact was accepted".to_string(),
-        },
-    }
+) -> std::result::Result<(), String> {
+    let artifact = artifact_result.as_ref().map_err(|err| {
+        format!("the artifact file was missing or not valid ReviewArtifact.v1 JSON ({err:#})")
+    })?;
+    validate_artifact_for_request(artifact, request)
+        .map_err(|err| format!("the artifact failed validation: {err}"))
 }
 
-/// Capture the OpenCode session id from its JSON event stream so the re-ask can
-/// continue the same conversation. Every event carries a top-level `sessionID`,
-/// and the first one is the run's root session: a session must exist before it
-/// can spawn a subagent, so the root's first event always precedes any child's.
-/// If that ever did not hold, the re-ask would continue the wrong session and
-/// re-read a still-invalid file — bounded retries then fail closed, never a
-/// silent accept. Only OpenCode is session-based; omp/fixture return `None`.
-fn capture_opencode_session_id(
-    substrate: CommandSubstrateConfig<'_>,
-    stdout: &[u8],
-) -> Option<String> {
-    if !matches!(substrate, CommandSubstrateConfig::Opencode(_)) {
-        return None;
-    }
-    for line in String::from_utf8_lossy(stdout).lines() {
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
-            continue;
-        };
-        if let Some(session) = value.get("sessionID").and_then(Value::as_str) {
-            if !session.is_empty() {
-                return Some(session.to_string());
-            }
-        }
-    }
-    None
+/// First `sessionID` in an OpenCode JSON event stream — the run's root session.
+/// A session must exist before it can spawn a subagent, so the root's first event
+/// always precedes any child's. Even if that did not hold, continuing the wrong
+/// session would re-read a still-invalid file and fail closed, never silently
+/// accept.
+fn first_opencode_session_id(stdout: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(stdout).lines().find_map(|line| {
+        serde_json::from_str::<Value>(line)
+            .ok()?
+            .get("sessionID")
+            .and_then(Value::as_str)
+            .filter(|session| !session.is_empty())
+            .map(str::to_string)
+    })
 }
 
-/// Build the `opencode run --session <id>` re-ask command that continues the
-/// review session and asks it to rewrite the out-path. Returns `None` for
-/// substrates that cannot continue a session.
+/// Build the `opencode run --session <id>` re-ask that continues the review
+/// session (captured from its prior output) and asks it to rewrite the out-path,
+/// carrying the exact `reason`. Returns `None` for substrates that cannot
+/// continue a session (omp/fixture) or when no session id was emitted — either
+/// way the caller stops re-asking. This is the single gate that makes the re-ask
+/// OpenCode-only.
 fn opencode_reask_args(
     substrate: CommandSubstrateConfig<'_>,
-    session: &str,
+    stdout: &[u8],
     reason: &str,
     out_path: &Path,
     request_path: &Path,
@@ -366,6 +344,7 @@ fn opencode_reask_args(
     let CommandSubstrateConfig::Opencode(config) = substrate else {
         return None;
     };
+    let session = first_opencode_session_id(stdout)?;
     let message = format!(
         "Your previous {filename} was rejected: {reason}. Fix exactly that problem and rewrite the COMPLETE corrected ReviewArtifact.v1 as a single raw JSON object to {out_path}, overwriting it. Write nothing else to that file — no Markdown fences, no prose.",
         filename = ARTIFACT_FILENAME,
@@ -376,7 +355,7 @@ fn opencode_reask_args(
         "run".to_string(),
         message,
         "--session".to_string(),
-        session.to_string(),
+        session,
         "--format".to_string(),
         "json".to_string(),
         "--dir".to_string(),
@@ -1262,35 +1241,21 @@ mod tests {
 
     #[test]
     fn captures_root_session_id_from_opencode_events() {
-        let config = test_opencode_config();
         let stdout = b"{\"type\":\"step_start\",\"sessionID\":\"ses_root\",\"part\":{}}\n{\"type\":\"step_finish\",\"sessionID\":\"ses_root\"}\n";
 
-        let session =
-            capture_opencode_session_id(CommandSubstrateConfig::Opencode(&config), stdout);
-
-        assert_eq!(session.as_deref(), Some("ses_root"));
-    }
-
-    #[test]
-    fn omp_substrate_has_no_session_to_continue() {
-        let config = OmpSubstrateConfig {
-            binary: "omp".to_string(),
-            model: None,
-        };
-        let stdout = b"{\"type\":\"step_start\",\"sessionID\":\"ses_root\"}\n";
-
-        assert!(
-            capture_opencode_session_id(CommandSubstrateConfig::Omp(&config), stdout).is_none()
+        assert_eq!(
+            first_opencode_session_id(stdout).as_deref(),
+            Some("ses_root")
         );
     }
 
     #[test]
-    fn emission_failure_reason_carries_the_validation_error() {
+    fn evaluate_emission_carries_the_validation_error() {
         let request = test_request();
         // Parses fine but its request_digest cannot match the request digest.
         let artifact: ReviewArtifact = serde_json::from_str(&minimal_artifact_json()).unwrap();
 
-        let reason = emission_failure_reason(&Ok(artifact), &request);
+        let reason = evaluate_emission(&Ok(artifact), &request).unwrap_err();
 
         assert!(
             reason.contains("failed validation"),
@@ -1303,11 +1268,11 @@ mod tests {
     }
 
     #[test]
-    fn emission_failure_reason_carries_the_parse_error() {
+    fn evaluate_emission_carries_the_parse_error() {
         let request = test_request();
         let parse_error = read_artifact_file(Path::new("/cerberus/does-not-exist.json"));
 
-        let reason = emission_failure_reason(&parse_error, &request);
+        let reason = evaluate_emission(&parse_error, &request).unwrap_err();
 
         assert!(
             reason.contains("missing or not valid"),
@@ -1316,14 +1281,26 @@ mod tests {
     }
 
     #[test]
+    fn evaluate_emission_accepts_a_valid_artifact() {
+        let request = test_request();
+        let mut artifact: ReviewArtifact = serde_json::from_str(&minimal_artifact_json()).unwrap();
+        artifact.request_id = request.request_id.clone();
+        artifact.request_digest = request_digest(&request).unwrap();
+        artifact.context_capabilities = ContextCapabilities::from_request(&request);
+
+        assert!(evaluate_emission(&Ok(artifact), &request).is_ok());
+    }
+
+    #[test]
     fn opencode_reask_continues_the_session_and_names_the_out_path() {
         let config = test_opencode_config();
+        let stdout = b"{\"type\":\"step_start\",\"sessionID\":\"ses_root\"}\n";
         let out_path = Path::new("/work/repo/review-artifact.json");
         let request_path = Path::new("/tmp/cerberus/review-request.json");
 
         let args = opencode_reask_args(
             CommandSubstrateConfig::Opencode(&config),
-            "ses_root",
+            stdout,
             "the artifact failed validation: artifact request digest mismatch",
             out_path,
             request_path,
@@ -1346,9 +1323,10 @@ mod tests {
             binary: "omp".to_string(),
             model: None,
         };
+        let stdout = b"{\"type\":\"step_start\",\"sessionID\":\"ses_root\"}\n";
         assert!(opencode_reask_args(
             CommandSubstrateConfig::Omp(&config),
-            "ses_root",
+            stdout,
             "reason",
             Path::new("/work/review-artifact.json"),
             Path::new("/tmp/request.json"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,7 @@ pub mod validation;
 
 pub use digest::{request_digest, sha256_digest};
 pub use harness::{
-    extract_marked_artifact, FixtureSubstrateConfig, HarnessKind, OmpSubstrateConfig,
-    OpenCodeSubstrateConfig,
+    FixtureSubstrateConfig, HarnessKind, OmpSubstrateConfig, OpenCodeSubstrateConfig,
 };
 pub use kernel::{ReviewKernel, ReviewRun, ReviewSubstrate, RunPolicy};
 pub use post::{build_post_plan, GithubClient, PostPlan, SummaryTarget};

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,7 +1,6 @@
-use crate::schema::{ContextCapabilities, ReviewRequest};
+use std::path::Path;
 
-pub const ARTIFACT_BEGIN: &str = "-----BEGIN CERBERUS_REVIEW_ARTIFACT_V1-----";
-pub const ARTIFACT_END: &str = "-----END CERBERUS_REVIEW_ARTIFACT_V1-----";
+use crate::schema::{ContextCapabilities, ReviewRequest};
 
 const ARTIFACT_FIELD_PATHS: &[&str] = &[
     "schema_version",
@@ -181,10 +180,12 @@ pub fn build_master_prompt(
     request: &ReviewRequest,
     capabilities: &ContextCapabilities,
     request_digest: &str,
+    out_path: &Path,
 ) -> Result<String, serde_json::Error> {
     let request_json = serde_json::to_string_pretty(request)?;
     let capabilities_json = serde_json::to_string_pretty(capabilities)?;
     let contract_checklist = artifact_contract_checklist();
+    let out_path = out_path.display();
     Ok(format!(
         r#"You are Cerberus, the master code reviewer.
 
@@ -202,9 +203,7 @@ Mission:
 - External research is allowed only if the request policy permits it. External claims require citations.
 - Blocking findings must cite concrete anchors.
 - PASS requires enough inspected evidence for the available context. If repo_head is true but direct checkout inspection fails or is skipped, use completed_degraded or WARN and record why.
-- Produce exactly one raw JSON artifact and nothing else.
-- The first output character must be `{{` and the last output character must be `}}`.
-- Do not wrap the artifact in Markdown fences or marker text.
+- Emit your review by writing one ReviewArtifact.v1 object to the file at {out_path} using your write tool. That file is your only deliverable: it must hold exactly one raw JSON object and nothing else — no Markdown fences, no prose. Overwrite it completely if it already exists.
 
 Required ReviewArtifact.v1 fields:
 - schema_version: "cerberus.review_artifact.v1"
@@ -254,15 +253,17 @@ pub fn build_opencode_message(
     request: &ReviewRequest,
     capabilities: &ContextCapabilities,
     request_digest: &str,
+    out_path: &Path,
 ) -> Result<String, serde_json::Error> {
     let capabilities_json = serde_json::to_string(capabilities)?;
     let contract_checklist = artifact_contract_checklist();
     Ok(format!(
-        "You are Cerberus, the master code reviewer. Read the attached ReviewRequest.v1 JSON file. Request id: {request_id}. Request digest: {request_digest}. ContextCapabilities: {capabilities_json}. Final response contract: return exactly one raw JSON ReviewArtifact.v1 object and nothing else; first character must be {{ and last character must be }}. If repo_head is true, explore the repository thoroughly and autonomously: use read, grep, glob, and the shell (ripgrep, ast-grep, git log/diff/blame) to understand the change in the context of the whole codebase and its history. The attached diff is a starting point, not your only evidence, and there is no fixed read budget. Be thorough but decisive: inspect the changed files and the code they directly touch — callers, callees, tests, and related config — then STOP exploring and emit your artifact. You do not need to read the entire repository, and you are on a wall-clock limit: producing one complete, grounded artifact is the objective, and an exploration that never emits an artifact is a failed review. If repo_base is true, compare relevant base files before making regression or behavior-change claims. Review like a senior engineer: prioritize correctness, security, and behavior regressions over style; ground every finding in a specific line you actually inspected and anchor it there; prefer a few high-signal findings over many low-value ones; never invent issues, and if the change is clean return PASS with empty findings; calibrate severity honestly and record what you did not inspect in summary.residual_risk. Use the shell only for read-only exploration; do not run builds, tests, applications, or network probes as evidence, and do not claim test, build, runtime, or QA results, unless local_runtime or remote_runtime is true (then rely only on the attached transcripts). Strict schema: lifecycle_state is completed/completed_degraded/failed/skipped/cancelled/stale; verdict is PASS/WARN/FAIL/SKIP; severity is info/minor/major/critical. summary must be an object {{\"title\",\"body\",\"analysis\",\"residual_risk\":[]}}. findings must be objects {{\"id\",\"severity\",\"category\",\"title\",\"description\",\"evidence\",\"confidence\":0.0,\"anchors\":[],\"citations\":[],\"suggested_fixes\":[]}}, where citations and suggested_fixes are arrays of string ids only. comments must be objects {{\"id\",\"kind\":\"inline|contextual\",\"intent\":\"finding|note|question|summary\",\"finding_id\":null,\"body\",\"anchor\":{{\"kind\":\"inline|file|change|run\",\"path\":null,\"line\":null}},\"dedupe_key\":null,\"suggested_fixes\":[]}}, where suggested_fixes is an array of string ids only. Top-level suggested_fixes must be objects {{\"id\",\"finding_id\":null,\"applicability\":\"safe|needs_review\",\"format\":\"instructions|replacement|unified_diff\",\"edits\":[],\"diff\":null}}. citations must be [] unless needed; citation.used_by may contain only exact finding.id values, never comment ids or citation ids; URL citations require observed_at. receipts must include {{\"id\":\"receipt-master\",\"role\":\"master\",\"harness\":\"opencode\",\"status\":\"completed\",\"verdict\":verdict,\"summary\":\"evidence inspected\",\"artifact_digest\":null,\"transcript_uri\":null,\"usage\":null}}. run must include {{\"engine_version\":\"cerberus-opencode\",\"config_digest\":\"sha256:prompt-only\",\"started_at\":\"0\",\"finished_at\":\"0\",\"duration_ms\":0,\"cost_usd\":null,\"coverage\":{{\"files_reviewed\":[],\"files_with_findings\":[]}}}}. {contract_checklist} Set run.coverage.files_reviewed to only files you actually inspected; if you skip changed files because of limits, record that reduced scope in lifecycle_state and summary.residual_risk. Prefer empty arrays over malformed objects.",
+        "You are Cerberus, the master code reviewer. Read the attached ReviewRequest.v1 JSON file. Request id: {request_id}. Request digest: {request_digest}. ContextCapabilities: {capabilities_json}. If repo_head is true, explore the repository thoroughly and autonomously: use read, grep, glob, and the shell (ripgrep, ast-grep, git log/diff/blame) to understand the change in the context of the whole codebase and its history. The attached diff is a starting point, not your only evidence, and there is no fixed read budget. Be thorough but decisive: inspect the changed files and the code they directly touch — callers, callees, tests, and related config — then STOP exploring and emit your artifact. You do not need to read the entire repository, and you are on a wall-clock limit: producing one complete, grounded artifact is the objective, and an exploration that never emits an artifact is a failed review. If repo_base is true, compare relevant base files before making regression or behavior-change claims. Review like a senior engineer: prioritize correctness, security, and behavior regressions over style; ground every finding in a specific line you actually inspected and anchor it there; prefer a few high-signal findings over many low-value ones; never invent issues, and if the change is clean return PASS with empty findings; calibrate severity honestly and record what you did not inspect in summary.residual_risk. Use the shell only for read-only exploration; do not run builds, tests, applications, or network probes as evidence, and do not claim test, build, runtime, or QA results, unless local_runtime or remote_runtime is true (then rely only on the attached transcripts). Set run.coverage.files_reviewed to only files you actually inspected; if you skip changed files because of limits, record that reduced scope in lifecycle_state and summary.residual_risk. {contract_checklist} Emit your review by writing one ReviewArtifact.v1 object to the file at {out_path} using your write tool — that file is your only deliverable. It must hold exactly one raw JSON object and nothing else: no Markdown fences, no prose, no surrounding text. Set request_id and request_digest to the exact values above. Overwrite the file completely if it already exists, and once it holds the complete valid artifact you are done.",
         request_id = request.request_id.as_str(),
         request_digest = request_digest,
         capabilities_json = capabilities_json,
-        contract_checklist = contract_checklist
+        contract_checklist = contract_checklist,
+        out_path = out_path.display(),
     ))
 }
 
@@ -270,6 +271,11 @@ pub fn build_opencode_message(
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+    use std::path::Path;
+
+    fn out_path() -> &'static Path {
+        Path::new("/work/repo/review-artifact.json")
+    }
 
     use crate::schema::{
         Anchor, AnchorKind, Citation, CitationKind, Comment, CommentIntent, CommentKind, Coverage,
@@ -283,8 +289,10 @@ mod tests {
     fn prompts_embed_generated_artifact_contract() {
         let request = minimal_request();
         let capabilities = ContextCapabilities::from_request(&request);
-        let prompt = build_master_prompt(&request, &capabilities, "sha256:test").unwrap();
-        let message = build_opencode_message(&request, &capabilities, "sha256:test").unwrap();
+        let prompt =
+            build_master_prompt(&request, &capabilities, "sha256:test", out_path()).unwrap();
+        let message =
+            build_opencode_message(&request, &capabilities, "sha256:test", out_path()).unwrap();
         let contract = artifact_contract_checklist();
 
         assert!(prompt.contains(&contract));
@@ -307,7 +315,8 @@ mod tests {
     fn opencode_message_drops_exploration_cap_and_adds_review_craft() {
         let request = minimal_request();
         let capabilities = ContextCapabilities::from_request(&request);
-        let message = build_opencode_message(&request, &capabilities, "sha256:test").unwrap();
+        let message =
+            build_opencode_message(&request, &capabilities, "sha256:test", out_path()).unwrap();
         assert!(
             !message.contains("at most eight"),
             "the fixture-era read cap must be gone"
@@ -318,6 +327,29 @@ mod tests {
         );
         assert!(message.contains("explore the repository thoroughly and autonomously"));
         assert!(message.contains("Review like a senior engineer"));
+    }
+
+    #[test]
+    fn prompts_instruct_file_emission_not_raw_stdout() {
+        let request = minimal_request();
+        let capabilities = ContextCapabilities::from_request(&request);
+        let message =
+            build_opencode_message(&request, &capabilities, "sha256:test", out_path()).unwrap();
+        let master =
+            build_master_prompt(&request, &capabilities, "sha256:test", out_path()).unwrap();
+        for prompt in [&message, &master] {
+            assert!(
+                prompt.contains("/work/repo/review-artifact.json"),
+                "emission target path must be named in the prompt"
+            );
+            assert!(
+                prompt.contains("your write tool"),
+                "the agent must be told to write the artifact as a file"
+            );
+        }
+        // The raw-stdout / first-character marker contract is gone: emission is a file now.
+        assert!(!message.contains("first character must be"));
+        assert!(!master.contains("first output character must be"));
     }
 
     #[test]


### PR DESCRIPTION
Closes backlog **016-review-emission**. Shape: `docs/plans/016-review-emission.html`.

## What changed
The review agent had to type the entire `ReviewArtifact.v1` as one JSON blob in its final message, and a defensive marker/XML/raw-scan parser tried to recover it from the transcript (it failed live twice). This replaces that with the simplest thing that works:

- **Emit** — the agent writes its `ReviewArtifact.v1` to `<workspace>/review-artifact.json` with its existing write tool; the harness reads + `serde`-parses that one file. The prompt drops the ~1800-char field-by-field lecture and the raw-output marker rules, keeping the generated contract checklist.
- **Re-ask** — on a missing/invalid emission, the harness continues the same OpenCode session (`opencode run --session <id>`) carrying the exact validation error, asking it to rewrite the file. Bounded at **2 retries** and **fail-closed** — an artifact that never validates is still an error, never silently accepted.
- **Delete** — `extract_marked_artifact` / `extract_opencode_text_events` / `extract_json_between_markers` / `extract_unmarked_artifact_json` / `strip_markdown_json_fence` / `artifact_text_for_substrate`, the `ARTIFACT_BEGIN/END` markers, and all their tests. **No new dependency.**

The caller-neutral artifact contract, `validation.rs`, and `post.rs` are unchanged: Cerberus still validates and posts; the agent never touches GitHub. Per ADR 0003, contract/validation stay deterministic; reliable emission is harness engineering (the re-ask).

## Oracle — all green
1. ✅ **Re-ask recovers (the test):** `verify.sh` drives a malformed-then-corrected fixture (`CERBERUS_FAKE_OPENCODE_FIRST_INVALID`); the review succeeds *only* via the re-ask and the transcript carries the exact `artifact request digest mismatch` error back.
2. ✅ **Parser gone:** `rg 'extract_marked_artifact|ARTIFACT_BEGIN|extract_unmarked_artifact_json' src/` → no hits.
3. ✅ **No regression / no new dep:** `./scripts/verify.sh` exit 0; `git diff Cargo.toml` empty.
4. ✅ **Bounded + fail-closed:** `while attempt < 2 && !is_acceptable(...)`; a parseable-but-invalid artifact is still surfaced to `main.rs`, which writes the failing receipt and errors.
5. ✅ **Live dogfood** (`openrouter/z-ai/glm-4.6` on a real git-range diff): the model's first emission was genuinely **missing** — the harness carried "artifact file was missing" back, continued the session, and recovered a valid `PASS` artifact (`trusted_for_posting: true`). The re-ask is load-bearing, not a rare safety net.

## Review
Fresh-context diverse-provider review (built + tested + traced the loop + `main.rs` + env-scrubbing): **no blocking issues**. Non-blocking notes dispositioned in `8b84d55` (session-root invariant documented; empty-diff footgun flagged → backlog **017**).

## Test plan
- `./scripts/verify.sh` (58 unit + 1 integration + the full CLI/adversarial/re-ask harness) — green.
- Live `cerberus review` against a real git-range diff with real OpenCode — valid posted-trusted artifact via file emission, recovered re-ask in the transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)