### PR TITLE
Emit Crucible producer manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ cerberus review --request fixtures/requests/diff-only.json \
   --out target/cerberus/artifact.json \
   --markdown target/cerberus/review.md \
   --execution-plan target/cerberus/execution_plan.json \
-  --receipt-bundle target/cerberus/receipts/fixture.json
+  --receipt-bundle target/cerberus/receipts/fixture.json \
+  --producer-manifest target/cerberus/producer-manifest.json
 
 cerberus render --artifact target/cerberus/artifact.json \
   --markdown target/cerberus/review-rendered.md
@@ -154,6 +155,32 @@ latency, capability tier, artifact/transcript URIs, and validation outcome
 without embedding prompt files, request files, secret names, or transcript
 excerpts. Daedalus or another lab can score those bundles without Cerberus
 owning model or harness evaluation.
+
+## Crucible producer handoff
+
+Crucible owns grading, intervals, adjudication, and Harbor export. Cerberus's
+producer side is the two-step request/review path:
+
+```sh
+cerberus request git-range --repo-path /path/to/workspace \
+  --base <base-sha> --head <head-sha> \
+  --out target/cerberus/crucible-producer/request.json
+
+cerberus review --request target/cerberus/crucible-producer/request.json \
+  --harness opencode \
+  --out target/cerberus/crucible-producer/artifact.json \
+  --execution-plan target/cerberus/crucible-producer/execution_plan.json \
+  --transcript target/cerberus/crucible-producer/transcript.txt \
+  --receipt-bundle target/cerberus/crucible-producer/receipt-bundle.json \
+  --producer-manifest target/cerberus/crucible-producer/producer-manifest.json
+```
+
+`producer-manifest.json` is metadata only: it points Crucible at the validated
+`ReviewArtifact.v1` `findings` array, records the redacted receipt bundle digest
+and validation state, and explicitly says the scorer owner is `crucible` with no
+score included. The repo gate writes the same packet under
+`target/cerberus/crucible-producer/` and checks that the artifact is gradeable
+by Crucible's adapter contract.
 
 GitHub Checks writes require a token with Checks write access, usually a GitHub
 App or fine-grained token. Classic user tokens commonly cannot create check

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -11,6 +11,7 @@ cargo run --locked -- review --help > target/cerberus-review-help.txt
 grep -q '\[default: opencode\]' target/cerberus-review-help.txt
 grep -q 'possible values: opencode, omp, fixture' target/cerberus-review-help.txt
 grep -q -- '--receipt-bundle' target/cerberus-review-help.txt
+grep -q -- '--producer-manifest' target/cerberus-review-help.txt
 cargo run --locked -- request --help > target/cerberus-request-help.txt
 grep -q 'git-range' target/cerberus-request-help.txt
 grep -Eq '^  pr([[:space:]]|$)' target/cerberus-request-help.txt
@@ -219,6 +220,83 @@ GH_TOKEN=should-not-leak cargo run --locked -- review \
   --execution-plan target/cerberus/git-range-opencode-execution_plan.json \
   --transcript target/cerberus/git-range-opencode-transcript.txt \
   --receipt-bundle target/cerberus/receipts/git-range-opencode.json
