### PR TITLE
shape(018): agent-native review handoff; reshape 014 to consumer-owned posting

### DIFF
--- a/backlog.d/014-post-as-cerberus-github-app.md
+++ b/backlog.d/014-post-as-cerberus-github-app.md
@@ -1,34 +1,37 @@
-# Post reviews as Cerberus via a GitHub App
+# Safe GitHub posting: explicit injected token, refuse ambient auth
 
-Priority: P1 · Status: ready · Estimate: M
+Priority: P2 · Status: ready · Estimate: S · Reshaped: 2026-06-25
 
 ## Goal
-Cerberus posts its reviews under a branded `Cerberus[bot]` identity (not the operator's user account), using a GitHub App installation token, and can write real check-runs.
+When Cerberus posts a review to GitHub (`review-pr --post`), it uses an **explicit, caller-injected token** and **refuses to post under ambient/keyring (`gh`) user auth** — so it never silently posts as a human, and so a bot identity supplied by the caller (a GitHub App installation token) flows through cleanly, including check-runs.
+
+## Reshape note (was: "Post reviews as Cerberus via a GitHub App")
+The original ticket proposed creating a "Cerberus" GitHub App and baking `Cerberus[bot]` identity into Cerberus. That points the wrong way: spec.md says GitHub posting is a projection/"convenience orchestrator," **not the core execution path**, and VISION assigns *where results are posted* to the consumer. Prior art is unanimous (reviewdog/SARIF/PR-Agent/Danger/CodeRabbit/Greptile): **bot identity lives at the delivery boundary as injected config, never in the engine.** So this ticket keeps only the part that is genuinely Cerberus's — the **posting safety invariant** — and the App identity becomes a **consumer concern** (Bitterblossom / the operator's CI creates the App and injects its installation token). See [[cerberus-posting-boundary]]. The agent-native (no-GitHub) primary form factor is **018**.
 
 ## Non-Goals
-- Not coupling posting to running inside GitHub Actions (the App token works from any runner).
-- Not baking a single global identity into Cerberus — the token/identity is caller-injected (consumers may use their own App).
+- **No Cerberus-owned GitHub App, no baked identity.** Cerberus consumes whatever token it is given; it does not know or care that the token belongs to `Cerberus[bot]`.
+- **No token minting / JWT in Cerberus.** Signing an App JWT → installation token is the caller's job (`actions/create-github-app-token` in CI, or a consumer helper). Cerberus receives an already-minted token.
+- Posting stays an optional thin adapter (`post.rs`), not the core; not coupled to running inside GitHub Actions.
 
 ## Oracle
-- [ ] A "Cerberus" GitHub App exists (perms: pull_requests:write, checks:write, statuses:write, contents:read), installed on `misty-step/cerberus`.
-- [ ] `cerberus review-pr --post` with the App installation token posts the summary comment, inline comments, and status/check as `Cerberus[bot]`, not as a user.
-- [ ] Cerberus refuses to `--post` with ambient user auth (no silent posting as a human); the posting token is explicit.
-- [ ] `--summary-target check-run` works (App can create check-runs) and renders the Cerberus verdict.
+- [ ] `cerberus review-pr --post` posts **only** with an explicit injected token (`--gh-token-file <path>` or an explicit env var), and the `gh` subprocess uses that token — not the operator's keyring identity.
+- [ ] With no explicit token (only ambient/keyring `gh` auth available), `--post` **refuses**: exits non-zero with an actionable message, posts nothing. (Dry-run / artifact emission still work without a token.)
+- [ ] When the injected token is a GitHub App installation token, the posted comment/check author is that App's `*[bot]` identity (verified out-of-band) and `--summary-target check-run` succeeds — Cerberus is token-agnostic, so this is the same code path as a PAT with `checks:write`.
+- [ ] `./scripts/verify.sh` green (fake-gh exercises the explicit-token path; the ambient-auth refusal is covered by a fixture that provides no token).
+- [ ] A consumer doc (`docs/` or README) shows how Bitterblossom / CI creates the "Cerberus" App (perms: `pull_requests:write`, `checks:write`, `statuses:write`, `contents:read`; webhook off), mints an installation token, and injects it into `cerberus review-pr --post`.
 
 ## Children
