### PR TITLE
feat(factory): package Cerberus agent surfaces

### DIFF
--- a/.agents/skills/cerberus-review/SKILL.md
+++ b/.agents/skills/cerberus-review/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: cerberus-review
+description: |
+  Run Cerberus as an agent-native code reviewer. Use when an agent needs a
+  review of a local git range, a verdict-gated exit code, an MCP review tool,
+  artifact rendering/validation, or GitHub PR posting through an explicit
+  caller-injected token. Do not use for generic code review advice without a
+  checkout or ReviewArtifact.v1.
+argument-hint: "[review-diff|mcp|render|validate|post-pr]"
+---
+
+# Cerberus Review
+
+Cerberus is a caller-neutral review runner. The stable seam is
+`ReviewRequest.v1 -> ReviewArtifact.v1`; GitHub is only a projection adapter.
+Use the existing CLI or MCP server rather than reimplementing review logic.
+
+## Fast Path: Local Agent Review
+
+For a branch or committed range:
+
+```sh
+cerberus review-diff --base origin/master --head HEAD \
+  --harness opencode \
+  --model openrouter/z-ai/glm-5.2 \
+  --allow-env OPENROUTER_API_KEY \
+  --fail-on fail
+```
+
+stdout is the review. stderr is logs/errors.
+
+Exit codes:
+
+- `0`: valid review, verdict below the threshold.
+- `1`: valid review, blocking verdict. Read stdout and fix the findings.
+- `2`: Cerberus error; no trustworthy review was produced.
+
+Use the fixture harness only for deterministic machinery tests:
+
+```sh
+cerberus review-diff --base <base> --head <head> \
+  --harness fixture \
+  --fixture-output fixtures/harness/valid-review.txt
+```
+
+## MCP
+
+Start the stdio MCP server when the calling agent has an MCP client:
+
+```sh
+cerberus mcp
+```
+
+Tools are intent-shaped:
+
+- `review_git_range`: review a committed local `base...head` range and return
+  rendered review text plus verdict metadata.
+- `render_review_artifact`: render a saved `ReviewArtifact.v1` to Markdown.
+- `validate_review_artifact`: validate a saved artifact against its
+  `ReviewRequest.v1`.
+
+Prefer `review-diff` for shell-native agent loops; prefer MCP when the caller
+benefits from tool schemas and structured results.
+
+## GitHub Posting
+
+Never let Cerberus post through ambient/keyring `gh` auth. `review-pr --post`
+requires exactly one explicit token source:
+
+```sh
+cerberus review-pr --number <n> --repo owner/name \
+  --harness opencode \
+  --summary-target check-run \
+  --gh-token-file /path/to/github-app-installation-token \
+  --post
+```
+
+or:
+
+```sh
+cerberus review-pr --number <n> --repo owner/name \
+  --harness opencode \
+  --summary-target status \
+  --gh-token-env GH_RELEASE_TOKEN \
+  --post
+```
+
+GitHub App registration and token minting belong to the consumer or CI layer.
+Cerberus only consumes an already-minted token and projects the artifact into
+GitHub. Use `--dry-run` first when checking the post plan.
+
+## Verification
+
+Before claiming changes to Cerberus complete:
+
+```sh
+./scripts/verify.sh
+```
+
+For prompt, doctrine, substrate, or review-quality changes, also do the
+repo-local live-review QA described by the `cerberus-qa` skill; the deterministic
+gate does not prove reviewer quality.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows:
+      - Verify
+    types:
+      - completed
+    branches:
+      - master
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Landmark
+        uses: misty-step/landmark@v1
+        with:
+          mode: full
+          healthcheck: 'true'
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          node-version: '24'
+          synthesis: 'true'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,25 @@
+{
+  "branches": [
+    "master"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ cerberus review-pr --number 123 --repo owner/name \
   --harness opencode \
   --out-dir target/cerberus/review-pr \
   --summary-target check-run \
+  --gh-token-file /path/to/github-app-installation-token \
   --post
 
 # Agent-native: review the current branch against a base in one command,
@@ -121,6 +122,31 @@ projection. It writes `request.json`, `artifact.json`, `review.md`,
 `post-plan.json` under `--out-dir`. `--dry-run` reads existing GitHub
 comments/checks through `gh api` and prints the exact create/update plan
 without writing. `--post` applies that plan and writes `post-result.json`.
+Posting refuses ambient/keyring `gh` auth: pass exactly one explicit token
+source, either `--gh-token-file <path>` or `--gh-token-env <VAR>`. If the token
+is a GitHub App installation token, Cerberus posts as that app identity; token
+minting remains the caller/CI boundary.
+
+## MCP
+
+Cerberus also ships a small stdio MCP server for agents that prefer tool calls
+over shelling out:
+
+```sh
+cerberus mcp
+```
+
+The MCP surface is intent-shaped rather than a CLI mirror:
+
+- `review_git_range` reviews a committed local `base...head` range and returns
+  the rendered review plus verdict metadata.
+- `render_review_artifact` renders a saved `ReviewArtifact.v1` to Markdown.
+- `validate_review_artifact` validates a saved artifact against its
+  `ReviewRequest.v1`.
+
+For local implementation work, `cerberus review-diff --base <ref> --fail-on
+fail` remains the lowest-friction handoff. Use MCP when the calling agent has a
+native MCP client and benefits from tool schemas/results.
 
 `ReviewReceiptBundle.v1` is the upstream evaluation handoff. It records the
 request digest, artifact digest, harness, model and usage when available,

--- a/backlog.d/014-post-as-cerberus-github-app.md
+++ b/backlog.d/014-post-as-cerberus-github-app.md
@@ -1,6 +1,13 @@
 # Safe GitHub posting: explicit injected token, refuse ambient auth
 
-Priority: P2 · Status: ready · Estimate: S · Reshaped: 2026-06-25
+Priority: P2 · Status: shipped · Estimate: S · Reshaped: 2026-06-25
+
+**Shipped 2026-07-01:** `review-pr --post` now refuses ambient/keyring `gh`
+auth and requires exactly one explicit token source (`--gh-token-file` or
+`--gh-token-env`). The token is passed to PR acquisition, stale-head checks, and
+`gh api` posting while ambient GitHub token env vars are removed for those
+subprocesses. `./scripts/verify.sh` covers no-token refusal, explicit-token
+fake-gh posting, and idempotent update behavior.
 
 ## Goal
 When Cerberus posts a review to GitHub (`review-pr --post`), it uses an **explicit, caller-injected token** and **refuses to post under ambient/keyring (`gh`) user auth** — so it never silently posts as a human, and so a bot identity supplied by the caller (a GitHub App installation token) flows through cleanly, including check-runs.

--- a/backlog.d/020-review-doctrine-and-daedalus-eval.md
+++ b/backlog.d/020-review-doctrine-and-daedalus-eval.md
@@ -44,6 +44,10 @@ still designs any lane from the diff at runtime (`prompt.rs` mission rules hold)
 - `_done/015-measure-improve-review-faithfulness.md`: eval lab = Daedalus; Cerberus
   emits `ReviewReceiptBundle.v1` (shipped in `_done/005`) and owns reviewer quality
   (prompt/context/substrate) — exactly the lever this change pulls.
+- Factory lane note, 2026-07-01: the measurement path is the Crucible/Threshold
+  review-quality eval (factory backlog 020/054). Cerberus should keep emitting
+  request/artifact/receipt evidence that that arena can consume; it should not
+  grow an in-repo scorer, leaderboard, or promotion loop.
 - If the arena surfaces a missing receipt field needed to score the doctrine, that
   becomes a small concrete Cerberus ticket *pulled by Daedalus*.
 

--- a/docs/plans/021-factory-agent-surface.html
+++ b/docs/plans/021-factory-agent-surface.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cerberus Factory Lane: Posting Safety, MCP, Skill, Landmark</title>
+  <style>
+    body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #171717; background: #faf8f2; }
+    main { width: min(82rem, calc(100% - 3rem)); margin: 0 auto; padding: 2rem 0 4rem; }
+    header { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(22rem, .65fr); gap: 2rem; align-items: end; border-bottom: 1px solid #d8d0bd; padding-bottom: 1.4rem; }
+    h1 { margin: 0; font-size: clamp(2.1rem, 4vw, 3.8rem); line-height: 1; }
+    h2 { margin: 0 0 .7rem; font-size: .78rem; letter-spacing: .08em; text-transform: uppercase; }
+    h3 { margin: 1.4rem 0 .4rem; }
+    p, li { line-height: 1.5; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .92em; }
+    .muted { color: #625d54; }
+    .panel { border: 1px solid #d8d0bd; background: #fffdfa; padding: 1rem; }
+    .grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; background: #d8d0bd; border: 1px solid #d8d0bd; margin-top: 1.5rem; }
+    .cell { background: #fffdfa; padding: 1rem; }
+    .wash { background: #f0ece0; }
+    .phase { display: grid; grid-template-columns: 8rem minmax(0, 1fr) minmax(16rem, .68fr); gap: 1.2rem; border-top: 1px solid #d8d0bd; padding-top: .85rem; margin-top: .85rem; }
+    table { border-collapse: collapse; width: 100%; font-size: .9rem; }
+    th, td { border: 1px solid #d8d0bd; padding: .55rem .65rem; vertical-align: top; text-align: left; }
+    th { background: #f0ece0; }
+    .ok { border-left: 4px solid #2c7a68; }
+    .warn { border-left: 4px solid #b4392a; }
+    @media (max-width: 900px) { header, .grid, .phase { grid-template-columns: 1fr; } main { width: min(100% - 2rem, 82rem); } }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <section>
+      <p class="muted">Factory lane / backlog 014 plus agent-native packaging</p>
+      <h1>Make Cerberus safe to post and easy for agents to invoke.</h1>
+      <p>Cerberus already has the primary CLI handoff: <code>review-diff</code> returns review output on stdout and a verdict-gated exit code. This branch finishes the factory surface around it: posting requires an explicit caller-injected GitHub token, agents get an intent-shaped MCP server, the repo ships a Cerberus skill, and releases run through Landmark.</p>
+    </section>
+    <aside class="panel ok">
+      <h2>Chosen Design</h2>
+      <p><strong>Posting:</strong> accept <code>--gh-token-file</code> or <code>--gh-token-env</code>; refuse <code>--post</code> without one; pass the token only to <code>gh api</code>.</p>
+      <p><strong>MCP:</strong> stdio JSON-RPC, intent tools over the existing CLI/review core, no REST mirror and no new review logic.</p>
+      <p><strong>Release:</strong> add the standard Landmark semantic-release workflow and config for <code>master</code>.</p>
+    </aside>
+  </header>
+
+  <section class="grid">
+    <article class="cell"><h2>Standards</h2><p>Caller-neutral core; GitHub remains a projection adapter. No ambient auth, no baked bot identity, no static reviewer fleet.</p></article>
+    <article class="cell"><h2>Acceptance</h2><p>Fake GitHub proves explicit-token posting and no-token refusal; MCP exposes 2-3 high-level review tools; skill documents invocation.</p></article>
+    <article class="cell"><h2>Verify</h2><p><code>./scripts/verify.sh</code>, MCP stdio smoke, fake-gh auth log, generated plan/skill docs inspected, final git status clean.</p></article>
+    <article class="cell wash"><h2>Stop If</h2><p>If a required GitHub App registration secret is needed, document the consumer step instead of baking token minting into Cerberus.</p></article>
+  </section>
+
+  <section class="panel" style="margin-top: 1.5rem">
+    <h2>Execution Plan</h2>
+    <div class="phase"><strong>1 Safety</strong><p>Add explicit posting token flags and plumb them to <code>GithubClient</code>. Refuse <code>--post</code> when neither token source is provided.</p><p class="muted">Proof: fake-gh post with token succeeds; fake-gh post without token exits non-zero and writes no post result.</p></div>
+    <div class="phase"><strong>2 Agent Surface</strong><p>Add <code>cerberus mcp</code> using stdio JSON-RPC. Tools stay intent-shaped: review a git range, render an artifact, and validate an artifact/request pair.</p><p class="muted">Proof: protocol initialize, tools/list, and tools/call fixture review smoke under <code>target/cerberus/mcp-*</code>.</p></div>
+    <div class="phase"><strong>3 Skill</strong><p>Add a shipped skill that tells an agent when to use CLI vs MCP, how to gate on exit codes, and how to avoid posting without explicit token injection.</p><p class="muted">Proof: skill file exists in <code>.agents/skills/cerberus-review/</code> and points to repo gate + artifacts.</p></div>
+    <div class="phase"><strong>4 Landmark</strong><p>Add <code>.github/workflows/release.yml</code> and <code>.releaserc.json</code> using Landmark's semantic-release adoption path for <code>master</code>.</p><p class="muted">Proof: workflow/config present and verify still passes.</p></div>
+  </section>
+
+  <section style="margin-top: 1.5rem">
+    <h2>Alternatives</h2>
+    <table>
+      <tr><th>Option</th><th>Why It Helps</th><th>Verdict</th></tr>
+      <tr><td>Cerberus-owned GitHub App minting</td><td>Would hide token creation from consumers.</td><td>Reject: violates 014 reshape and caller-neutral boundary.</td></tr>
+      <tr><td>MCP wraps every CLI subcommand</td><td>Fast to enumerate.</td><td>Reject: factory report calls out REST/CLI mirror MCP as the anti-pattern.</td></tr>
+      <tr><td>Only document MCP, no server</td><td>Cheap.</td><td>Reject: lane deliverable explicitly asks for a packageable MCP server.</td></tr>
+    </table>
+  </section>
+
+  <section class="panel warn" style="margin-top: 1.5rem">
+    <h2>Review Focus</h2>
+    <p>Critic should attack auth leakage, post idempotency under injected tokens, MCP stdout/stderr separation, and whether the new agent surface forks review behavior instead of calling the existing kernel/CLI path.</p>
+  </section>
+</main>
+</body>
+</html>

--- a/fixtures/bin/fake-gh
+++ b/fixtures/bin/fake-gh
@@ -7,10 +7,18 @@ log_file="${CERBERUS_FAKE_GH_LOG:-}"
 
 mkdir -p "$state_dir"
 
+if [[ "${CERBERUS_FAKE_GH_REQUIRE_TOKEN:-}" == "1" && -z "${GH_TOKEN:-}" ]]; then
+  echo "fake-gh expected explicit GH_TOKEN" >&2
+  exit 1
+fi
+
 record() {
   if [[ -n "$log_file" ]]; then
     {
       printf '%s %s\n' "$1" "$2"
+      printf 'AUTH gh_token=%s github_token=%s\n' \
+        "$([[ -n "${GH_TOKEN:-}" ]] && printf present || printf absent)" \
+        "$([[ -n "${GITHUB_TOKEN:-}" ]] && printf present || printf absent)"
       if [[ -n "${3:-}" ]]; then
         printf '%s\n' "$3"
       fi
@@ -19,6 +27,11 @@ record() {
 }
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+  record "PR_VIEW" "${*:3}"
+  if [[ "${CERBERUS_FAKE_GH_FAIL_PR_VIEW:-}" == "1" ]]; then
+    echo "pr view failed with GH_TOKEN=${GH_TOKEN:-}" >&2
+    exit 1
+  fi
   count_file="$state_dir/pr-view-count"
   count=0
   if [[ -s "$count_file" ]]; then
@@ -42,6 +55,11 @@ PY
 fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "diff" ]]; then
+  record "PR_DIFF" "${*:3}"
+  if [[ "${CERBERUS_FAKE_GH_FAIL_PR_DIFF:-}" == "1" ]]; then
+    echo "pr diff failed with GH_TOKEN=${GH_TOKEN:-}" >&2
+    exit 1
+  fi
   cat "$repo_root/fixtures/github/pr.diff"
   exit 0
 fi
@@ -83,6 +101,11 @@ if [[ "$read_input" == "1" ]]; then
   body="$(cat)"
 fi
 record "$method" "$path" "$body"
+
+if [[ "${CERBERUS_FAKE_GH_FAIL_API:-}" == "1" ]]; then
+  echo "api failed with GH_TOKEN=${GH_TOKEN:-}" >&2
+  exit 1
+fi
 
 comment_array() {
   local file="$1"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -25,6 +25,10 @@ grep -q -- '--dry-run' target/cerberus-review-pr-help.txt
 grep -q -- '--post' target/cerberus-review-pr-help.txt
 grep -q -- '--summary-target' target/cerberus-review-pr-help.txt
 grep -q -- '--receipt-bundle' target/cerberus-review-pr-help.txt
+grep -q -- '--gh-token-file' target/cerberus-review-pr-help.txt
+grep -q -- '--gh-token-env' target/cerberus-review-pr-help.txt
+cargo run --locked -- mcp --help > target/cerberus-mcp-help.txt
+grep -q 'Run the Cerberus MCP server over stdio' target/cerberus-mcp-help.txt
 
 rm -rf target/cerberus
 mkdir -p target/cerberus
@@ -260,6 +264,19 @@ expect_exit 1 review-failon-fail cargo run --locked -- review \
   --harness fixture --fixture-output target/cerberus/review-diff-fail-fixture.txt \
   --out target/cerberus/review-failon-artifact.json --fail-on fail
 
+mcp_init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25"}}'
+mcp_tools='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+mcp_review="$(printf '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"review_git_range","arguments":{"repo_path":"%s","base":"%s","head":"%s","harness":"fixture","fixture_output":"fixtures/harness/valid-review.txt","fail_on":"fail"}}}' "$tmp_repo" "$base_sha" "$head_sha")"
+printf '%s\n%s\n%s\n' "$mcp_init" "$mcp_tools" "$mcp_review" \
+  | cargo run --quiet --locked -- mcp \
+  > target/cerberus/mcp.stdout \
+  2> target/cerberus/mcp.stderr
+grep -q '"protocolVersion":"2025-11-25"' target/cerberus/mcp.stdout
+grep -q '"name":"review_git_range"' target/cerberus/mcp.stdout
+grep -q 'Cerberus Review:' target/cerberus/mcp.stdout
+grep -q '"blocking":false' target/cerberus/mcp.stdout
+test ! -s target/cerberus/mcp.stderr
+
 if cargo run --locked -- request git-range \
   --repo-path "$tmp_repo" \
   --base "$base_sha" \
@@ -354,6 +371,8 @@ GH_TOKEN=should-not-leak cargo run --locked -- review \
 
 fake_gh="$PWD/fixtures/bin/fake-gh"
 fake_gh_state="target/cerberus/fake-gh-state"
+fake_gh_token="target/cerberus/fake-gh-token.txt"
+printf 'cerberus-fixture-token\n' > "$fake_gh_token"
 rm -rf "$fake_gh_state"
 CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" cargo run --locked -- review-pr \
   --number 7 \
@@ -372,6 +391,134 @@ grep -q '"path": "/repos/example/fixture/pulls/7/reviews"' target/cerberus/revie
 grep -q '"line": 3' target/cerberus/review-pr-dry-run/post-plan.json
 grep -q '"commit_id": "0123456789abcdef"' target/cerberus/review-pr-dry-run/post-plan.json
 grep -q 'comment-001' target/cerberus/review-pr-dry-run/review.md
+
+rm -rf "$fake_gh_state"
+mkdir -p target/cerberus/review-pr-post-no-token
+printf 'stale post result\n' > target/cerberus/review-pr-post-no-token/post-result.json
+printf 'stale post plan\n' > target/cerberus/review-pr-post-no-token/post-plan.json
+if CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+  CERBERUS_FAKE_GH_LOG=target/cerberus/review-pr-post-no-token-gh.log \
+  cargo run --locked -- review-pr \
+    --number 7 \
+    --repo example/fixture \
+    --gh-binary "$fake_gh" \
+    --harness fixture \
+    --fixture-output fixtures/harness/valid-review.txt \
+    --out-dir target/cerberus/review-pr-post-no-token \
+    --summary-target check-run \
+    --post \
+    > target/cerberus/review-pr-post-no-token.stdout \
+    2> target/cerberus/review-pr-post-no-token.stderr; then
+  echo "expected review-pr post to refuse ambient auth without explicit token" >&2
+  exit 1
+fi
+grep -q 'requires an explicit GitHub token' target/cerberus/review-pr-post-no-token.stderr
+test ! -e target/cerberus/review-pr-post-no-token/post-result.json
+test ! -e target/cerberus/review-pr-post-no-token/post-plan.json
+if [[ -e target/cerberus/review-pr-post-no-token-gh.log ]] && \
+  grep -q '^POST ' target/cerberus/review-pr-post-no-token-gh.log; then
+  echo "review-pr posted without explicit token" >&2
+  exit 1
+fi
+
+rm -rf "$fake_gh_state"
+if CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+  CERBERUS_FAKE_GH_LOG=target/cerberus/review-pr-post-both-token-sources-gh.log \
+  CERBERUS_REVIEW_POST_TOKEN=cerberus-fixture-token \
+  cargo run --locked -- review-pr \
+    --number 7 \
+    --repo example/fixture \
+    --gh-binary "$fake_gh" \
+    --harness fixture \
+    --fixture-output fixtures/harness/valid-review.txt \
+    --out-dir target/cerberus/review-pr-post-both-token-sources \
+    --summary-target check-run \
+    --gh-token-file "$fake_gh_token" \
+    --gh-token-env CERBERUS_REVIEW_POST_TOKEN \
+    --post \
+    > target/cerberus/review-pr-post-both-token-sources.stdout \
+    2> target/cerberus/review-pr-post-both-token-sources.stderr; then
+  echo "expected review-pr post to reject multiple explicit token sources" >&2
+  exit 1
+fi
+grep -q 'exactly one explicit GitHub token source' \
+  target/cerberus/review-pr-post-both-token-sources.stderr
+
+rm -rf "$fake_gh_state"
+if CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+  CERBERUS_FAKE_GH_REQUIRE_TOKEN=1 \
+  CERBERUS_FAKE_GH_FAIL_PR_VIEW=1 \
+  CERBERUS_REVIEW_POST_TOKEN=cerberus-fixture-token \
+  cargo run --locked -- review-pr \
+    --number 7 \
+    --repo example/fixture \
+    --gh-binary "$fake_gh" \
+    --harness fixture \
+    --fixture-output fixtures/harness/valid-review.txt \
+    --out-dir target/cerberus/review-pr-post-pr-view-token-leak \
+    --summary-target check-run \
+    --gh-token-env CERBERUS_REVIEW_POST_TOKEN \
+    --post \
+    > target/cerberus/review-pr-post-pr-view-token-leak.stdout \
+    2> target/cerberus/review-pr-post-pr-view-token-leak.stderr; then
+  echo "expected injected-token pr view failure" >&2
+  exit 1
+fi
+grep -q 'GH_TOKEN=<redacted>' target/cerberus/review-pr-post-pr-view-token-leak.stderr
+if grep -q 'cerberus-fixture-token' target/cerberus/review-pr-post-pr-view-token-leak.stderr; then
+  echo "pr view failure leaked injected token" >&2
+  exit 1
+fi
+
+rm -rf "$fake_gh_state"
+if CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+  CERBERUS_FAKE_GH_REQUIRE_TOKEN=1 \
+  CERBERUS_FAKE_GH_FAIL_PR_DIFF=1 \
+  cargo run --locked -- review-pr \
+    --number 7 \
+    --repo example/fixture \
+    --gh-binary "$fake_gh" \
+    --harness fixture \
+    --fixture-output fixtures/harness/valid-review.txt \
+    --out-dir target/cerberus/review-pr-post-pr-diff-token-leak \
+    --summary-target check-run \
+    --gh-token-file "$fake_gh_token" \
+    --post \
+    > target/cerberus/review-pr-post-pr-diff-token-leak.stdout \
+    2> target/cerberus/review-pr-post-pr-diff-token-leak.stderr; then
+  echo "expected injected-token pr diff failure" >&2
+  exit 1
+fi
+grep -q 'GH_TOKEN=<redacted>' target/cerberus/review-pr-post-pr-diff-token-leak.stderr
+if grep -q 'cerberus-fixture-token' target/cerberus/review-pr-post-pr-diff-token-leak.stderr; then
+  echo "pr diff failure leaked injected token" >&2
+  exit 1
+fi
+
+rm -rf "$fake_gh_state"
+if CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+  CERBERUS_FAKE_GH_REQUIRE_TOKEN=1 \
+  CERBERUS_FAKE_GH_FAIL_API=1 \
+  cargo run --locked -- review-pr \
+    --number 7 \
+    --repo example/fixture \
+    --gh-binary "$fake_gh" \
+    --harness fixture \
+    --fixture-output fixtures/harness/valid-review.txt \
+    --out-dir target/cerberus/review-pr-post-api-token-leak \
+    --summary-target check-run \
+    --gh-token-file "$fake_gh_token" \
+    --post \
+    > target/cerberus/review-pr-post-api-token-leak.stdout \
+    2> target/cerberus/review-pr-post-api-token-leak.stderr; then
+  echo "expected injected-token api failure" >&2
+  exit 1
+fi
+grep -q 'GH_TOKEN=<redacted>' target/cerberus/review-pr-post-api-token-leak.stderr
+if grep -q 'cerberus-fixture-token' target/cerberus/review-pr-post-api-token-leak.stderr; then
+  echo "api failure leaked injected token" >&2
+  exit 1
+fi
 
 rm -rf "$fake_gh_state"
 if CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
@@ -394,6 +541,7 @@ test ! -e target/cerberus/review-pr-stale-head/receipt-bundle.json
 
 rm -rf "$fake_gh_state"
 if CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+  CERBERUS_FAKE_GH_REQUIRE_TOKEN=1 \
   CERBERUS_FAKE_GH_MOVED_HEAD_SHA=feedfacefeedface \
   CERBERUS_FAKE_GH_MOVE_HEAD_AFTER_VIEW_COUNT=3 \
   CERBERUS_FAKE_GH_LOG=target/cerberus/review-pr-post-final-stale-gh.log \
@@ -405,6 +553,7 @@ if CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
     --fixture-output fixtures/harness/valid-review.txt \
     --out-dir target/cerberus/review-pr-post-final-stale \
     --summary-target check-run \
+    --gh-token-file "$fake_gh_token" \
     --post \
     > target/cerberus/review-pr-post-final-stale.stdout \
     2> target/cerberus/review-pr-post-final-stale.stderr; then
@@ -422,6 +571,7 @@ fi
 
 rm -rf "$fake_gh_state"
 CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+CERBERUS_FAKE_GH_REQUIRE_TOKEN=1 \
 CERBERUS_FAKE_GH_LOG=target/cerberus/review-pr-post-first-gh.log \
 cargo run --locked -- review-pr \
   --number 7 \
@@ -431,9 +581,11 @@ cargo run --locked -- review-pr \
   --fixture-output fixtures/harness/valid-review.txt \
   --out-dir target/cerberus/review-pr-post-first \
   --summary-target check-run \
+  --gh-token-file "$fake_gh_token" \
   --post
 
 CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+CERBERUS_FAKE_GH_REQUIRE_TOKEN=1 \
 CERBERUS_FAKE_GH_LOG=target/cerberus/review-pr-post-second-gh.log \
 cargo run --locked -- review-pr \
   --number 7 \
@@ -443,9 +595,11 @@ cargo run --locked -- review-pr \
   --fixture-output fixtures/harness/valid-review.txt \
   --out-dir target/cerberus/review-pr-post-second \
   --summary-target check-run \
+  --gh-token-file "$fake_gh_token" \
   --post
 
 CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+CERBERUS_FAKE_GH_REQUIRE_TOKEN=1 \
 CERBERUS_FAKE_GH_MARKERS_ON_PAGE_2=1 \
 CERBERUS_FAKE_GH_LOG=target/cerberus/review-pr-post-page-two-gh.log \
 cargo run --locked -- review-pr \
@@ -456,6 +610,7 @@ cargo run --locked -- review-pr \
   --fixture-output fixtures/harness/valid-review.txt \
   --out-dir target/cerberus/review-pr-post-page-two \
   --summary-target check-run \
+  --gh-token-file "$fake_gh_token" \
   --post
 
 test -s target/cerberus/artifact.json
@@ -467,6 +622,7 @@ test -s target/cerberus/git-range-request.json
 test -s target/cerberus/git-range-artifact.json
 test -s target/cerberus/git-range-review.md
 test -s target/cerberus/git-range-execution_plan.json
+test -s target/cerberus/mcp.stdout
 test -s target/cerberus/git-range-opencode-artifact.json
 test -s target/cerberus/git-range-opencode-review.md
 test -s target/cerberus/git-range-opencode-execution_plan.json
@@ -536,6 +692,7 @@ if grep -R 'GH_TOKEN\|should-not-leak\|master-prompt.md\|review-request.json' ta
 fi
 grep -q 'POST /repos/example/fixture/check-runs' target/cerberus/review-pr-post-first-gh.log
 grep -q 'POST /repos/example/fixture/pulls/7/reviews' target/cerberus/review-pr-post-first-gh.log
+grep -q 'AUTH gh_token=present github_token=absent' target/cerberus/review-pr-post-first-gh.log
 grep -q 'GET /repos/example/fixture/issues/7/comments?per_page=100&page=1' target/cerberus/review-pr-post-first-gh.log
 grep -q 'GET /repos/example/fixture/pulls/7/comments?per_page=100&page=1' target/cerberus/review-pr-post-first-gh.log
 grep -q 'GET /repos/example/fixture/commits/0123456789abcdef/check-runs?check_name=Cerberus%20Review&per_page=100&page=1' target/cerberus/review-pr-post-first-gh.log
@@ -553,9 +710,20 @@ if [[ "${CERBERUS_LIVE_REVIEW_PR:-}" == "1" ]]; then
   : "${CERBERUS_LIVE_REVIEW_REPO:?set CERBERUS_LIVE_REVIEW_REPO=owner/name}"
   : "${CERBERUS_LIVE_REVIEW_NUMBER:?set CERBERUS_LIVE_REVIEW_NUMBER=<pull request number>}"
   live_out="target/cerberus/live-review-pr"
-  live_mode="--dry-run"
+  live_mode=(--dry-run)
   if [[ "${CERBERUS_LIVE_REVIEW_POST:-}" == "1" ]]; then
-    live_mode="--post"
+    live_mode=(--post)
+    if [[ -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE:-}" && -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV:-}" ]]; then
+      echo "set only one of CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE or CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV" >&2
+      exit 1
+    elif [[ -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE:-}" ]]; then
+      live_mode+=(--gh-token-file "$CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE")
+    elif [[ -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV:-}" ]]; then
+      live_mode+=(--gh-token-env "$CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV")
+    else
+      echo "live review posting requires CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE or CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV" >&2
+      exit 1
+    fi
   fi
   cargo run --locked -- review-pr \
     --number "$CERBERUS_LIVE_REVIEW_NUMBER" \
@@ -563,5 +731,5 @@ if [[ "${CERBERUS_LIVE_REVIEW_PR:-}" == "1" ]]; then
     --out-dir "$live_out" \
     --summary-target "${CERBERUS_LIVE_REVIEW_SUMMARY_TARGET:-status}" \
     --harness "${CERBERUS_LIVE_REVIEW_HARNESS:-opencode}" \
-    $live_mode
+    "${live_mode[@]}"
 fi

--- a/spec.md
+++ b/spec.md
@@ -278,8 +278,11 @@ cerberus render --artifact <artifact.json> --markdown <review.md>
 cerberus review-pr --number <n> --repo <owner/name> \
   [--out-dir <dir>] [--dry-run|--post] \
   [--summary-target check-run|status] \
+  [--gh-token-file <path>|--gh-token-env <VAR>] \
   [--receipt-bundle <bundle.json>] \
   [--harness opencode|omp|fixture]
+
+cerberus mcp
 ```
 
 The request commands are acquisition helpers. They produce `ReviewRequest.v1`
@@ -313,10 +316,22 @@ comments. Inline review comments are emitted only when the artifact anchor maps
 to a changed new-side line in the PR diff; every unmappable inline comment is
 included in contextual summary output instead.
 
+`--post` requires an explicit caller-injected GitHub token source
+(`--gh-token-file` or `--gh-token-env`) and refuses ambient/keyring `gh` auth.
+The token may be a GitHub App installation token, fine-grained token, or other
+caller-owned credential with the required destination permissions. Cerberus does
+not mint GitHub App JWTs or installation tokens; that remains the consumer or CI
+boundary. Dry-run and artifact emission may still run without an explicit token.
+
 `--summary-target check-run` creates or updates a Cerberus check run when the
-available token has Checks write access. `--summary-target status` posts a
-commit status fallback for user-token environments where check-run creation is
-not authorized.
+injected token has Checks write access. `--summary-target status` posts a
+commit status fallback for environments where check-run creation is not
+authorized.
+
+`mcp` runs a stdio JSON-RPC MCP server. Its tools are review intents, not a
+REST/CLI mirror: review a local git range, render a saved artifact, and validate
+an artifact against its request. Each tool delegates to the same request builder,
+kernel, validator, and renderer used by the CLI.
 
 The fixture harness exists only for deterministic verification. The preferred
 production product path is the OpenCode harness; OMP is a local fallback.
@@ -379,7 +394,10 @@ MVP is complete when:
   bundles for upstream scoring;
 - Markdown rendering works from stored artifacts;
 - `review-pr` can dry-run and post through fake GitHub fixtures without
-  duplicate comments and without inline comments outside changed lines;
+  duplicate comments, without inline comments outside changed lines, and without
+  posting under ambient/keyring GitHub auth;
+- `mcp` can initialize, list intent-shaped tools, and run a fixture-backed
+  git-range review over stdio;
 - `./scripts/verify.sh` passes from a clean checkout;
 - final git state is clean.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod digest;
 pub mod harness;
 pub mod kernel;
+pub mod mcp;
 pub mod post;
 pub mod prompt;
 pub mod receipt;
 pub mod render;
 pub mod request;
 pub mod schema;
+mod secrets;
 mod telemetry;
 pub mod validation;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,8 @@ enum Command {
     ReviewDiff(Box<ReviewDiffArgs>),
     ReviewPr(Box<ReviewPrArgs>),
     Render(RenderArgs),
+    /// Run the Cerberus MCP server over stdio.
+    Mcp,
 }
 
 #[derive(Debug, Args)]
@@ -208,6 +210,12 @@ struct ReviewPrArgs {
     summary_target: SummaryTarget,
     #[arg(long, default_value = "gh")]
     gh_binary: String,
+    /// Read the GitHub posting token from this file. Required for --post unless --gh-token-env is used.
+    #[arg(long)]
+    gh_token_file: Option<PathBuf>,
+    /// Read the GitHub posting token from this explicitly named env var. Required for --post unless --gh-token-file is used.
+    #[arg(long)]
+    gh_token_env: Option<String>,
     #[arg(long)]
     head_workspace: Option<PathBuf>,
     #[arg(long)]
@@ -307,6 +315,7 @@ fn run() -> Result<ExitCode> {
         Command::ReviewDiff(args) => review_diff(*args),
         Command::ReviewPr(args) => review_pr(*args).map(|()| ExitCode::SUCCESS),
         Command::Render(args) => render(args).map(|()| ExitCode::SUCCESS),
+        Command::Mcp => cerberus::mcp::run_stdio().map(|()| ExitCode::SUCCESS),
     }
 }
 
@@ -339,6 +348,7 @@ fn request(args: RequestArgs) -> Result<()> {
                 number: args.number,
                 repo: args.repo,
                 gh_binary: args.gh_binary,
+                gh_token: None,
                 head_workspace: args.head_workspace,
                 base_workspace: args.base_workspace,
                 common: RequestOptions {
@@ -523,12 +533,21 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     let post_result_path = args.out_dir.join("post-result.json");
     clean_review_pr_post_receipts(&post_plan_path, &post_result_path)?;
     remove_file_if_exists(&receipt_bundle_path)?;
+    let posting_token = if args.post {
+        Some(resolve_post_token(
+            args.gh_token_file.as_deref(),
+            args.gh_token_env.as_deref(),
+        )?)
+    } else {
+        None
+    };
     let gh_binary = args.gh_binary.clone();
 
     let request = build_pull_request(&PullRequestOptions {
         number: args.number,
         repo: Some(args.repo.clone()),
         gh_binary: gh_binary.clone(),
+        gh_token: posting_token.clone(),
         head_workspace: args.head_workspace,
         base_workspace: args.base_workspace,
         common: RequestOptions {
@@ -548,7 +567,13 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
         .as_deref()
         .ok_or_else(|| anyhow!("review-pr requires request.change.head_sha"))?
         .to_string();
-    ensure_pr_head_unchanged(args.number, &args.repo, &gh_binary, &head_sha)?;
+    ensure_pr_head_unchanged(
+        args.number,
+        &args.repo,
+        &gh_binary,
+        posting_token.as_deref(),
+        &head_sha,
+    )?;
 
     let cwd = args
         .cwd
@@ -564,7 +589,13 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     write_text(&transcript_path, &run.transcript)?;
     write_json(&artifact_path, &run.artifact)?;
     let validation_result = validate_artifact_for_request(&run.artifact, &request);
-    ensure_pr_head_unchanged(args.number, &args.repo, &gh_binary, &head_sha)?;
+    ensure_pr_head_unchanged(
+        args.number,
+        &args.repo,
+        &gh_binary,
+        posting_token.as_deref(),
+        &head_sha,
+    )?;
     if validation_result.is_err() {
         write_review_receipt_bundle(
             &receipt_bundle_path,
@@ -595,7 +626,10 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     }
     write_text(&markdown_path, &render_markdown(&run.artifact))?;
 
-    let github = GithubClient::new(gh_binary.clone());
+    let mut github = GithubClient::new(gh_binary.clone());
+    if let Some(token) = &posting_token {
+        github = github.with_token(token.clone());
+    }
     let existing =
         github.read_existing_state(&args.repo, args.number, &head_sha, args.summary_target)?;
     let post_plan = build_post_plan(
@@ -609,7 +643,13 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     write_json(&post_plan_path, &post_plan)?;
 
     if args.post {
-        ensure_pr_head_unchanged(args.number, &args.repo, &gh_binary, &post_plan.head_sha)?;
+        ensure_pr_head_unchanged(
+            args.number,
+            &args.repo,
+            &gh_binary,
+            posting_token.as_deref(),
+            &post_plan.head_sha,
+        )?;
         write_review_receipt_bundle(
             &receipt_bundle_path,
             &request,
@@ -650,13 +690,47 @@ fn remove_file_if_exists(path: &Path) -> Result<()> {
     }
 }
 
+fn resolve_post_token(token_file: Option<&Path>, token_env: Option<&str>) -> Result<String> {
+    match (token_file, token_env) {
+        (Some(_), Some(_)) => Err(anyhow!(
+            "review-pr --post accepts exactly one explicit GitHub token source: --gh-token-file or --gh-token-env"
+        )),
+        (Some(path), None) => {
+            let raw = fs::read_to_string(path)
+                .with_context(|| format!("read GitHub token file {}", path.display()))?;
+            let token = raw.trim_end_matches(['\r', '\n']).to_string();
+            if token.trim().is_empty() {
+                return Err(anyhow!(
+                    "GitHub token file {} is empty; refusing to post",
+                    path.display()
+                ));
+            }
+            Ok(token)
+        }
+        (None, Some(var)) => {
+            let token = std::env::var(var)
+                .with_context(|| format!("read explicit GitHub token env var {var}"))?;
+            if token.trim().is_empty() {
+                return Err(anyhow!(
+                    "explicit GitHub token env var {var} is empty; refusing to post"
+                ));
+            }
+            Ok(token)
+        }
+        (None, None) => Err(anyhow!(
+            "review-pr --post requires an explicit GitHub token via --gh-token-file <path> or --gh-token-env <VAR>; ambient gh auth is refused for posting"
+        )),
+    }
+}
+
 fn ensure_pr_head_unchanged(
     number: u64,
     repo: &str,
     gh_binary: &str,
+    gh_token: Option<&str>,
     expected_head_sha: &str,
 ) -> Result<()> {
-    let current = fetch_pull_request_head_sha(number, Some(repo), gh_binary)?;
+    let current = fetch_pull_request_head_sha(number, Some(repo), gh_binary, gh_token)?;
     if current != expected_head_sha {
         return Err(anyhow!(
             "pull request #{number} head moved from {expected_head_sha} to {current}; refusing to post stale Cerberus output"

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,388 @@
+//! Minimal Model Context Protocol server for Cerberus.
+//!
+//! Transport is stdio with one JSON-RPC 2.0 message per line, matching the
+//! simple local MCP servers used elsewhere in the fleet. stdout is the protocol
+//! channel; diagnostics go to stderr.
+
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::kernel::{ReviewKernel, ReviewSubstrate, RunPolicy};
+use crate::request::{build_git_range_request, GitRangeRequestOptions, RequestOptions};
+use crate::schema::{RuntimeTarget, Verdict};
+use crate::{
+    render_markdown, validate_artifact_for_request, validate_request, FixtureSubstrateConfig,
+    OmpSubstrateConfig, OpenCodeSubstrateConfig, ReviewArtifact, ReviewRequest,
+};
+
+const PROTOCOL_VERSION: &str = "2025-11-25";
+
+pub fn run_stdio() -> Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout().lock();
+
+    for line in stdin.lock().lines() {
+        let line = line.context("read MCP stdin")?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let message: Value = match serde_json::from_str(line) {
+            Ok(message) => message,
+            Err(err) => {
+                eprintln!("mcp: invalid JSON: {err}");
+                continue;
+            }
+        };
+
+        let id = message.get("id").cloned();
+        let method = message
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let result = dispatch(method, &message);
+        let Some(id) = id else { continue };
+
+        let response = match result {
+            Ok(value) => json!({ "jsonrpc": "2.0", "id": id, "result": value }),
+            Err(err) => json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": { "code": -32603, "message": err.to_string() }
+            }),
+        };
+        writeln!(stdout, "{}", serde_json::to_string(&response)?)?;
+        stdout.flush()?;
+    }
+
+    Ok(())
+}
+
+fn dispatch(method: &str, message: &Value) -> Result<Value> {
+    match method {
+        "initialize" => Ok(json!({
+            "protocolVersion": message["params"]["protocolVersion"]
+                .as_str()
+                .unwrap_or(PROTOCOL_VERSION),
+            "serverInfo": {
+                "name": "cerberus",
+                "version": env!("CARGO_PKG_VERSION")
+            },
+            "capabilities": { "tools": { "listChanged": false } }
+        })),
+        "tools/list" => Ok(json!({ "tools": tool_defs() })),
+        "tools/call" => call_tool(&message["params"]),
+        "ping" => Ok(json!({})),
+        other => Err(anyhow!("method not found: {other}")),
+    }
+}
+
+fn tool_defs() -> Value {
+    json!([
+        {
+            "name": "review_git_range",
+            "description": "Review a committed local git range with Cerberus and return the rendered review plus verdict metadata. Use when an agent needs a branchable code review artifact without GitHub posting.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["base"],
+                "properties": {
+                    "repo_path": { "type": "string", "default": "." },
+                    "base": { "type": "string", "description": "Base ref for git diff base...head." },
+                    "head": { "type": "string", "default": "HEAD" },
+                    "harness": { "type": "string", "enum": ["opencode", "omp", "fixture"], "default": "opencode" },
+                    "fixture_output": { "type": "string", "description": "Fixture artifact template path; required when harness=fixture." },
+                    "model": { "type": "string" },
+                    "allow_env": { "type": "array", "items": { "type": "string" } },
+                    "timeout_seconds": { "type": "integer", "minimum": 1, "default": 120 },
+                    "fail_on": { "type": "string", "enum": ["none", "warn", "fail"], "default": "none" },
+                    "json": { "type": "boolean", "description": "Return artifact JSON text instead of rendered Markdown." }
+                }
+            }
+        },
+        {
+            "name": "render_review_artifact",
+            "description": "Render a saved ReviewArtifact.v1 JSON file to Cerberus Markdown. Use when a caller already has an artifact and needs human-readable output.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["artifact_path"],
+                "properties": {
+                    "artifact_path": { "type": "string" }
+                }
+            }
+        },
+        {
+            "name": "validate_review_artifact",
+            "description": "Validate a saved ReviewArtifact.v1 against its ReviewRequest.v1. Use before trusting or posting an artifact from disk.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["request_path", "artifact_path"],
+                "properties": {
+                    "request_path": { "type": "string" },
+                    "artifact_path": { "type": "string" }
+                }
+            }
+        }
+    ])
+}
+
+fn call_tool(params: &Value) -> Result<Value> {
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("tools/call missing tool name"))?;
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    match name {
+        "review_git_range" => review_git_range(arguments),
+        "render_review_artifact" => render_review_artifact(arguments),
+        "validate_review_artifact" => validate_review_artifact(arguments),
+        other => Err(anyhow!("unknown tool: {other}")),
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ReviewGitRangeArgs {
+    #[serde(default = "default_repo_path")]
+    repo_path: PathBuf,
+    base: String,
+    #[serde(default = "default_head")]
+    head: String,
+    base_workspace: Option<PathBuf>,
+    title: Option<String>,
+    description: Option<String>,
+    request_id: Option<String>,
+    repo: Option<String>,
+    #[serde(default)]
+    instructions: Vec<String>,
+    #[serde(default)]
+    allow_env: Vec<String>,
+    #[serde(default)]
+    local_runtime_commands: Vec<String>,
+    #[serde(default)]
+    allow_local_runtime: bool,
+    #[serde(default = "default_timeout_seconds")]
+    timeout_seconds: u64,
+    harness: Option<String>,
+    fixture_output: Option<PathBuf>,
+    opencode_binary: Option<String>,
+    opencode_attach: Option<String>,
+    opencode_agent: Option<String>,
+    omp_binary: Option<String>,
+    model: Option<String>,
+    fail_on: Option<String>,
+    #[serde(default)]
+    json: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RenderArtifactArgs {
+    artifact_path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct ValidateArtifactArgs {
+    request_path: PathBuf,
+    artifact_path: PathBuf,
+}
+
+fn review_git_range(arguments: Value) -> Result<Value> {
+    let args: ReviewGitRangeArgs =
+        serde_json::from_value(arguments).context("parse review_git_range arguments")?;
+    let substrate = review_substrate(&args)?;
+    let fail_on = args.fail_on.clone();
+    let json_output = args.json;
+    let timeout_ms = args
+        .timeout_seconds
+        .checked_mul(1000)
+        .ok_or_else(|| anyhow!("timeout_seconds overflows milliseconds"))?;
+    let request = build_git_range_request(&GitRangeRequestOptions {
+        repo_path: args.repo_path,
+        base: args.base,
+        head: args.head,
+        base_workspace: args.base_workspace,
+        title: args.title,
+        description: args.description,
+        repo: args.repo,
+        common: RequestOptions {
+            request_id: args.request_id,
+            instructions: args.instructions,
+            local_runtime: runtime_targets(args.local_runtime_commands),
+            allow_local_runtime: args.allow_local_runtime,
+            allowed_env: args.allow_env,
+            timeout_ms,
+        },
+    })?;
+    validate_request(&request)?;
+
+    let kernel = ReviewKernel::new(substrate);
+    let run_policy = RunPolicy {
+        cwd: std::env::current_dir().context("read current directory")?,
+        timeout: Duration::from_millis(request.policy.timeout_ms),
+        failure_transcript: None,
+    };
+    let run = kernel.review(&request, &run_policy)?;
+    validate_artifact_for_request(&run.artifact, &request)?;
+
+    let body = if json_output {
+        serde_json::to_string_pretty(&run.artifact)?
+    } else {
+        render_markdown(&run.artifact)
+    };
+    Ok(json!({
+        "content": [{ "type": "text", "text": body }],
+        "structuredContent": {
+            "request_id": request.request_id,
+            "artifact_id": run.artifact.artifact_id,
+            "verdict": run.artifact.verdict,
+            "blocking": verdict_blocks(&run.artifact.verdict, fail_on.as_deref())?,
+            "context_capabilities": run.artifact.context_capabilities
+        }
+    }))
+}
+
+fn render_review_artifact(arguments: Value) -> Result<Value> {
+    let args: RenderArtifactArgs =
+        serde_json::from_value(arguments).context("parse render_review_artifact arguments")?;
+    let artifact = read_json::<ReviewArtifact>(&args.artifact_path)?;
+    Ok(json!({
+        "content": [{ "type": "text", "text": render_markdown(&artifact) }],
+        "structuredContent": {
+            "artifact_id": artifact.artifact_id,
+            "verdict": artifact.verdict
+        }
+    }))
+}
+
+fn validate_review_artifact(arguments: Value) -> Result<Value> {
+    let args: ValidateArtifactArgs =
+        serde_json::from_value(arguments).context("parse validate_review_artifact arguments")?;
+    let request = read_json::<ReviewRequest>(&args.request_path)?;
+    validate_request(&request)?;
+    let artifact = read_json::<ReviewArtifact>(&args.artifact_path)?;
+    validate_artifact_for_request(&artifact, &request)?;
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": format!("valid ReviewArtifact.v1 `{}` for request `{}`", artifact.artifact_id, request.request_id)
+        }],
+        "structuredContent": {
+            "valid": true,
+            "request_id": request.request_id,
+            "artifact_id": artifact.artifact_id,
+            "verdict": artifact.verdict
+        }
+    }))
+}
+
+fn review_substrate(args: &ReviewGitRangeArgs) -> Result<ReviewSubstrate> {
+    match args.harness.as_deref().unwrap_or("opencode") {
+        "fixture" => {
+            let output = args
+                .fixture_output
+                .clone()
+                .ok_or_else(|| anyhow!("fixture harness requires fixture_output"))?;
+            Ok(ReviewSubstrate::Fixture(FixtureSubstrateConfig { output }))
+        }
+        "opencode" => Ok(ReviewSubstrate::Opencode(OpenCodeSubstrateConfig {
+            binary: args
+                .opencode_binary
+                .clone()
+                .unwrap_or_else(|| "opencode".to_string()),
+            attach: args.opencode_attach.clone(),
+            agent: Some(
+                args.opencode_agent
+                    .clone()
+                    .unwrap_or_else(|| "build".to_string()),
+            ),
+            model: args.model.clone(),
+        })),
+        "omp" => Ok(ReviewSubstrate::Omp(OmpSubstrateConfig {
+            binary: args.omp_binary.clone().unwrap_or_else(|| "omp".to_string()),
+            model: args.model.clone(),
+        })),
+        other => Err(anyhow!(
+            "unsupported harness {other}; expected one of opencode, omp, fixture"
+        )),
+    }
+}
+
+fn runtime_targets(commands: Vec<String>) -> Vec<RuntimeTarget> {
+    commands
+        .into_iter()
+        .map(|command| RuntimeTarget {
+            kind: "command".to_string(),
+            command,
+            args: Vec::new(),
+            cwd: None,
+        })
+        .collect()
+}
+
+fn verdict_blocks(verdict: &Verdict, fail_on: Option<&str>) -> Result<bool> {
+    match fail_on.unwrap_or("none") {
+        "none" => Ok(false),
+        "warn" => Ok(matches!(verdict, Verdict::Warn | Verdict::Fail)),
+        "fail" => Ok(matches!(verdict, Verdict::Fail)),
+        other => Err(anyhow!(
+            "unsupported fail_on {other}; expected none, warn, or fail"
+        )),
+    }
+}
+
+fn read_json<T>(path: &Path) -> Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let text = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    serde_json::from_str(&text).with_context(|| format!("parse JSON {}", path.display()))
+}
+
+fn default_repo_path() -> PathBuf {
+    PathBuf::from(".")
+}
+
+fn default_head() -> String {
+    "HEAD".to_string()
+}
+
+fn default_timeout_seconds() -> u64 {
+    120
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mcp_tools_are_agent_intents_not_cli_mirrors() {
+        let tools = tool_defs();
+        let names = tools
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names.len(), 3);
+        assert!(names.contains(&"review_git_range"));
+        assert!(names.contains(&"render_review_artifact"));
+        assert!(names.contains(&"validate_review_artifact"));
+    }
+
+    #[test]
+    fn verdict_blocking_matches_agent_gate_contract() {
+        assert!(!verdict_blocks(&Verdict::Warn, Some("fail")).unwrap());
+        assert!(verdict_blocks(&Verdict::Warn, Some("warn")).unwrap());
+        assert!(verdict_blocks(&Verdict::Fail, Some("fail")).unwrap());
+        assert!(!verdict_blocks(&Verdict::Skip, Some("warn")).unwrap());
+    }
+}

--- a/src/post.rs
+++ b/src/post.rs
@@ -12,6 +12,7 @@ use crate::render::render_markdown;
 use crate::schema::{
     AnchorKind, Comment, CommentKind, LifecycleState, ReviewArtifact, ReviewRequest, Verdict,
 };
+use crate::secrets::redact_secret;
 
 pub const POST_PLAN_SCHEMA: &str = "cerberus.post_plan.v1";
 pub const POST_RESULT_SCHEMA: &str = "cerberus.post_result.v1";
@@ -467,13 +468,20 @@ struct InlineCommentBody {
 #[derive(Debug, Clone)]
 pub struct GithubClient {
     binary: String,
+    token: Option<String>,
 }
 
 impl GithubClient {
     pub fn new(binary: impl Into<String>) -> Self {
         Self {
             binary: binary.into(),
+            token: None,
         }
+    }
+
+    pub fn with_token(mut self, token: impl Into<String>) -> Self {
+        self.token = Some(token.into());
+        self
     }
 
     pub fn binary(&self) -> &str {
@@ -594,6 +602,13 @@ impl GithubClient {
     fn api_raw(&self, method: &str, path: &str, body: Option<Value>) -> Result<String> {
         let mut command = Command::new(&self.binary);
         command.arg("api").arg("--method").arg(method).arg(path);
+        if let Some(token) = &self.token {
+            command
+                .env("GH_TOKEN", token)
+                .env_remove("GITHUB_TOKEN")
+                .env_remove("GH_ENTERPRISE_TOKEN")
+                .env_remove("GITHUB_ENTERPRISE_TOKEN");
+        }
         if body.is_some() {
             command.arg("--input").arg("-");
             command.stdin(Stdio::piped());
@@ -613,10 +628,12 @@ impl GithubClient {
             .wait_with_output()
             .with_context(|| format!("wait for gh api --method {method} {path}"))?;
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = redact_secret(&stderr, self.token.as_deref());
             bail!(
                 "{} api --method {method} {path} failed: {}",
                 self.binary,
-                String::from_utf8_lossy(&output.stderr)
+                stderr
             );
         }
         Ok(String::from_utf8_lossy(&output.stdout).to_string())

--- a/src/request.rs
+++ b/src/request.rs
@@ -12,6 +12,7 @@ use crate::schema::{
     RuntimeTarget, Source, SourceKind, WorkspaceContext, WorkspaceKind, WorkspaceRef,
     REVIEW_REQUEST_SCHEMA,
 };
+use crate::secrets::redact_secret;
 
 #[derive(Debug, Clone)]
 pub struct RequestOptions {
@@ -40,6 +41,7 @@ pub struct PullRequestOptions {
     pub number: u64,
     pub repo: Option<String>,
     pub gh_binary: String,
+    pub gh_token: Option<String>,
     pub head_workspace: Option<PathBuf>,
     pub base_workspace: Option<PathBuf>,
     pub common: RequestOptions,
@@ -171,11 +173,13 @@ pub fn build_pull_request(options: &PullRequestOptions) -> Result<ReviewRequest>
         options.number,
         options.repo.as_deref(),
         options.gh_binary.as_str(),
+        options.gh_token.as_deref(),
     )?;
     let diff = gh_pr_diff(
         options.number,
         options.repo.as_deref(),
         options.gh_binary.as_str(),
+        options.gh_token.as_deref(),
     )?;
     if diff.trim().is_empty() {
         bail!("pull request #{} produced an empty diff", options.number);
@@ -276,8 +280,9 @@ pub fn fetch_pull_request_head_sha(
     number: u64,
     repo: Option<&str>,
     gh_binary: &str,
+    gh_token: Option<&str>,
 ) -> Result<String> {
-    let pr = gh_pr_view(number, repo, gh_binary)?;
+    let pr = gh_pr_view(number, repo, gh_binary, gh_token)?;
     require_pr_head_sha(number, &pr)
 }
 
@@ -291,17 +296,31 @@ fn policy_from_options(options: &RequestOptions) -> ReviewPolicy {
 }
 
 fn run(cwd: &Path, program: &str, args: &[&str]) -> Result<String> {
-    let output = Command::new(program)
-        .args(args)
-        .current_dir(cwd)
+    run_with_env(cwd, program, args, None)
+}
+
+fn run_with_env(
+    cwd: &Path,
+    program: &str,
+    args: &[&str],
+    gh_token: Option<&str>,
+) -> Result<String> {
+    let mut command = Command::new(program);
+    command.args(args).current_dir(cwd);
+    if let Some(token) = gh_token {
+        command
+            .env("GH_TOKEN", token)
+            .env_remove("GITHUB_TOKEN")
+            .env_remove("GH_ENTERPRISE_TOKEN")
+            .env_remove("GITHUB_ENTERPRISE_TOKEN");
+    }
+    let output = command
         .output()
         .with_context(|| format!("run {program} {}", args.join(" ")))?;
     if !output.status.success() {
-        bail!(
-            "{program} {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = redact_secret(&stderr, gh_token);
+        bail!("{program} {} failed: {}", args.join(" "), stderr);
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
@@ -482,24 +501,34 @@ fn short_sha(value: &str) -> String {
     value.chars().take(12).collect()
 }
 
-fn gh_pr_view(number: u64, repo: Option<&str>, gh_binary: &str) -> Result<GhPullRequest> {
+fn gh_pr_view(
+    number: u64,
+    repo: Option<&str>,
+    gh_binary: &str,
+    gh_token: Option<&str>,
+) -> Result<GhPullRequest> {
     let number = number.to_string();
     let fields = "number,title,body,url,baseRefName,baseRefOid,headRefName,headRefOid,files";
     let mut args = vec!["pr", "view", number.as_str(), "--json", fields];
     if let Some(repo) = repo {
         args.extend(["-R", repo]);
     }
-    let output = run(Path::new("."), gh_binary, &args)?;
+    let output = run_with_env(Path::new("."), gh_binary, &args, gh_token)?;
     serde_json::from_str(&output).context("parse gh pr view JSON")
 }
 
-fn gh_pr_diff(number: u64, repo: Option<&str>, gh_binary: &str) -> Result<String> {
+fn gh_pr_diff(
+    number: u64,
+    repo: Option<&str>,
+    gh_binary: &str,
+    gh_token: Option<&str>,
+) -> Result<String> {
     let number = number.to_string();
     let mut args = vec!["pr", "diff", number.as_str(), "--patch", "--color", "never"];
     if let Some(repo) = repo {
         args.extend(["-R", repo]);
     }
-    run(Path::new("."), gh_binary, &args)
+    run_with_env(Path::new("."), gh_binary, &args, gh_token)
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,0 +1,28 @@
+pub(crate) fn redact_secret(text: &str, secret: Option<&str>) -> String {
+    let Some(secret) = secret else {
+        return text.to_string();
+    };
+    if secret.is_empty() {
+        return text.to_string();
+    }
+    text.replace(secret, "<redacted>")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_exact_secret_value() {
+        assert_eq!(
+            redact_secret("token=abc123\n", Some("abc123")),
+            "token=<redacted>\n"
+        );
+    }
+
+    #[test]
+    fn leaves_text_without_secret_unchanged() {
+        assert_eq!(redact_secret("ok", None), "ok");
+        assert_eq!(redact_secret("ok", Some("")), "ok");
+    }
+}


### PR DESCRIPTION
## Summary
- require explicit caller-injected GitHub token sources for `review-pr --post`, pass them through PR acquisition/stale-head checks/posting, and redact injected token values from failed `gh` stderr
- add a stdio MCP server with intent-shaped tools over the existing request/kernel/validation/rendering path
- ship the `cerberus-review` skill, factory plan artifact, and Landmark release workflow/config

## Verification
- `./scripts/verify.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `ruby -e 'require "json"; JSON.parse(File.read(".releaserc.json"))'`
- inspected redacted token-failure evidence under `target/cerberus/review-pr-post-*-token-leak.stderr`

## Critic
Fresh read-only critic found token-redaction, manual release bypass, and live-post-token gaps; all three were fixed and `./scripts/verify.sh` reran green.

Agent: Codex
Agent-Surface: Codex CLI
Agent-Task: factory-cerberus-lane