### PR TITLE
chore(release): adopt Landmark synthesis

### DIFF
--- a/.github/workflows/landmark-release.yml
+++ b/.github/workflows/landmark-release.yml
@@ -1,0 +1,28 @@
+name: Synthesize Release Notes
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  synthesize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: misty-step/landmark@v1
+        with:
+          mode: synthesis-only
+          healthcheck: "true"
+          node-version: "24"
+          release-tag: ${{ github.event.release.tag_name }}
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          changelog-source: auto

--- a/.landmark.yml
+++ b/.landmark.yml
@@ -1,0 +1,14 @@
+product:
+  name: Cerberus
+  description: Code-review harness that produces validated, replayable review artifacts.
+audience: developer
+voice: Precise, evidence-grounded, and honest about inspected context.
+changelog:
+  source: auto
+release:
+  profile: synthesis-only
+model:
+  policy: balanced
+budget:
+  max_input_tokens: 12000
+  max_output_tokens: 1200


### PR DESCRIPTION
Adds Landmark release intelligence in synthesis-only mode:

- adds `.landmark.yml`
- adds `.github/workflows/landmark-release.yml` on `release.published`
- keeps existing release ownership unchanged

Verification:
- `/Users/phaedrus/Development/landmark/target/debug/landmark doctor --repo-root /tmp/landmark-fleet.E9PmHX/cerberus` => manifest ok
- `./scripts/verify.sh` => pass

Agent: Codex
Agent-Surface: Codex API
Agent-Model: GPT-5
Agent-Task: factory Landmark lane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release note generation when a new release is published.
  * Introduced a release-specific configuration to standardize how release notes are created.
* **Chores**
  * Set up the project with release-note generation settings, permissions, and token limits for the new workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->