### PR TITLE
fix(release): stop protected master changelog push

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,21 +5,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "CHANGELOG.md"
-        ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -3,6 +3,16 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+grep -q 'misty-step/landmark@v1' .github/workflows/release.yml
+if grep -q '"@semantic-release/git"' .releaserc.json; then
+  echo ".releaserc.json must not use @semantic-release/git; protected master rejects release commits" >&2
+  exit 1
+fi
+if grep -q '"@semantic-release/changelog"' .releaserc.json; then
+  echo ".releaserc.json must not generate CHANGELOG.md during release; releases are GitHub-release only" >&2
+  exit 1
+fi
+
 cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --locked


### PR DESCRIPTION
## Summary
- remove semantic-release changelog/git prepare plugins that tried to push generated `CHANGELOG.md` commits back to protected `master`
- keep GitHub release publication through commit analysis, release notes, and `@semantic-release/github`
- add a `verify.sh` guard so the protected-branch write plugins cannot be reintroduced silently

## Verification
- `jq . .releaserc.json`
- `./scripts/verify.sh`

## Factory epic
- Starts `backlog.d/022-fix-broken-basics.md` child 2. The final oracle is the next post-merge Release workflow run going green.