+
+producer_dir="target/cerberus/crucible-producer"
+mkdir -p "$producer_dir"
+cargo run --locked -- request git-range \
+  --repo-path "$tmp_repo" \
+  --base "$base_sha" \
+  --head "$head_sha" \
+  --instruction "Produce a Crucible-gradeable Cerberus packet." \
+  --out "$producer_dir/request.json"
+
+GH_TOKEN=should-not-leak cargo run --locked -- review \
+  --request "$producer_dir/request.json" \
+  --harness opencode \
+  --opencode-binary "$PWD/fixtures/bin/fake-opencode" \
+  --out "$producer_dir/artifact.json" \
+  --execution-plan "$producer_dir/execution_plan.json" \
+  --transcript "$producer_dir/transcript.txt" \
+  --receipt-bundle "$producer_dir/receipt-bundle.json" \
+  --producer-manifest "$producer_dir/producer-manifest.json"
+
+if cargo run --locked -- review \
+  --request "$producer_dir/request.json" \
+  --harness fixture \
+  --fixture-output fixtures/harness/valid-review.txt \
+  --out "$producer_dir/no-receipt-artifact.json" \
+  --producer-manifest "$producer_dir/stale-producer-manifest.json" \
+  > "$producer_dir/no-receipt.stdout" \
+  2> "$producer_dir/no-receipt.stderr"; then
+  echo "expected --producer-manifest without --receipt-bundle to fail" >&2
+  exit 1
+fi
+grep -q -- '--producer-manifest requires --receipt-bundle' "$producer_dir/no-receipt.stderr"
+test ! -e "$producer_dir/stale-producer-manifest.json"
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+root = Path("target/cerberus/crucible-producer")
+artifact = json.loads((root / "artifact.json").read_text())
+receipt = json.loads((root / "receipt-bundle.json").read_text())
+manifest = json.loads((root / "producer-manifest.json").read_text())
+
+assert artifact["schema_version"] == "cerberus.review_artifact.v1"
+assert isinstance(artifact["findings"], list)
+for finding in artifact["findings"]:
+    assert finding["id"].strip()
+    assert finding["category"].strip()
+    assert 0.0 <= finding["confidence"] <= 1.0
+    assert finding["title"].strip() or finding["description"].strip()
+
+assert receipt["schema_version"] == "cerberus.review_receipt_bundle.v1"
+assert receipt["validation"]["status"] == "passed"
+assert receipt["validation"]["trusted_for_posting"] is True
+assert receipt["artifact_uri"] == str(root / "artifact.json")
+
+assert manifest["schema_version"] == "cerberus.crucible_producer_manifest.v1"
+assert manifest["consumer"] == "crucible"
+assert manifest["artifact"]["schema_version"] == artifact["schema_version"]
+assert manifest["artifact"]["artifact_digest"] == receipt["artifact_digest"]
+assert manifest["artifact"]["finding_count"] == len(artifact["findings"])
+assert manifest["receipt_bundle"]["schema_version"] == receipt["schema_version"]
+assert manifest["grader_input"]["format"] == "cerberus.review_artifact.v1"
+assert manifest["grader_input"]["artifact_uri"] == str(root / "artifact.json")
+assert manifest["grader_input"]["findings_path"] == "findings"
+assert manifest["grader_input"]["finding_id_path"] == "findings[].id"
+assert manifest["validation"]["status"] == "passed"
+assert manifest["validation"]["trusted_for_grading"] is True
+assert manifest["boundary"]["scorer_owner"] == "crucible"
+assert manifest["boundary"]["includes_score"] is False
+
+for path in [root / "receipt-bundle.json", root / "producer-manifest.json"]:
+    text = path.read_text()
+    for forbidden in ["GH_TOKEN", "should-not-leak", "master-prompt.md", "review-request.json"]:
+        if forbidden in text:
+            raise SystemExit(f"{path} leaked {forbidden}")
+PY
 
 test "$(git -C "$tmp_repo" rev-parse HEAD)" = "$head_sha"
 

--- a/spec.md
+++ b/spec.md
@@ -267,6 +267,7 @@ cerberus request pr --number <n> --out <request.json>
 
 cerberus review --request <request.json> --out <artifact.json> \
   [--markdown <review.md>] [--receipt-bundle <bundle.json>] \
+  [--producer-manifest <manifest.json>] \
   [--harness opencode|omp|fixture] [--fail-on none|warn|fail]
 
 cerberus review-diff --base <ref> [--head <ref>] [--repo-path <dir>] \
@@ -303,6 +304,14 @@ artifact. Without `--fail-on` (default `none`) the exit status is `0` on a valid
 artifact regardless of verdict and `2` on error, so existing callers are
 unaffected. A blocking verdict (exit `1`) is a *successful* review that found
 issues — distinct from a tool error (exit `2`).
+
+`review --producer-manifest <manifest.json>` writes a
+`cerberus.crucible_producer_manifest.v1` sidecar for upstream eval consumers.
+It requires `--receipt-bundle` so the packet always includes redacted receipt
+metadata. The manifest points Crucible at the validated `ReviewArtifact.v1`
+`findings` array, records request/artifact/receipt digests and validation state,
+and explicitly carries no score; Crucible owns grading, intervals, adjudication,
+and Harbor export.
 
 `review-pr` is a convenience orchestrator over the existing acquisition and
 review boundaries. It must write the same request, execution plan, transcript,
