### PR TITLE
fix(review): allow env override for request files

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ cerberus request git-range --repo-path /path/to/workspace \
 
 cerberus review --request target/cerberus/crucible-producer/request.json \
   --harness opencode \
+  --model openrouter/z-ai/glm-5.2 \
+  --allow-env OPENROUTER_API_KEY \
   --out target/cerberus/crucible-producer/artifact.json \
   --execution-plan target/cerberus/crucible-producer/execution_plan.json \
   --transcript target/cerberus/crucible-producer/transcript.txt \

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,8 @@ struct ReviewArgs {
     /// Write a Crucible producer manifest sidecar. Requires --receipt-bundle and contains no scores.
     #[arg(long)]
     producer_manifest: Option<PathBuf>,
+    #[arg(long = "allow-env")]
+    allowed_env: Vec<String>,
     #[arg(long, value_enum, default_value_t = FailOn::None)]
     fail_on: FailOn,
 }
@@ -430,6 +432,7 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
         transcript,
         receipt_bundle,
         producer_manifest,
+        allowed_env,
         fail_on,
     } = args;
     if producer_manifest.is_some() && receipt_bundle.is_none() {
@@ -443,7 +446,8 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
     if let Some(producer_manifest) = &producer_manifest {
         remove_file_if_exists(producer_manifest)?;
     }
-    let request = read_json::<ReviewRequest>(&request)?;
+    let mut request = read_json::<ReviewRequest>(&request)?;
+    extend_review_allowed_env(&mut request, allowed_env);
     validate_request(&request)?;
     let cwd = cwd.unwrap_or(std::env::current_dir().context("read current directory")?);
     let transcript_path = transcript.or_else(|| {
@@ -454,7 +458,9 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
     let timeout = timeout_seconds
         .map(Duration::from_secs)
         .unwrap_or_else(|| Duration::from_millis(request.policy.timeout_ms));
-    let kernel = ReviewKernel::new(review_substrate(substrate)?);
+    let substrate = review_substrate(substrate)?;
+    require_child_env_for_substrate(&request, &substrate)?;
+    let kernel = ReviewKernel::new(substrate);
     let run_policy = RunPolicy {
         cwd,
         timeout,
@@ -505,6 +511,45 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
     Ok(verdict_exit_code(&run.artifact.verdict, fail_on))
 }
 
+fn extend_review_allowed_env(request: &mut ReviewRequest, allowed_env: Vec<String>) {
+    for key in allowed_env {
+        if !request
+            .policy
+            .allowed_env
+            .iter()
+            .any(|existing| existing == &key)
+        {
+            request.policy.allowed_env.push(key);
+        }
+    }
+}
+
+fn require_child_env_for_substrate(
+    request: &ReviewRequest,
+    substrate: &ReviewSubstrate,
+) -> Result<()> {
+    let ReviewSubstrate::Opencode(config) = substrate else {
+        return Ok(());
+    };
+    let Some(model) = config.model.as_deref() else {
+        return Ok(());
+    };
+    if config.attach.is_some() || !model.starts_with("openrouter/") {
+        return Ok(());
+    }
+    if request
+        .policy
+        .allowed_env
+        .iter()
+        .any(|key| key == "OPENROUTER_API_KEY")
+    {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "opencode OpenRouter model {model:?} requires OPENROUTER_API_KEY in Cerberus's scrubbed child environment; pass --allow-env OPENROUTER_API_KEY or include it in request.policy.allowed_env"
+    ))
+}
+
 fn review_diff(args: ReviewDiffArgs) -> Result<ExitCode> {
     let request = build_git_range_request(&GitRangeRequestOptions {
         repo_path: args.repo_path,
@@ -525,7 +570,9 @@ fn review_diff(args: ReviewDiffArgs) -> Result<ExitCode> {
     })?;
     validate_request(&request)?;
     let cwd = std::env::current_dir().context("read current directory")?;
-    let kernel = ReviewKernel::new(review_substrate(args.substrate)?);
+    let substrate = review_substrate(args.substrate)?;
+    require_child_env_for_substrate(&request, &substrate)?;
+    let kernel = ReviewKernel::new(substrate);
     let run_policy = RunPolicy {
         cwd,
         timeout: Duration::from_millis(request.policy.timeout_ms),
@@ -609,7 +656,9 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     let cwd = args
         .cwd
         .unwrap_or(std::env::current_dir().context("read current directory")?);
-    let kernel = ReviewKernel::new(review_substrate(args.substrate)?);
+    let substrate = review_substrate(args.substrate)?;
+    require_child_env_for_substrate(&request, &substrate)?;
+    let kernel = ReviewKernel::new(substrate);
     let run_policy = RunPolicy {
         cwd,
         timeout: Duration::from_millis(request.policy.timeout_ms),
@@ -865,6 +914,66 @@ mod tests {
         assert!(!is_blocking(&Verdict::Pass, FailOn::Warn));
         // SKIP means "could not review", not "blocking".
         assert!(!is_blocking(&Verdict::Skip, FailOn::Warn));
+    }
+
+    #[test]
+    fn review_allow_env_override_extends_request_policy() {
+        let request_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/requests/diff-only.json");
+        let mut request: ReviewRequest = read_json(&request_path).expect("fixture request loads");
+
+        extend_review_allowed_env(
+            &mut request,
+            vec![
+                "OPENROUTER_API_KEY".to_string(),
+                "OPENROUTER_API_KEY".to_string(),
+                "CERBERUS_RUNTIME_FLAG".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            request.policy.allowed_env,
+            vec![
+                "OPENROUTER_API_KEY".to_string(),
+                "CERBERUS_RUNTIME_FLAG".to_string()
+            ],
+            "review --allow-env should augment a request file without duplicating names"
+        );
+    }
+
+    #[test]
+    fn openrouter_model_without_allowed_key_is_a_clear_preflight_error() {
+        let request_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/requests/diff-only.json");
+        let request: ReviewRequest = read_json(&request_path).expect("fixture request loads");
+        let substrate = ReviewSubstrate::Opencode(OpenCodeSubstrateConfig {
+            binary: "opencode".to_string(),
+            attach: None,
+            agent: Some("build".to_string()),
+            model: Some("openrouter/z-ai/glm-5.2".to_string()),
+        });
+
+        let err = require_child_env_for_substrate(&request, &substrate).unwrap_err();
+        assert!(
+            err.to_string().contains("--allow-env OPENROUTER_API_KEY"),
+            "error should name the concrete fix: {err}"
+        );
+    }
+
+    #[test]
+    fn openrouter_model_with_allowed_key_passes_preflight() {
+        let request_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/requests/diff-only.json");
+        let mut request: ReviewRequest = read_json(&request_path).expect("fixture request loads");
+        extend_review_allowed_env(&mut request, vec!["OPENROUTER_API_KEY".to_string()]);
+        let substrate = ReviewSubstrate::Opencode(OpenCodeSubstrateConfig {
+            binary: "opencode".to_string(),
+            attach: None,
+            agent: Some("build".to_string()),
+            model: Some("openrouter/z-ai/glm-5.2".to_string()),
+        });
+
+        require_child_env_for_substrate(&request, &substrate).unwrap();
     }
 
     // The ExitCode mapping (blocking -> 1, clean -> 0, error -> 2) is proven


### PR DESCRIPTION
## Summary
- Add `--allow-env` to `cerberus review --request` so prebuilt request files can pass provider keys into Cerberus's scrubbed child environment.
- Add an OpenRouter preflight for local opencode runs: if an `openrouter/...` model is selected without `OPENROUTER_API_KEY` in the child allowlist, fail with a clear `--allow-env OPENROUTER_API_KEY` error instead of opencode's misleading `Model not found`.
- Update the Crucible producer handoff README example to use `openrouter/z-ai/glm-5.2` with `--allow-env OPENROUTER_API_KEY`.

## Diagnosis
- OpenRouter live catalog lists `z-ai/glm-5.2`; local `opencode models openrouter --refresh --verbose` lists `openrouter/z-ai/glm-5.2`.
- In Cerberus's scrubbed child environment, `opencode run --model openrouter/z-ai/glm-5.2` succeeds when `OPENROUTER_API_KEY` is present and reproduces `ProviderModelNotFoundError` when the key is absent.
- `cerberus review --request` previously had no CLI way to augment a prebuilt request's `policy.allowed_env`, unlike `review-diff` / request builders.

## Verification
- `cargo test review_allow_env_override_extends_request_policy -- --nocapture`
- `cargo test openrouter_model -- --nocapture`
- `cargo run -- review --help | rg -n 'allow-env|model|request|receipt-bundle'`
- no-key preflight: `cargo run -- review --request fixtures/requests/diff-only.json --harness opencode --model openrouter/z-ai/glm-5.2 --out target/cerberus/glm52-preflight/artifact.json --transcript target/cerberus/glm52-preflight/transcript.txt --timeout-seconds 20` now exits with the clear `--allow-env OPENROUTER_API_KEY` error.
- direct scrubbed opencode proof: `opencode run 'Say OK.' --format json --model openrouter/z-ai/glm-5.2 --agent build` with only `OPENROUTER_API_KEY` passed succeeded.
- `./scripts/verify.sh`

Agent: codex
Agent-Surface: Codex CLI
Agent-Runner: GPT-5 coding agent
Agent-Task: diagnose opencode GLM 5.2 Cerberus producer failure
