### PR TITLE
ci: harden verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,17 +7,25 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Install Rust
-        run: |
-          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
-          rustup default stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust build outputs
+        uses: Swatinem/rust-cache@v2
 
       - name: Run repo gate
         run: ./scripts/verify.sh
@@ -28,6 +36,7 @@ jobs:
   merge-gate:
     needs: [verify]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     steps:
       - name: Require all checks to pass


### PR DESCRIPTION
## Summary
- keep GitHub Actions as a thin caller around `./scripts/verify.sh`
- add PR-only cancellation, Rust setup/cache, and explicit timeouts
- preserve the existing merge-gate aggregation context

## Verification
- actionlint .github/workflows/verify.yml
- ./scripts/verify.sh
- git diff --check
- thermo-nuclear review: no blockers