@@ -370,6 +379,7 @@ Evidence packet:
 - `target/cerberus/review.md`
 - `target/cerberus/execution_plan.json`
 - `target/cerberus/receipts/*.json`
+- `target/cerberus/crucible-producer/producer-manifest.json`
 - `target/cerberus/review-pr/post-plan.json`
 - `target/cerberus/review-pr/post-result.json`
 - `target/cerberus/context-tiers/*`
@@ -392,6 +402,8 @@ MVP is complete when:
   and leave transcript evidence;
 - review and review-pr can emit redacted `ReviewReceiptBundle.v1` handoff
   bundles for upstream scoring;
+- review can emit a Crucible producer manifest sidecar that identifies the
+  gradeable artifact/receipt packet without embedding a scorer;
 - Markdown rendering works from stored artifacts;
 - `review-pr` can dry-run and post through fake GitHub fixtures without
   duplicate comments, without inline comments outside changed lines, and without

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod harness;
 pub mod kernel;
 pub mod mcp;
 pub mod post;
+pub mod producer;
 pub mod prompt;
 pub mod receipt;
 pub mod render;
@@ -18,6 +19,10 @@ pub use harness::{
 };
 pub use kernel::{ReviewKernel, ReviewRun, ReviewSubstrate, RunPolicy};
 pub use post::{build_post_plan, GithubClient, PostPlan, SummaryTarget};
+pub use producer::{
+    build_crucible_producer_manifest, CrucibleProducerManifest, CrucibleProducerManifestInput,
+    CRUCIBLE_PRODUCER_MANIFEST_SCHEMA,
+};
 pub use receipt::{
     build_review_receipt_bundle, ReceiptBundleInput, ReceiptValidation, ReceiptValidationStatus,
     ReviewReceiptBundle, REVIEW_RECEIPT_BUNDLE_SCHEMA,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use cerberus::harness::{
 };
 use cerberus::kernel::{ReviewKernel, ReviewRun, ReviewSubstrate, RunPolicy};
 use cerberus::post::{build_post_plan, trusted_lifecycle, GithubClient, SummaryTarget};
+use cerberus::producer::{build_crucible_producer_manifest, CrucibleProducerManifestInput};
 use cerberus::receipt::{build_review_receipt_bundle, ReceiptBundleInput};
 use cerberus::request::{
     build_git_range_request, build_pull_request, fetch_pull_request_head_sha,
@@ -185,6 +186,9 @@ struct ReviewArgs {
     transcript: Option<PathBuf>,
     #[arg(long)]
     receipt_bundle: Option<PathBuf>,
+    /// Write a Crucible producer manifest sidecar. Requires --receipt-bundle and contains no scores.
+    #[arg(long)]
+    producer_manifest: Option<PathBuf>,
     #[arg(long, value_enum, default_value_t = FailOn::None)]
     fail_on: FailOn,
 }
@@ -425,10 +429,19 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
         execution_plan,
         transcript,
         receipt_bundle,
+        producer_manifest,
         fail_on,
     } = args;
+    if producer_manifest.is_some() && receipt_bundle.is_none() {
+        return Err(anyhow!(
+            "review --producer-manifest requires --receipt-bundle so the packet includes redacted receipt metadata"
+        ));
+    }
     if let Some(receipt_bundle) = &receipt_bundle {
         remove_file_if_exists(receipt_bundle)?;
+    }
+    if let Some(producer_manifest) = &producer_manifest {
+        remove_file_if_exists(producer_manifest)?;
     }
     let request = read_json::<ReviewRequest>(&request)?;
     validate_request(&request)?;
@@ -455,8 +468,8 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
     }
     write_json(&out, &run.artifact)?;
     let validation_result = validate_artifact_for_request(&run.artifact, &request);