-1. **(Operator) Create + install the App** — name, avatar, permissions above, webhook disabled; generate the private key; install on the repo; store App ID + private key as secrets.
-2. **Token minting** — a helper (Rust util, or `scripts/` shell using an openssl-signed JWT → installation token) that mints a short-lived installation token from App ID + private key. In CI use `actions/create-github-app-token`.
-3. **Cerberus-side token injection + safety** — accept an explicit posting token (`--gh-token-file` / env); refuse `--post` when only ambient user auth is present. (Buildable/testable without the App.)
-4. **Check-run upgrade** — default `--summary-target check-run` when an App token is present; keep `status` as the user-token fallback.
-5. **Consumer doc** — how Bitterblossom / Olympus install the App (or use their own) and inject the token.
+1. **Posting safety (Cerberus-side, buildable/testable now):** accept an explicit posting token (`--gh-token-file`/env); set it for the `gh` subprocess; **refuse `--post` when only ambient auth is present**. Add `verify.sh` coverage for both (explicit-token posts; no-token refuses).
+2. **Check-run with injected token:** confirm `--summary-target check-run` works with the injected token; keep `status` as the fallback.
+3. **(Consumer, operator-gated) App creation + token minting doc:** the `Cerberus[bot]` App and `create-github-app-token` step live in the consumer's posting workflow, documented — not in Cerberus code.
 
 ## Verification System
-- Claim: Cerberus posts reviews as `Cerberus[bot]` via a GitHub App installation token, and refuses to post under ambient user auth.
-- Falsifier: a posted comment/check shows a human author; or `--post` succeeds using only keyring/user auth with no explicit token; or check-run creation fails with the App token.
-- Driver: `GH_TOKEN=<app-installation-token> cerberus review-pr --post` against a throwaway PR; then `--post` with no explicit token to confirm refusal.
-- Grader: `gh api .../comments|.../check-runs` author login == the App's `*[bot]` identity; the no-token `--post` exits non-zero.
+- Claim: Cerberus posts to GitHub only with an explicit injected token and refuses ambient/keyring auth; a caller-supplied App token posts as `*[bot]` and creates check-runs through the same path.
+- Falsifier: `--post` succeeds using only keyring/user auth with no explicit token; a posted comment shows the operator's human account; check-run creation fails with a valid injected token; dry-run/emission breaks without a token.
+- Driver: `--gh-token-file <tok>` `review-pr --post` against a throwaway PR (or fake-gh) ⇒ posts; `--post` with no token ⇒ refuses non-zero.
+- Grader: posted author login is the injected identity; the no-token `--post` exits non-zero and wrote nothing; `verify.sh` green.
 - Evidence packet: posted comment/check author JSON + the refused-ambient-auth transcript.
-- Cadence: once at App setup; then on any change to the posting/auth path.
+- Cadence: on any change to the posting/auth path.
 
 ## Notes
