### PR TITLE
feat(018): agent-native review handoff — review-diff + verdict-gated exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,39 @@ cerberus review-pr --number 123 --repo owner/name \
   --out-dir target/cerberus/review-pr \
   --summary-target check-run \
   --post
+
+# Agent-native: review the current branch against a base in one command,
+# review printed to stdout, no GitHub and no token.
+cerberus review-diff --base origin/master --fail-on fail
 ```
+
+## Agent-native handoff
+
+The primary way to call Cerberus from another agent (or CI, or a script) is to
+spawn it on a local diff, read the review off **stdout**, and branch on the
+**exit code** — no GitHub, no token, no intermediate request file:
+
+```sh
+cerberus review-diff --base origin/master --head HEAD \
+  --harness opencode --model openrouter/z-ai/glm-5.2 \
+  --allow-env OPENROUTER_API_KEY \
+  --fail-on fail
+```
+
+- **stdout** carries only the review (rendered Markdown; pass `--json` for the
+  raw `ReviewArtifact.v1`). Logs and errors go to stderr.
+- The **exit code** is the gate a calling agent branches on:
+
+  | Exit | Meaning | When |
+  |------|---------|------|
+  | `0`  | clean — proceed | a valid review was produced and the verdict is below `--fail-on` (or `--fail-on none`, the default) |
+  | `1`  | blocking — read the review | a valid review was produced and the verdict is at or above the threshold (`--fail-on fail` ⇒ `FAIL`; `--fail-on warn` ⇒ `WARN`/`FAIL`) |
+  | `2`  | Cerberus error — no review | the harness failed, the artifact did not validate, or no review could be produced |
+
+`--fail-on` is also available on `cerberus review`. Without it, exit status is
+unchanged (`0` on a valid artifact regardless of verdict, `2` on error), so
+existing callers are unaffected. Use `--out`/`--markdown` to also persist the
+artifact and Markdown to files while still printing to stdout.
 
 Git range requests include disposable base and head worktree capability from
 the supplied refs. PR requests may include `--head-workspace` and

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cerberus review-diff --base origin/master --head HEAD \
   |------|---------|------|
   | `0`  | clean — proceed | a valid review was produced and the verdict is below `--fail-on` (or `--fail-on none`, the default) |
   | `1`  | blocking — read the review | a valid review was produced and the verdict is at or above the threshold (`--fail-on fail` ⇒ `FAIL`; `--fail-on warn` ⇒ `WARN`/`FAIL`) |
-  | `2`  | Cerberus error — no review | the harness failed, the artifact did not validate, or no review could be produced |
+  | `2`  | Cerberus error — no review | the harness failed, the artifact did not validate, the invocation was invalid, or no review could be produced |
 
 `--fail-on` is also available on `cerberus review`. Without it, exit status is
 unchanged (`0` on a valid artifact regardless of verdict, `2` on error), so

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -218,6 +218,48 @@ GH_TOKEN=should-not-leak cargo run --locked -- review \
 
 test "$(git -C "$tmp_repo" rev-parse HEAD)" = "$head_sha"
 
+# --- 018: agent-native review-diff exit-code matrix --------------------------
+# review-diff fuses request + review locally (no GitHub, no token), prints the
+# review to stdout, and gates the exit code on the verdict via --fail-on:
+#   0 clean/proceed | 1 blocking verdict | 2 Cerberus error (no valid artifact).
+sed 's/"verdict": "WARN"/"verdict": "FAIL"/' fixtures/harness/valid-review.txt \
+  > target/cerberus/review-diff-fail-fixture.txt
+printf 'not a review artifact\n' > target/cerberus/review-diff-invalid-fixture.txt
+
+expect_exit() {
+  local want="$1" name="$2"
+  shift 2
+  local rc=0
+  "$@" > "target/cerberus/review-diff-${name}.stdout" \
+    2> "target/cerberus/review-diff-${name}.stderr" || rc=$?
+  if [ "$rc" -ne "$want" ]; then
+    echo "review-diff exit-code: ${name} wanted ${want}, got ${rc}" >&2
+    exit 1
+  fi
+}
+
+rd() {
+  cargo run --locked -- review-diff \
+    --repo-path "$tmp_repo" --base "$base_sha" --head "$head_sha" \
+    --harness fixture --fixture-output "$1" "${@:2}"
+}
+
+# WARN fixture (valid-review.txt): below 'fail' threshold => 0; at 'warn' => 1.
+expect_exit 0 warn-failon-fail rd fixtures/harness/valid-review.txt --fail-on fail
+expect_exit 1 warn-failon-warn rd fixtures/harness/valid-review.txt --fail-on warn
+# FAIL fixture: blocking under 'fail' => 1; default (no --fail-on) => 0 (back-compat).
+expect_exit 1 fail-failon-fail rd target/cerberus/review-diff-fail-fixture.txt --fail-on fail
+expect_exit 0 fail-default rd target/cerberus/review-diff-fail-fixture.txt
+# Unparseable emission: a Cerberus error, not a verdict => 2 (distinct from blocking).
+expect_exit 2 invalid rd target/cerberus/review-diff-invalid-fixture.txt --fail-on fail
+# stdout carries the rendered review (Markdown), not logs.
+grep -q 'Cerberus Review:' target/cerberus/review-diff-warn-failon-fail.stdout
+# --fail-on also gates plain `review`, and a blocking verdict is exit 1 there too.
+expect_exit 1 review-failon-fail cargo run --locked -- review \
+  --request target/cerberus/git-range-request.json \
+  --harness fixture --fixture-output target/cerberus/review-diff-fail-fixture.txt \
+  --out target/cerberus/review-failon-artifact.json --fail-on fail
+
 if cargo run --locked -- request git-range \
   --repo-path "$tmp_repo" \
   --base "$base_sha" \

--- a/spec.md
+++ b/spec.md
@@ -267,7 +267,11 @@ cerberus request pr --number <n> --out <request.json>
 
 cerberus review --request <request.json> --out <artifact.json> \
   [--markdown <review.md>] [--receipt-bundle <bundle.json>] \
-  [--harness opencode|omp|fixture]
+  [--harness opencode|omp|fixture] [--fail-on none|warn|fail]
+
+cerberus review-diff --base <ref> [--head <ref>] [--repo-path <dir>] \
+  [--harness opencode|omp|fixture] [--model <m>] [--allow-env <VAR>] \
+  [--fail-on none|warn|fail] [--out <artifact.json>] [--markdown <review.md>] [--json]
 
 cerberus render --artifact <artifact.json> --markdown <review.md>
 
@@ -281,6 +285,21 @@ cerberus review-pr --number <n> --repo <owner/name> \
 The request commands are acquisition helpers. They produce `ReviewRequest.v1`
 and do not launch the reviewer or post comments. The review command remains
 the only execution boundary.
+
+`review-diff` is the agent-native convenience orchestrator: it fuses the
+git-range acquisition helper and the review boundary into one local command,
+renders the review to stdout (or `--json` for the raw artifact), and writes
+nothing to GitHub. It is the primary form factor for a calling agent that spawns
+Cerberus on a local diff and consumes the review directly.
+
+`--fail-on` makes the exit code a gate a caller can branch on, on both `review`
+and `review-diff`: `0` when a valid review's verdict is below the threshold,
+`1` when the verdict is at or above it (`fail` ⇒ `FAIL`; `warn` ⇒ `WARN`/`FAIL`;
+`SKIP` is never blocking), and `2` for any Cerberus error that yields no valid
+artifact. Without `--fail-on` (default `none`) the exit status is `0` on a valid
+artifact regardless of verdict and `2` on error, so existing callers are
+unaffected. A blocking verdict (exit `1`) is a *successful* review that found
+issues — distinct from a tool error (exit `2`).
 
 `review-pr` is a convenience orchestrator over the existing acquisition and
 review boundaries. It must write the same request, execution plan, transcript,

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,14 +142,11 @@ struct PullRequestArgs {
     timeout_seconds: u64,
 }
 
+/// Substrate selection flags shared by every command that runs a review
+/// (`review`, `review-pr`, `review-diff`). Flattened into each so the CLI
+/// surface stays identical while the declaration lives in one place.
 #[derive(Debug, Args)]
-struct ReviewArgs {
-    #[arg(long)]
-    request: PathBuf,
-    #[arg(long)]
-    out: PathBuf,
-    #[arg(long)]
-    markdown: Option<PathBuf>,
+struct SubstrateArgs {
     #[arg(long, value_enum, default_value_t = HarnessKind::Opencode)]
     harness: HarnessKind,
     #[arg(long)]
@@ -164,6 +161,18 @@ struct ReviewArgs {
     omp_binary: String,
     #[arg(long)]
     model: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct ReviewArgs {
+    #[arg(long)]
+    request: PathBuf,
+    #[arg(long)]
+    out: PathBuf,
+    #[arg(long)]
+    markdown: Option<PathBuf>,
+    #[command(flatten)]
+    substrate: SubstrateArgs,
     #[arg(long)]
     cwd: Option<PathBuf>,
     #[arg(long)]
@@ -215,20 +224,8 @@ struct ReviewPrArgs {
     allowed_env: Vec<String>,
     #[arg(long, default_value_t = 120)]
     timeout_seconds: u64,
-    #[arg(long, value_enum, default_value_t = HarnessKind::Opencode)]
-    harness: HarnessKind,
-    #[arg(long)]
-    fixture_output: Option<PathBuf>,
-    #[arg(long, default_value = "opencode")]
-    opencode_binary: String,
-    #[arg(long)]
-    opencode_attach: Option<String>,
-    #[arg(long, default_value = "build")]
-    opencode_agent: Option<String>,
-    #[arg(long, default_value = "omp")]
-    omp_binary: String,
-    #[arg(long)]
-    model: Option<String>,
+    #[command(flatten)]
+    substrate: SubstrateArgs,
     #[arg(long)]
     cwd: Option<PathBuf>,
     #[arg(long)]
@@ -274,20 +271,8 @@ struct ReviewDiffArgs {
     allowed_env: Vec<String>,
     #[arg(long, default_value_t = 120)]
     timeout_seconds: u64,
-    #[arg(long, value_enum, default_value_t = HarnessKind::Opencode)]
-    harness: HarnessKind,
-    #[arg(long)]
-    fixture_output: Option<PathBuf>,
-    #[arg(long, default_value = "opencode")]
-    opencode_binary: String,
-    #[arg(long)]
-    opencode_attach: Option<String>,
-    #[arg(long, default_value = "build")]
-    opencode_agent: Option<String>,
-    #[arg(long, default_value = "omp")]
-    omp_binary: String,
-    #[arg(long)]
-    model: Option<String>,
+    #[command(flatten)]
+    substrate: SubstrateArgs,
     #[arg(long, value_enum, default_value_t = FailOn::None)]
     fail_on: FailOn,
     /// Also write the artifact JSON to this path (still printed to stdout).
@@ -390,15 +375,16 @@ fn runtime_targets(commands: Vec<String>) -> Vec<RuntimeTarget> {
         .collect()
 }
 
-fn review_substrate(
-    harness: HarnessKind,
-    fixture_output: Option<PathBuf>,
-    opencode_binary: String,
-    opencode_attach: Option<String>,
-    opencode_agent: Option<String>,
-    omp_binary: String,
-    model: Option<String>,
-) -> Result<ReviewSubstrate> {
+fn review_substrate(args: SubstrateArgs) -> Result<ReviewSubstrate> {
+    let SubstrateArgs {
+        harness,
+        fixture_output,
+        opencode_binary,
+        opencode_attach,
+        opencode_agent,
+        omp_binary,
+        model,
+    } = args;
     match harness {
         HarnessKind::Fixture => {
             let output = fixture_output
@@ -423,13 +409,7 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
         request,
         out,
         markdown,
-        harness,
-        fixture_output,
-        opencode_binary,
-        opencode_attach,
-        opencode_agent,
-        omp_binary,
-        model,
+        substrate,
         cwd,
         timeout_seconds,
         execution_plan,
@@ -451,15 +431,7 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
     let timeout = timeout_seconds
         .map(Duration::from_secs)
         .unwrap_or_else(|| Duration::from_millis(request.policy.timeout_ms));
-    let kernel = ReviewKernel::new(review_substrate(
-        harness,
-        fixture_output,
-        opencode_binary,
-        opencode_attach,
-        opencode_agent,
-        omp_binary,
-        model,
-    )?);
+    let kernel = ReviewKernel::new(review_substrate(substrate)?);
     let run_policy = RunPolicy {
         cwd,
         timeout,
@@ -512,15 +484,7 @@ fn review_diff(args: ReviewDiffArgs) -> Result<ExitCode> {
     })?;
     validate_request(&request)?;
     let cwd = std::env::current_dir().context("read current directory")?;
-    let kernel = ReviewKernel::new(review_substrate(
-        args.harness,
-        args.fixture_output,
-        args.opencode_binary,
-        args.opencode_attach,
-        args.opencode_agent,
-        args.omp_binary,
-        args.model,
-    )?);
+    let kernel = ReviewKernel::new(review_substrate(args.substrate)?);
     let run_policy = RunPolicy {
         cwd,
         timeout: Duration::from_millis(request.policy.timeout_ms),
@@ -589,15 +553,7 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     let cwd = args
         .cwd
         .unwrap_or(std::env::current_dir().context("read current directory")?);
-    let kernel = ReviewKernel::new(review_substrate(
-        args.harness,
-        args.fixture_output,
-        args.opencode_binary,
-        args.opencode_attach,
-        args.opencode_agent,
-        args.omp_binary,
-        args.model,
-    )?);
+    let kernel = ReviewKernel::new(review_substrate(args.substrate)?);
     let run_policy = RunPolicy {
         cwd,
         timeout: Duration::from_millis(request.policy.timeout_ms),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
@@ -13,11 +14,44 @@ use cerberus::request::{
     build_git_range_request, build_pull_request, fetch_pull_request_head_sha,
     GitRangeRequestOptions, PullRequestOptions, RequestOptions,
 };
-use cerberus::schema::RuntimeTarget;
+use cerberus::schema::{RuntimeTarget, Verdict};
 use cerberus::{
     render_markdown, validate_artifact_for_request, validate_request, ReviewArtifact, ReviewRequest,
 };
-use clap::{ArgGroup, Args, Parser, Subcommand};
+use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
+
+/// Maps a review verdict to a process exit code so a calling agent can gate on
+/// it. A blocking verdict (exit 1) is a *successful* review that found issues —
+/// distinct from a Cerberus error (exit 2), which means no valid review at all.
+#[derive(Debug, Clone, Copy, Default, ValueEnum, PartialEq, Eq)]
+enum FailOn {
+    /// Never block on the verdict; exit 0 on any valid artifact (back-compat).
+    #[default]
+    None,
+    /// Block (exit 1) when the verdict is WARN or FAIL.
+    Warn,
+    /// Block (exit 1) when the verdict is FAIL.
+    Fail,
+}
+
+fn is_blocking(verdict: &Verdict, fail_on: FailOn) -> bool {
+    match fail_on {
+        FailOn::None => false,
+        FailOn::Warn => matches!(verdict, Verdict::Warn | Verdict::Fail),
+        FailOn::Fail => matches!(verdict, Verdict::Fail),
+    }
+}
+
+/// Exit code for a review that produced a valid artifact: 1 if the verdict is
+/// blocking under `fail_on`, else 0. Cerberus errors never reach here — they
+/// propagate as `Err` and `main` maps them to exit 2.
+fn verdict_exit_code(verdict: &Verdict, fail_on: FailOn) -> ExitCode {
+    if is_blocking(verdict, fail_on) {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
 
 #[derive(Debug, Parser)]
 #[command(name = "cerberus")]
@@ -31,6 +65,7 @@ struct Cli {
 enum Command {
     Request(Box<RequestArgs>),
     Review(Box<ReviewArgs>),
+    ReviewDiff(Box<ReviewDiffArgs>),
     ReviewPr(Box<ReviewPrArgs>),
     Render(RenderArgs),
 }
@@ -139,6 +174,8 @@ struct ReviewArgs {
     transcript: Option<PathBuf>,
     #[arg(long)]
     receipt_bundle: Option<PathBuf>,
+    #[arg(long, value_enum, default_value_t = FailOn::None)]
+    fail_on: FailOn,
 }
 
 #[derive(Debug, Args)]
@@ -206,13 +243,85 @@ struct RenderArgs {
     markdown: PathBuf,
 }
 
-fn main() -> Result<()> {
+/// Agent-native: build a git-range request and review it in one command, with
+/// no GitHub and no token. The review is printed to stdout (Markdown, or the raw
+/// artifact under `--json`); the exit code gates on the verdict via `--fail-on`.
+#[derive(Debug, Args)]
+struct ReviewDiffArgs {
+    #[arg(long, default_value = ".")]
+    repo_path: PathBuf,
+    #[arg(long)]
+    base: String,
+    #[arg(long, default_value = "HEAD")]
+    head: String,
+    #[arg(long)]
+    base_workspace: Option<PathBuf>,
+    #[arg(long)]
+    title: Option<String>,
+    #[arg(long)]
+    description: Option<String>,
+    #[arg(long)]
+    request_id: Option<String>,
+    #[arg(long)]
+    repo: Option<String>,
+    #[arg(long = "instruction")]
+    instructions: Vec<String>,
+    #[arg(long = "local-runtime-command")]
+    local_runtime_commands: Vec<String>,
+    #[arg(long)]
+    allow_local_runtime: bool,
+    #[arg(long = "allow-env")]
+    allowed_env: Vec<String>,
+    #[arg(long, default_value_t = 120)]
+    timeout_seconds: u64,
+    #[arg(long, value_enum, default_value_t = HarnessKind::Opencode)]
+    harness: HarnessKind,
+    #[arg(long)]
+    fixture_output: Option<PathBuf>,
+    #[arg(long, default_value = "opencode")]
+    opencode_binary: String,
+    #[arg(long)]
+    opencode_attach: Option<String>,
+    #[arg(long, default_value = "build")]
+    opencode_agent: Option<String>,
+    #[arg(long, default_value = "omp")]
+    omp_binary: String,
+    #[arg(long)]
+    model: Option<String>,
+    #[arg(long, value_enum, default_value_t = FailOn::None)]
+    fail_on: FailOn,
+    /// Also write the artifact JSON to this path (still printed to stdout).
+    #[arg(long)]
+    out: Option<PathBuf>,
+    /// Also write the rendered Markdown to this path.
+    #[arg(long)]
+    markdown: Option<PathBuf>,
+    /// Print the raw ReviewArtifact.v1 JSON to stdout instead of Markdown.
+    #[arg(long)]
+    json: bool,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(code) => code,
+        // Any error means Cerberus produced no valid review: exit 2, distinct
+        // from a blocking verdict (exit 1). Preserve the anyhow Debug chain so
+        // the stderr messages callers/verify.sh match on are unchanged.
+        Err(err) => {
+            eprintln!("Error: {err:?}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run() -> Result<ExitCode> {
     let cli = Cli::parse();
     match cli.command {
-        Command::Request(args) => request(*args),
+        Command::Request(args) => request(*args).map(|()| ExitCode::SUCCESS),
         Command::Review(args) => review(*args),
-        Command::ReviewPr(args) => review_pr(*args),
-        Command::Render(args) => render(args),
+        Command::ReviewDiff(args) => review_diff(*args),
+        Command::ReviewPr(args) => review_pr(*args).map(|()| ExitCode::SUCCESS),
+        Command::Render(args) => render(args).map(|()| ExitCode::SUCCESS),
     }
 }
 
@@ -309,7 +418,7 @@ fn review_substrate(
     }
 }
 
-fn review(args: ReviewArgs) -> Result<()> {
+fn review(args: ReviewArgs) -> Result<ExitCode> {
     let ReviewArgs {
         request,
         out,
@@ -326,6 +435,7 @@ fn review(args: ReviewArgs) -> Result<()> {
         execution_plan,
         transcript,
         receipt_bundle,
+        fail_on,
     } = args;
     if let Some(receipt_bundle) = &receipt_bundle {
         remove_file_if_exists(receipt_bundle)?;
@@ -379,7 +489,60 @@ fn review(args: ReviewArgs) -> Result<()> {
     if let Some(markdown) = markdown {
         write_text(&markdown, &render_markdown(&run.artifact))?;
     }
-    Ok(())
+    Ok(verdict_exit_code(&run.artifact.verdict, fail_on))
+}
+
+fn review_diff(args: ReviewDiffArgs) -> Result<ExitCode> {
+    let request = build_git_range_request(&GitRangeRequestOptions {
+        repo_path: args.repo_path,
+        base: args.base,
+        head: args.head,
+        base_workspace: args.base_workspace,
+        title: args.title,
+        description: args.description,
+        repo: args.repo,
+        common: RequestOptions {
+            request_id: args.request_id,
+            instructions: args.instructions,
+            local_runtime: runtime_targets(args.local_runtime_commands),
+            allow_local_runtime: args.allow_local_runtime,
+            allowed_env: args.allowed_env,
+            timeout_ms: timeout_ms(args.timeout_seconds)?,
+        },
+    })?;
+    validate_request(&request)?;
+    let cwd = std::env::current_dir().context("read current directory")?;
+    let kernel = ReviewKernel::new(review_substrate(
+        args.harness,
+        args.fixture_output,
+        args.opencode_binary,
+        args.opencode_attach,
+        args.opencode_agent,
+        args.omp_binary,
+        args.model,
+    )?);
+    let run_policy = RunPolicy {
+        cwd,
+        timeout: Duration::from_millis(request.policy.timeout_ms),
+        failure_transcript: None,
+    };
+    let run = kernel.review(&request, &run_policy)?;
+    validate_artifact_for_request(&run.artifact, &request)?;
+
+    // Optional persistence; stdout stays the primary deliverable for the caller.
+    if let Some(out) = &args.out {
+        write_json(out, &run.artifact)?;
+    }
+    let markdown = render_markdown(&run.artifact);
+    if let Some(path) = &args.markdown {
+        write_text(path, &markdown)?;
+    }
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&run.artifact)?);
+    } else {
+        print!("{markdown}");
+    }
+    Ok(verdict_exit_code(&run.artifact.verdict, args.fail_on))
 }
 
 fn review_pr(args: ReviewPrArgs) -> Result<()> {
@@ -610,4 +773,39 @@ fn sibling_path(out: &Path, filename: &str) -> PathBuf {
 #[allow(dead_code)]
 fn _assert_plan_is_serializable(plan: &ExecutionPlan) -> Result<String> {
     serde_json::to_string(plan).context("serialize execution plan")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_VERDICTS: [Verdict; 4] = [Verdict::Pass, Verdict::Warn, Verdict::Fail, Verdict::Skip];
+
+    #[test]
+    fn fail_on_none_never_blocks() {
+        for verdict in ALL_VERDICTS {
+            assert!(!is_blocking(&verdict, FailOn::None));
+        }
+    }
+
+    #[test]
+    fn fail_on_fail_blocks_only_fail() {
+        assert!(is_blocking(&Verdict::Fail, FailOn::Fail));
+        for verdict in [Verdict::Pass, Verdict::Warn, Verdict::Skip] {
+            assert!(!is_blocking(&verdict, FailOn::Fail));
+        }
+    }
+
+    #[test]
+    fn fail_on_warn_blocks_warn_and_fail() {
+        assert!(is_blocking(&Verdict::Warn, FailOn::Warn));
+        assert!(is_blocking(&Verdict::Fail, FailOn::Warn));
+        assert!(!is_blocking(&Verdict::Pass, FailOn::Warn));
+        // SKIP means "could not review", not "blocking".
+        assert!(!is_blocking(&Verdict::Skip, FailOn::Warn));
+    }
+
+    // The ExitCode mapping (blocking -> 1, clean -> 0, error -> 2) is proven
+    // end-to-end by the exit-code matrix in scripts/verify.sh; ExitCode is not
+    // PartialEq, so it cannot be asserted here.
 }


### PR DESCRIPTION
Closes backlog **018-agent-native-review-handoff**. Shape: `docs/plans/018-agent-native-handoff.html`.

## What
Cerberus's primary form factor — an agent spawns it on a local diff, reads the review off stdout, branches on the exit code — made first-class, with no GitHub and no token.

- **`--fail-on <none|warn|fail>`** (on `review` and the new `review-diff`) turns the exit code into a gate: **0** clean/proceed · **1** blocking verdict · **2** Cerberus error. A blocking verdict (1) is a *successful* review that found issues — distinct from a tool error (2), which used to collide on exit 1. `main` now returns `ExitCode`; errors map to 2 (the anyhow Debug stderr callers/verify.sh match on is preserved); no `--fail-on` keeps existing `review` exit behavior.
- **`cerberus review-diff --base <ref> [--head HEAD]`** fuses `build_git_range_request` + `ReviewKernel` + `render_markdown` into one no-GitHub command; review → stdout (`--json` for the raw artifact), `--out`/`--markdown` also persist. No new review logic.

## Oracle — green
- ✅ Exit-code matrix in `verify.sh` over a fixture git repo: WARN+`--fail-on fail`⇒0, WARN+`--fail-on warn`⇒1, FAIL+`--fail-on fail`⇒1, FAIL default⇒0 (back-compat), invalid emission⇒2; stdout carries the rendered review; `--fail-on` gates plain `review` too.
- ✅ `is_blocking` unit tests pin the verdict→block matrix.
- ✅ `./scripts/verify.sh` green; `cargo clippy -D warnings` clean; 58+3+1 tests pass.
- ✅ README "Agent-native handoff" section + spec CLI surface + exit-code table.
- ✅ Live `review-diff` with real OpenCode on a committed branch returns review-on-stdout + a branchable exit code (evidence under `target/cerberus/dogfood-018b/`).

## Scope
Reviewing the **uncommitted working tree** is a deliberate follow-on (`review-diff` takes a committed range). GitHub posting + bot identity stay consumer-owned (reshaped 014). Per spec.md (artifact caller-neutral, posting is projection) and VISION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-native `review-diff` handoff that writes rendered output to standard output, with optional saved Markdown/JSON artifacts.
  * Added `--fail-on` to `review` and `review-diff` (`none|warn|fail`) to control when warnings/failures produce nonzero exit codes.

* **Bug Fixes**
  * Implemented deterministic exit codes: `0` clean, `1` blocking (based on `--fail-on`), `2` for tool/processing errors.

* **Documentation**
  * Updated README and CLI spec with exit-code semantics and examples.

* **Tests**
  * Extended verification with an exit-code matrix for `review-diff` and threshold handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->