-    if let Some(receipt_bundle) = &receipt_bundle {
-        write_review_receipt_bundle(
+    let receipt_bundle_value = if let Some(receipt_bundle) = &receipt_bundle {
+        Some(write_review_receipt_bundle(
             receipt_bundle,
             &request,
             &run,
@@ -464,9 +477,27 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
             transcript_path.as_deref(),
             Some(&plan_path),
             validation_result.is_err(),
-        )?;
-    }
+        )?)
+    } else {
+        None
+    };
     validation_result?;
+
+    if let Some(producer_manifest) = &producer_manifest {
+        let receipt_bundle_path = receipt_bundle
+            .as_ref()
+            .expect("--producer-manifest requires --receipt-bundle");
+        let receipt_bundle_value = receipt_bundle_value
+            .as_ref()
+            .expect("receipt bundle was written before producer manifest");
+        let manifest = build_crucible_producer_manifest(CrucibleProducerManifestInput {
+            request: &request,
+            artifact: &run.artifact,
+            receipt_bundle: receipt_bundle_value,
+            receipt_bundle_uri: receipt_bundle_path.display().to_string(),
+        })?;
+        write_json(producer_manifest, &manifest)?;
+    }
 
     if let Some(markdown) = markdown {
         write_text(&markdown, &render_markdown(&run.artifact))?;
@@ -753,7 +784,7 @@ fn write_review_receipt_bundle(
     transcript_path: Option<&Path>,
     execution_plan_path: Option<&Path>,
     validation_failed: bool,
-) -> Result<()> {
+) -> Result<cerberus::ReviewReceiptBundle> {
     let bundle = build_review_receipt_bundle(ReceiptBundleInput {
         request,
         artifact: &run.artifact,
@@ -765,7 +796,8 @@ fn write_review_receipt_bundle(
         execution_plan_uri: execution_plan_path.map(|path| path.display().to_string()),
         validation_failed,
     })?;
-    write_json(path, &bundle)
+    write_json(path, &bundle)?;
+    Ok(bundle)
 }
 
 fn read_json<T>(path: &Path) -> Result<T>

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1,0 +1,225 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::digest::{request_digest, sha256_digest};
+use crate::receipt::{ReceiptValidationStatus, ReviewReceiptBundle};
+use crate::schema::{ContextCapabilities, LifecycleState, ReviewArtifact, ReviewRequest};
+
+pub const CRUCIBLE_PRODUCER_MANIFEST_SCHEMA: &str = "cerberus.crucible_producer_manifest.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CrucibleProducerManifest {
+    pub schema_version: String,
+    pub consumer: String,
+    pub request: ProducerRequestRef,
+    pub artifact: ProducerArtifactRef,
+    pub receipt_bundle: ProducerReceiptBundleRef,
+    pub grader_input: ProducerGraderInput,
+    pub validation: ProducerValidation,
+    pub boundary: ProducerBoundary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProducerRequestRef {
+    pub request_id: String,
+    pub request_digest: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProducerArtifactRef {
+    pub artifact_id: String,
+    pub artifact_uri: String,
+    pub artifact_digest: String,
+    pub schema_version: String,
+    pub finding_count: usize,
+    pub comment_count: usize,
+    pub capability_tier: String,
+    pub context_capabilities: ContextCapabilities,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProducerReceiptBundleRef {
+    pub schema_version: String,
+    pub receipt_bundle_uri: String,
+    pub receipt_bundle_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcript_uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_plan_uri: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProducerGraderInput {
+    pub format: String,
+    pub artifact_uri: String,
+    pub findings_path: String,
+    pub finding_id_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProducerValidation {
+    pub status: ReceiptValidationStatus,
+    pub trusted_for_grading: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProducerBoundary {
+    pub scorer_owner: String,
+    pub includes_score: bool,
+    pub note: String,
+}
+
+pub struct CrucibleProducerManifestInput<'a> {
+    pub request: &'a ReviewRequest,
+    pub artifact: &'a ReviewArtifact,
+    pub receipt_bundle: &'a ReviewReceiptBundle,
+    pub receipt_bundle_uri: String,
+}
+
+pub fn build_crucible_producer_manifest(
+    input: CrucibleProducerManifestInput<'_>,
+) -> Result<CrucibleProducerManifest> {
+    let request_digest = request_digest(input.request)?;
+    let receipt_bundle_digest = stable_json_digest(input.receipt_bundle)?;
+    let trusted_for_grading = input.receipt_bundle.validation.status
+        == ReceiptValidationStatus::Passed
+        && matches!(
+            input.artifact.lifecycle_state,
+            LifecycleState::Completed | LifecycleState::CompletedDegraded
+        );
+    Ok(CrucibleProducerManifest {
+        schema_version: CRUCIBLE_PRODUCER_MANIFEST_SCHEMA.to_string(),
+        consumer: "crucible".to_string(),
+        request: ProducerRequestRef {
+            request_id: input.request.request_id.clone(),
+            request_digest,
+        },
+        artifact: ProducerArtifactRef {
+            artifact_id: input.artifact.artifact_id.clone(),
+            artifact_uri: input.receipt_bundle.artifact_uri.clone(),
+            artifact_digest: input.receipt_bundle.artifact_digest.clone(),
+            schema_version: input.artifact.schema_version.clone(),
+            finding_count: input.artifact.findings.len(),
+            comment_count: input.artifact.comments.len(),
+            capability_tier: input.receipt_bundle.capability_tier.clone(),
+            context_capabilities: input.receipt_bundle.context_capabilities.clone(),
+        },
+        receipt_bundle: ProducerReceiptBundleRef {
+            schema_version: input.receipt_bundle.schema_version.clone(),
+            receipt_bundle_uri: input.receipt_bundle_uri,
+            receipt_bundle_digest,
+            transcript_uri: input.receipt_bundle.transcript_uri.clone(),
+            execution_plan_uri: input.receipt_bundle.execution_plan_uri.clone(),
+        },
+        grader_input: ProducerGraderInput {
+            format: "cerberus.review_artifact.v1".to_string(),
+            artifact_uri: input.receipt_bundle.artifact_uri.clone(),
+            findings_path: "findings".to_string(),
+            finding_id_path: "findings[].id".to_string(),
+        },
+        validation: ProducerValidation {
+            status: input.receipt_bundle.validation.status.clone(),
+            trusted_for_grading,
+        },
+        boundary: ProducerBoundary {
+            scorer_owner: "crucible".to_string(),
+            includes_score: false,
+            note: "Cerberus produced the validated review artifact and redacted receipts only; Crucible owns grading, intervals, adjudication, and export.".to_string(),
+        },
+    })
+}
+
+fn stable_json_digest(value: &impl Serialize) -> Result<String> {
+    let mut serialized = serde_json::to_string_pretty(value)?;
+    serialized.push('\n');
+    Ok(sha256_digest(serialized.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::receipt::{build_review_receipt_bundle, ReceiptBundleInput};
+    use crate::schema::{ReviewTelemetry, REVIEW_ARTIFACT_SCHEMA};
+
+    #[test]
+    fn manifest_points_crucible_at_the_artifact_findings_array() {
+        let request = request();
+        let artifact = artifact();
+        let telemetry = ReviewTelemetry::default();
+        let bundle = build_review_receipt_bundle(ReceiptBundleInput {
+            request: &request,
+            artifact: &artifact,
+            harness: "fixture",
+            telemetry: &telemetry,
+            transcript: "elapsed_ms: 9",
+            artifact_uri: "target/cerberus/crucible-producer/artifact.json".to_string(),
+            transcript_uri: Some("target/cerberus/crucible-producer/transcript.txt".to_string()),
+            execution_plan_uri: Some(
+                "target/cerberus/crucible-producer/execution_plan.json".to_string(),
+            ),
+            validation_failed: false,
+        })
+        .unwrap();
+
+        let manifest = build_crucible_producer_manifest(CrucibleProducerManifestInput {
+            request: &request,
+            artifact: &artifact,
+            receipt_bundle: &bundle,
+            receipt_bundle_uri: "target/cerberus/crucible-producer/receipt-bundle.json".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(manifest.schema_version, CRUCIBLE_PRODUCER_MANIFEST_SCHEMA);
+        assert_eq!(manifest.consumer, "crucible");
+        assert_eq!(manifest.artifact.schema_version, REVIEW_ARTIFACT_SCHEMA);
+        assert_eq!(manifest.artifact.finding_count, 1);
+        assert_eq!(manifest.grader_input.format, REVIEW_ARTIFACT_SCHEMA);
+        assert_eq!(manifest.grader_input.findings_path, "findings");
+        assert_eq!(manifest.grader_input.finding_id_path, "findings[].id");
+        assert!(manifest.validation.trusted_for_grading);
+        assert_eq!(manifest.boundary.scorer_owner, "crucible");
+        assert!(!manifest.boundary.includes_score);
+    }
+
+    #[test]
+    fn manifest_does_not_mark_failed_validation_as_gradeable() {
+        let request = request();
+        let artifact = artifact();
+        let telemetry = ReviewTelemetry::default();
+        let bundle = build_review_receipt_bundle(ReceiptBundleInput {
+            request: &request,
+            artifact: &artifact,
+            harness: "fixture",
+            telemetry: &telemetry,
+            transcript: "elapsed_ms: 9",
+            artifact_uri: "target/cerberus/crucible-producer/artifact.json".to_string(),
+            transcript_uri: None,
+            execution_plan_uri: None,
+            validation_failed: true,
+        })
+        .unwrap();
+
+        let manifest = build_crucible_producer_manifest(CrucibleProducerManifestInput {
+            request: &request,
+            artifact: &artifact,
+            receipt_bundle: &bundle,
+            receipt_bundle_uri: "target/cerberus/crucible-producer/receipt-bundle.json".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(manifest.validation.status, ReceiptValidationStatus::Failed);
+        assert!(!manifest.validation.trusted_for_grading);
+    }
+
+    fn request() -> ReviewRequest {
+        serde_json::from_str(include_str!("../fixtures/requests/diff-only.json")).unwrap()
+    }
+
+    fn artifact() -> ReviewArtifact {
+        let raw = include_str!("../fixtures/harness/valid-review.txt").replace(
+            "{{context_capabilities}}",
+            r#"{"diff":true,"repo_head":false,"repo_base":false,"local_runtime":false,"remote_runtime":false,"external_research":"forbid"}"#,
+        );
+        serde_json::from_str(&raw).unwrap()
+    }
+}


### PR DESCRIPTION
## Summary

Adds the Cerberus producer-side handoff for Crucible's upcoming `pr-review-key-recall-v0` eval without moving grading into Cerberus:

- adds `cerberus.crucible_producer_manifest.v1`, a metadata-only sidecar that points Crucible at the validated `ReviewArtifact.v1` `findings` array;
- adds `cerberus review --producer-manifest <path>`, gated on `--receipt-bundle`, and writes the manifest only after artifact validation succeeds;
- extends `./scripts/verify.sh` to build a throwaway git range, run `request git-range` + `review --receipt-bundle --producer-manifest`, assert gradeable finding fields, redaction, and no-score boundary;
- documents the Crucible producer handoff in `README.md` and `spec.md`.

Cerberus remains producer-only. Crucible owns grading, intervals, adjudication, and Harbor export.

## Evidence

Producer packet emitted under:

- `target/cerberus/crucible-producer/request.json`
- `target/cerberus/crucible-producer/artifact.json`
- `target/cerberus/crucible-producer/receipt-bundle.json`
- `target/cerberus/crucible-producer/producer-manifest.json`
- `target/cerberus/crucible-producer/transcript.txt`
- `target/cerberus/crucible-producer/execution_plan.json`

Manifest proof from the local run:

- `schema_version`: `cerberus.crucible_producer_manifest.v1`
- `validation.trusted_for_grading`: `true`
- `grader_input.findings_path`: `findings`
- `boundary.scorer_owner`: `crucible`
- `boundary.includes_score`: `false`

Crucible consumer smoke:

`cargo run -p crucible -- adapt /Users/phaedrus/Development/cerberus/target/cerberus/crucible-producer/artifact.json --json`

Result: `crucible.adapt_report.v1`, `count: 1`, source id `finding-001` mapped to `src/ratio.rs:3`.

## Verification

- `./scripts/verify.sh`
- Fresh artifact-only critic: `BLOCKING: no`

Residual risk: redaction assertions are known-token negative checks, not a complete structural proof against every future schema expansion.

Agent: Codex
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: cerberus-crucible-producer-packet