-**Why:** the dogfood (PR #466) posted as `phrazzld` because `gh` fell back to keyring auth. The posting path already honors `GH_TOKEN`, so the only gap is identity: a GitHub App gives `Cerberus[bot]` + check-runs + short-lived scoped tokens with no seat — how CodeRabbit/Dependabot work, and aligned with VISION (identity is the destination's concern; Cerberus stays the engine). App creation is operator-gated (browser/manifest); everything else is Cerberus-side. Decided 2026-06-22 (brainstorm: App over machine-user / Actions-bot).
+**Why:** the dogfood (PR #466) posted as `phrazzld` because `gh` fell back to keyring auth — a real safety wart. The fix that belongs in Cerberus is the **refusal of ambient auth + explicit-token requirement**; the *identity* (an App) is the destination's concern, injected as a token. Decided 2026-06-25 (reshaped from the original GitHub-App framing after the posting-boundary brainstorm). The original "create + install a Cerberus App / mint tokens via openssl JWT" steps are preserved in git history and relocated to the consumer.

--- a/backlog.d/018-agent-native-review-handoff.md
+++ b/backlog.d/018-agent-native-review-handoff.md
@@ -1,0 +1,77 @@
+# Agent-native review handoff: spawn Cerberus, get the review back, branch on it
+
+Priority: P1 · Status: ready · Estimate: M · Shape: docs/plans/018-agent-native-handoff.html
+
+## Goal
+Make Cerberus's **primary** form factor first-class: a calling agent (or human, or CI) spawns Cerberus on a local diff, reads the review off stdout, and branches on a **verdict-gated exit code** — no GitHub, no token, no intermediate request file.
+
+## Why
+This is how Cerberus is actually used on our own repos: an agent working in the repo dispatches Cerberus as a subprocess, gets a review of the current changes, and decides what to fix / whether it's blocking. The engine already produces the review (`cerberus review` → `ReviewArtifact.v1` + `render_markdown`); the gaps are (1) `review` exits `0` even on a `FAIL` verdict, so an agent can't gate without parsing, and (2) reviewing a local range is a two-command dance (`request git-range … > req.json` then `review --request req.json`). Prior art is unanimous (reviewdog `-fail-level`, linters, Claude Code hooks): **structured result + a severity-gated exit code** is the agent/CI contract. GitHub posting stays the secondary, consumer-owned path (see reshaped 014); this ticket is the engine's native handoff. Per spec.md (artifact is caller-neutral; renderers project out) and VISION.
+
+## Non-Goals
+- No GitHub, no posting, no token in this path — that is 014 (consumer-owned).
+- No MCP server yet. Build the CLI contract first; an MCP wrapper over it is an additive later layer, not a rewrite (benchmark: MCP costs ~4–32× the tokens for the same call). Note it as a future option, don't build it.
+- **Reviewing the uncommitted working tree** (vs a committed range) is a follow-on: it needs a working-tree diff acquisition + a non-SHA isolation story. Scope 018 to a committed range (`base...head`), which covers the common "review my branch vs main before I push" flow. File the working-tree variant separately if wanted.
+- No new review logic. Reuse `build_git_range_request` + `ReviewKernel` + `render_markdown`.
+
+## Constraints (invariants that must survive)
+- The `ReviewRequest.v1 → ReviewArtifact.v1` seam and `validation.rs` are unchanged.
+- A Cerberus **error** (no valid artifact) must stay distinguishable from a **blocking verdict** (a successful review that found issues) — different exit codes.
+- Default behavior of existing `cerberus review` stays back-compatible (no `--fail-on` ⇒ current exit behavior).
+- Clean stdout: in the agent-native command, stdout carries ONLY the review (markdown or artifact JSON); logs/errors go to stderr.
+
+## Repo Anchors
+- `src/main.rs` — `Command` enum, `review()` / `review_pr()` orchestrator pattern, `fn main() -> Result<()>` (today: Err ⇒ exit 1, Ok ⇒ exit 0; no custom codes).
+- `src/request.rs` — `build_git_range_request(GitRangeRequestOptions)` (does `git diff base...head`); reuse verbatim.
+- `src/kernel.rs` — `ReviewKernel::review`; `src/render.rs` — `render_markdown(artifact)`.
+- `src/schema.rs` — `Verdict { Pass, Warn, Fail, Skip }`.
+- `scripts/verify.sh` — `expect_review_failure` checks *non-zero* (so error⇒exit 2 stays compatible); add exit-code-matrix coverage here.
+
+## Design (chosen)
+
+**1. Verdict-gated exit code (the core).** Add `--fail-on <none|warn|fail>` to `review` and the new `review-diff`. Exit-code contract — the load-bearing surface:
+
+| Exit | Meaning | When |
+|---|---|---|
+| **0** | clean / proceed | review produced a valid artifact; verdict below the `--fail-on` threshold (or `--fail-on none`, the default) |
+| **1** | blocking — read the review | review produced a valid artifact; verdict at/above the threshold (`--fail-on fail` ⇒ `FAIL`; `--fail-on warn` ⇒ `WARN`/`FAIL`) |
+| **2** | Cerberus error — no review | harness/validation/IO failure; untrusted lifecycle; no valid artifact produced |
+
+Today every error exits 1 (Rust default). Move tool errors to **2** so exit `1` can mean "blocking verdict" unambiguously. `SKIP` verdict is not "blocking" (it means couldn't review) — treat as exit 0 unless explicitly gated; the agent reads the verdict for nuance.
+
+**2. `cerberus review-diff` (the ergonomic entry).** One command, no GitHub:
+```
+cerberus review-diff [--repo-path .] --base <ref> [--head HEAD] \
+  [--harness opencode] [--model …] [--allow-env …] [--timeout-seconds …] \
+  [--fail-on fail] [--out artifact.json] [--markdown review.md] [--json]
+```
+Fuses `build_git_range_request` + `ReviewKernel` + `render_markdown`. **Default: render the review markdown to stdout** (the deliverable the calling agent reads); `--json` emits the artifact JSON to stdout instead; `--out`/`--markdown` also persist to files. Exit code per the matrix.
+
+**3. Document the contract.** A README/spec "Agent-native handoff" section: spawn → read stdout (review) → branch on exit code. The one example an orchestrating agent needs.
+
+## Oracle (executable)
+- [ ] `cerberus review-diff --repo-path <r> --base <b> --head <h> --harness fixture --fixture-output <f>` prints the rendered review to stdout, writes a valid `ReviewArtifact.v1` with `--out`, touches no GitHub and needs no token; exit 0 when verdict is below threshold.
+- [ ] Exit-code matrix proven with fixtures in `verify.sh`: a `PASS` artifact ⇒ exit 0; a `FAIL` artifact with `--fail-on fail` ⇒ exit **1**; a malformed/invalid emission ⇒ exit **2** (and `--fail-on fail` on a `PASS` ⇒ 0, i.e. gating never fires on non-blocking verdicts).
+- [ ] `--fail-on warn` ⇒ exit 1 on a `WARN` artifact; `--fail-on none` (default) ⇒ exit 0 even on `FAIL` (back-compat for existing `review`).
+- [ ] stdout in `review-diff` contains only the review (markdown, or artifact JSON under `--json`); secret-leak/stderr checks from `verify.sh` still pass.
+- [ ] `./scripts/verify.sh` green; `cerberus review-diff --help` documents `--fail-on` and the exit codes; the README/spec handoff section exists.
+- [ ] Live: `cerberus review-diff --base <merge-base> --harness opencode --model … --fail-on fail` on a real local branch returns the review on stdout and an exit code an agent can branch on.
+
+## Verification System
+- Claim: a calling agent can spawn Cerberus on a local diff and get back (a) the full review on stdout and (b) a verdict-gated exit code that distinguishes proceed / blocking / tool-error — with no GitHub and no token.
+- Falsifier: a blocking `FAIL` review exits 0 (agent can't gate); a tool error and a blocking verdict share an exit code (agent can't tell "broke" from "blocked"); stdout is polluted with logs; `--fail-on` defaults change existing `review` exit behavior; `verify.sh` regresses.
+- Driver: the fixture exit-code matrix in `verify.sh` (PASS/WARN/FAIL × `--fail-on` × error path) + one real `review-diff` on a local branch.
+- Grader: each fixture's `$?` equals the matrix; stdout-only-review check; `verify.sh` exit 0.
+- Evidence packet: `target/cerberus/review-diff-*` artifacts + the captured exit codes per case.
+- Cadence: the matrix in `verify.sh` always; the live run on any change to the exit-code or `review-diff` path.
+
+## Risks + Rollout
+- **Exit-code change ripple:** moving tool-errors from 1→2 could surprise a caller asserting `== 1`. `verify.sh`'s `expect_review_failure` only checks non-zero, so it's safe; audit for any `== 1` assumption. Rollback = revert; the `ReviewArtifact.v1` seam is untouched.
+- **Scope drift toward an arena/eval:** keep this a dumb handoff (review + exit code). Measuring review quality is Daedalus ([[cerberus-daedalus-eval-boundary]]).
+- **Naming:** `review-diff` reviews a committed `base...head` range; if "diff" misleads toward uncommitted, rename to `review-range` — the working-tree variant is a separate ticket.
+
+## Premise Source
+Operator session 2026-06-25: reframed the GitHub-App work after recognizing the agent-native subprocess handoff is the *primary* form factor and GitHub posting is a consumer-owned delivery layer (see [[cerberus-posting-boundary]]). Research lane (reviewdog/SARIF/PR-Agent/Danger/CodeRabbit/Greptile; MCP-vs-CLI benchmark) confirmed: host-neutral artifact + severity-gated exit code is the universal agent/CI contract; build the CLI before any MCP layer. Grounding: spec.md (artifact caller-neutral, posting is projection/post-MVP), VISION.md (consumer owns where results post). No durable transcript stored — explicit waiver.
+
+## HTML Plan
+`docs/plans/018-agent-native-handoff.html`

--- a/docs/plans/018-agent-native-handoff.html
+++ b/docs/plans/018-agent-native-handoff.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cerberus Plan 018: Agent-native review handoff</title>
+  <style>
+    body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #151515; background: #fff; }
+    main { width: min(84rem, calc(100% - 3rem)); margin: 0 auto; padding: 2rem 0 4rem; }
+    header { display: grid; grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.55fr); gap: 2rem; align-items: end; border-bottom: 1px solid #d8dde3; padding-bottom: 1.5rem; }
+    h1 { margin: 0; font-size: clamp(2.1rem, 4vw, 3.8rem); line-height: 1.0; }
+    h2 { margin: 0 0 0.75rem; font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; }
+    h3 { margin: 1.5rem 0 0.5rem; font-size: 1.05rem; }
+    p, li { line-height: 1.5; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.92em; }
+    pre { background: #14171a; color: #e8edf2; padding: 1rem; overflow-x: auto; font-size: 0.84rem; line-height: 1.45; }
+    .muted { color: #606872; }
+    .panel { border: 1px solid #d8dde3; background: #f5f7f9; padding: 1rem; }
+    .win { border-left: 4px solid #1e7e45; background: #f1f8f3; padding: 0.75rem 1rem; margin: 1.5rem 0; }
+    .flag { border-left: 4px solid #c0392b; background: #fcf3f2; padding: 0.75rem 1rem; margin: 1.5rem 0; }
+    .grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; background: #d8dde3; border: 1px solid #d8dde3; margin-top: 1.5rem; }
+    .cell { background: #fff; padding: 1rem; }
+    .cell.em { background: #f5f7f9; }
+    .two { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin-top: 2rem; }
+    table { border-collapse: collapse; width: 100%; margin-top: 0.5rem; font-size: 0.9rem; }
+    th, td { border: 1px solid #d8dde3; padding: 0.5rem 0.65rem; text-align: left; vertical-align: top; }
+    th { background: #f5f7f9; }
+    .phase { display: grid; grid-template-columns: 7rem 1fr; gap: 1rem; border-top: 1px solid #d8dde3; padding: 0.85rem 0; }
+    .phase b { font-size: 0.95rem; }
+    @media (max-width: 900px) { main { width: min(100% - 2rem, 84rem); } header, .grid, .two, .phase { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <section>
+        <p class="muted">Backlog 018 / Agent-native handoff · the primary form factor, made first-class</p>
+        <h1>Spawn Cerberus. Read the review. Branch on the exit code.</h1>
+        <p>The way Cerberus is actually used on our own repos: an agent working in the repo dispatches it as a subprocess, gets a review of the current changes, and decides what's blocking. The engine already produces the review — <code>cerberus review</code> → <code>ReviewArtifact.v1</code> + <code>render_markdown</code>. Two gaps make it clumsy: <strong>(1) a <code>FAIL</code> verdict still exits 0</strong>, so an agent can't gate without parsing; <strong>(2) reviewing a local range is a two-command dance</strong> through a temp request file. Close both: a verdict-gated exit code, and one no-GitHub command that hands the review back on stdout. No token, no posting — that's the consumer's layer (014).</p>
+      </section>
+      <aside class="panel">
+        <h2>Chosen Design</h2>
+        <p><strong>Gate:</strong> <code>--fail-on &lt;none|warn|fail&gt;</code> on <code>review</code> + <code>review-diff</code>. Exit <code>0</code> proceed · <code>1</code> blocking verdict · <code>2</code> Cerberus error.</p>
+        <p><strong>Entry:</strong> <code>cerberus review-diff --base &lt;ref&gt; [--head HEAD]</code> fuses <code>build_git_range_request</code> + kernel + render; review markdown to <strong>stdout</strong> by default.</p>
+        <p><strong>Reuse:</strong> no new review logic — request-builder, <code>ReviewKernel</code>, <code>render_markdown</code> unchanged.</p>
+        <p><strong>Out of scope:</strong> GitHub/posting (014); MCP wrapper (later); uncommitted working-tree diff (follow-on).</p>
+      </aside>
+    </header>
+
+    <div class="win">
+      <strong>Why exit codes, not just the artifact.</strong> Prior art is unanimous — reviewdog <code>-fail-level</code>, linters, Claude Code hooks: an orchestrating agent needs two channels, the full machine-readable review <em>and</em> a one-bit block/proceed signal. The load-bearing subtlety: a blocking verdict (a <em>successful</em> review that found issues) must be distinguishable from a tool error (no review produced). Today both would collide on exit 1, so this moves tool errors to <strong>exit 2</strong> and reserves <strong>exit 1</strong> for "blocked — read the review."
+    </div>
+
+    <section class="grid">
+      <article class="cell"><h2>Standards</h2><p>Caller-neutral artifact + a host-neutral handoff. No GitHub, no token in this path. <code>ReviewRequest.v1 → ReviewArtifact.v1</code> and <code>validation.rs</code> untouched; existing <code>review</code> stays back-compatible without <code>--fail-on</code>.</p></article>
+      <article class="cell"><h2>Acceptance</h2><p>A fixture exit-code matrix in <code>verify.sh</code> (PASS/WARN/FAIL × <code>--fail-on</code> × error path) plus one live <code>review-diff</code> on a real branch returning review-on-stdout + a branchable code.</p></article>
+      <article class="cell"><h2>Verify</h2><p><code>./scripts/verify.sh</code> green; each fixture's <code>$?</code> equals the matrix; stdout carries only the review; <code>review-diff --help</code> + a README handoff section exist.</p></article>
+      <article class="cell em"><h2>Stop / waiver</h2><p>If "diff" misleads toward uncommitted changes, rename <code>review-diff</code> → <code>review-range</code>. Keep this a dumb handoff — measuring review <em>quality</em> is Daedalus, not here.</p></article>
+    </section>
+
+    <section class="two">
+      <article>
+        <h2>Exit-code contract (load-bearing)</h2>
+        <table>
+          <tr><th>Exit</th><th>Means</th><th>When</th></tr>
+          <tr><td><b>0</b></td><td>clean / proceed</td><td>valid artifact; verdict below <code>--fail-on</code> (or <code>none</code>, default)</td></tr>
+          <tr><td><b>1</b></td><td>blocking — read it</td><td>valid artifact; verdict ≥ threshold (<code>fail</code>⇒FAIL; <code>warn</code>⇒WARN/FAIL)</td></tr>
+          <tr><td><b>2</b></td><td>Cerberus error</td><td>harness/validation/IO failure; untrusted lifecycle; no valid artifact</td></tr>
+        </table>
+        <p class="muted">SKIP ("couldn't review") is not blocking ⇒ exit 0 unless explicitly gated; the agent reads the verdict field for nuance. Today <code>main()</code> returns <code>Result</code> (Err⇒1); introduce explicit <code>process::exit</code> codes.</p>
+      </article>
+      <article>
+        <h2>Alternatives</h2>
+        <table>
+          <tr><th>Path</th><th>Verdict</th></tr>
+          <tr><td><b>CLI: artifact + gated exit code</b></td><td>Cheapest, composable, pretraining-aligned, stateless. <b>Choose.</b></td></tr>
+          <tr><td>MCP server tool</td><td>Same validator endpoint; ~4–32× tokens; build the CLI first, wrap later. <b>Defer.</b></td></tr>
+          <tr><td>Exit code only (no artifact on stdout)</td><td>Loses "what to fix"; agent can't act, only gate. <b>Reject.</b></td></tr>
+          <tr><td>Keep two-step <code>request</code>+<code>review</code></td><td>Works but clunky per call; the primary entry should be one command. <b>Reject the friction, keep the pieces.</b></td></tr>
+        </table>
+      </article>
+    </section>
+
+    <h3>Milestones</h3>
+    <div class="phase"><b>M1 · Gate</b><div><code>--fail-on</code> + the exit-code matrix on <code>review</code>; move tool-errors to exit 2; keep no-flag back-compat. <em>Gate: fixture matrix in verify.sh passes; <code>expect_review_failure</code> (non-zero) still green.</em></div></div>
+    <div class="phase"><b>M2 · Entry</b><div><code>review-diff</code> — fuse <code>build_git_range_request</code> + kernel + render; markdown→stdout default, <code>--json</code>/<code>--out</code>/<code>--markdown</code> options; clean stdout (logs→stderr). <em>Gate: one-command local review, no token, exit code per matrix.</em></div></div>
+    <div class="phase"><b>M3 · Doc</b><div>README/spec "Agent-native handoff" section: spawn → read stdout → branch on exit code, with the one example an orchestrator needs. <em>Gate: <code>--help</code> documents codes; section exists.</em></div></div>
+
+    <h3>Risks + Rollout</h3>
+    <table>
+      <tr><th>Risk</th><th>Mitigation</th></tr>
+      <tr><td>Exit 1→2 move surprises a caller asserting <code>== 1</code></td><td><code>verify.sh</code> only checks non-zero (safe); audit for any <code>== 1</code> assumption. Revert-safe; artifact seam untouched.</td></tr>
+      <tr><td>stdout pollution breaks the handoff</td><td>Logs/errors strictly to stderr in <code>review-diff</code>; verify.sh asserts stdout-only-review + no secret leak.</td></tr>
+      <tr><td>Scope drift into eval/quality scoring</td><td>This is a dumb handoff. Quality measurement is Daedalus (closed 015). Hold the line.</td></tr>
+      <tr><td><b>Rollback</b></td><td>Additive subcommand + an opt-in flag; revert the commit. No schema/contract/dep change.</td></tr>
+    </table>
+
+    <h3>Adversarial Review Focus</h3>
+    <p class="muted">For diverse-provider review (artifact + oracle only): (1) Can a blocking verdict and a tool error ever collide on the same exit code? (2) Does <code>--fail-on none</code> truly preserve existing <code>review</code> exit behavior (no silent break of current callers / verify.sh)? (3) Is <code>review-diff</code> stdout genuinely review-only under a real OpenCode run (no log/telemetry bleed)? (4) Does <code>review-diff</code> reuse the request-builder + kernel verbatim, or did it fork review logic?</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Shaping output of a premise-challenge on the GitHub-App work.

## The reframe
VISION + spec.md already say Cerberus's artifact is caller-neutral, GitHub posting is a "convenience orchestrator" / projection / **post-MVP** (not the core), and *where results are posted* belongs to the consumer. Prior-art research (reviewdog/SARIF/PR-Agent/Danger/CodeRabbit/Greptile) is unanimous: **host-neutral artifact + thin swappable sink**, and **bot identity lives at the delivery boundary as injected config, never in the engine** (local/"don't post" modes need no token at all). Operator decision (2026-06-25): the **agent-native subprocess handoff is the PRIMARY form factor**; GitHub posting + bot identity are a consumer-owned delivery layer.

## 018 — agent-native review handoff (new, P1, primary)
Make "spawn Cerberus → read the review → branch on it" first-class:
- **Verdict-gated exit code** `--fail-on <none|warn|fail>`: exit **0** proceed · **1** blocking verdict · **2** Cerberus error (today a `FAIL` review exits 0, and a tool error vs a blocking verdict would collide — this separates them).
- **`cerberus review-diff --base <ref>`** — one no-GitHub command that fuses `build_git_range_request` + kernel + `render_markdown`, hands the review back on **stdout**. No token, no posting.
- Reuses existing pieces; no new review logic. Full packet + `docs/plans/018-agent-native-handoff.html`.

## 014 — reshaped (was "post as a Cerberus GitHub App")
Shrunk to the engine-side **safety invariant** only: refuse `--post` under ambient/keyring `gh` auth; require an **explicit injected token**; check-runs work with whatever token is injected. The `Cerberus[bot]` App identity + token minting **relocate to the consumer** (Bitterblossom/CI) as injected config + a doc. Drops M→S, P1→P2 behind 018.

Docs/backlog only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)