### PR TITLE
fix(review): make GLM artifact path complete by default

### DIFF
--- a/backlog.d/022-fix-broken-basics.md
+++ b/backlog.d/022-fix-broken-basics.md
@@ -31,9 +31,9 @@ evidence to decide whether a review is worth trusting.
 
 ## Children
 
-1. Promote and finish `021-glm52-artifact-timeout.md`: root-cause the live
-   artifact-emission timeout and make the error actionable if the model remains
-   unusable.
+1. **Done:** `021-glm52-artifact-timeout.md` moved to `_done/` after the live
+   default GLM 5.2 path emitted a valid artifact and receipt in one initial
+   attempt.
 2. Fix the release workflow. Live evidence on 2026-07-01: Release run
    `28544516079` still failed because `@semantic-release/git` tried to push
    generated `CHANGELOG.md` back to protected `master`; `release.yml` already

--- a/backlog.d/_done/021-glm52-artifact-timeout.md
+++ b/backlog.d/_done/021-glm52-artifact-timeout.md
@@ -1,6 +1,31 @@
 # Diagnose GLM 5.2 opencode artifact timeout
 
-Priority: P1 · Status: pending · Estimate: S · Factory child: 022
+Priority: P1 · Status: shipped · Estimate: S · Factory child: 022
+
+**Shipped 2026-07-01:** the live default OpenCode/OpenRouter GLM 5.2 path now
+emits a valid `ReviewArtifact.v1` and receipt within the configured 120-second
+timeout on the small diff-only fixture. The fix was not a blanket timeout bump:
+Cerberus now treats a timed-out OpenCode attempt with no valid artifact as a
+terminal failure instead of spending two more full-timeout re-asks, and the
+artifact schema/prompt no longer split `cost_usd` types or permit confidence
+labels.
+
+Live evidence:
+
+```sh
+cargo run --locked -- review \
+  --request fixtures/requests/diff-only.json \
+  --harness opencode \
+  --model openrouter/z-ai/glm-5.2 \
+  --allow-env OPENROUTER_API_KEY \
+  --out target/cerberus/live-glm52-021/default-after-fix/artifact.json \
+  --transcript target/cerberus/live-glm52-021/default-after-fix/transcript.txt \
+  --receipt-bundle target/cerberus/live-glm52-021/default-after-fix/receipt-bundle.json
+```
+
+Result: exit 0, `receipt-bundle.json` validation `passed`,
+`trusted_for_posting: true`, model `openrouter/z-ai/glm-5.2`, latency `59845ms`,
+single `[attempt: initial]`, no re-ask.
 
 ## Goal
 
@@ -20,14 +45,14 @@ attempt without writing `review-artifact.json`.
 
 ## Oracle
 
-- [ ] `cerberus review --request fixtures/requests/diff-only.json --harness
+- [x] `cerberus review --request fixtures/requests/diff-only.json --harness
       opencode --model openrouter/z-ai/glm-5.2 --allow-env OPENROUTER_API_KEY
       --out <artifact> --transcript <transcript> --receipt-bundle <receipt>`
       emits a valid artifact and receipt on the diff-only fixture.
-- [ ] The transcript shows at least one complete model turn that either writes
+- [x] The transcript shows at least one complete model turn that either writes
       the artifact or gives an actionable schema/prompt failure. A silent timeout
       with only `step_start` is not acceptable.
-- [ ] If GLM 5.2 needs a longer default timeout, the timeout is explicit in docs
+- [x] If GLM 5.2 needs a longer default timeout, the timeout is explicit in docs
       or config and does not mask artifact-emission failures.
 
 ## Evidence From Initial Diagnosis

--- a/fixtures/bin/fake-opencode
+++ b/fixtures/bin/fake-opencode
@@ -145,6 +145,12 @@ if [[ "${CERBERUS_FAKE_OPENCODE_FIRST_INVALID:-}" == "1" && -z "$session_id" ]];
   artifact_digest="sha256:0000000000000000000000000000000000000000000000000000000000000000"
 fi
 
+if [[ "${CERBERUS_FAKE_OPENCODE_TIMEOUT:-}" == "1" ]]; then
+  printf '%s\n' '{"type":"step_start","sessionID":"ses_fake_opencode_timeout"}'
+  sleep "${CERBERUS_FAKE_OPENCODE_TIMEOUT_SECONDS:-3}"
+  exit 0
+fi
+
 sed \
   -e "s/{{request_id}}/$request_id/g" \
   -e "s#{{request_digest}}#$artifact_digest#g" \

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -111,6 +111,27 @@ if grep -q 'sha256:0000000000000000000000000000000000000000000000000000000000000
   exit 1
 fi
 
+if CERBERUS_FAKE_OPENCODE_TIMEOUT=1 CERBERUS_FAKE_OPENCODE_TIMEOUT_SECONDS=3 cargo run --locked -- review \
+  --request fixtures/requests/diff-only.json \
+  --harness opencode \
+  --opencode-binary "$PWD/fixtures/bin/fake-opencode" \
+  --allow-env CERBERUS_FAKE_OPENCODE_TIMEOUT \
+  --allow-env CERBERUS_FAKE_OPENCODE_TIMEOUT_SECONDS \
+  --timeout-seconds 1 \
+  --out target/cerberus/timeout-no-reask-artifact.json \
+  --transcript target/cerberus/timeout-no-reask-transcript.txt \
+  > target/cerberus/timeout-no-reask.stdout \
+  2> target/cerberus/timeout-no-reask.stderr; then
+  echo "expected timed-out opencode review to fail without a re-ask" >&2
+  exit 1
+fi
+grep -q 'harness timed out after' target/cerberus/timeout-no-reask.stderr
+grep -q '\[attempt: initial\]' target/cerberus/timeout-no-reask-transcript.txt
+if grep -q '\[attempt: re-ask\]' target/cerberus/timeout-no-reask-transcript.txt; then
+  echo "timed-out opencode attempt should not launch a re-ask" >&2
+  exit 1
+fi
+
 printf 'stale receipt should be removed before a failed run\n' \
   > target/cerberus/receipts/stale-before-failed-review.json
 printf 'no review artifact here\n' > target/cerberus/no-artifact.txt

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -255,6 +255,16 @@ pub(crate) fn run_command_substrate(
     let mut artifact_result = read_artifact_file(&out_path);
     let mut attempt = 0;
     while let Err(reason) = evaluate_emission(&artifact_result, request) {
+        if output.status == "timeout" {
+            write_failure_transcript(failure_transcript, &transcript)?;
+            let transcript_hint = failure_transcript
+                .map(|path| format!("; transcript: {}", path.display()))
+                .unwrap_or_default();
+            return Err(anyhow!(
+                "{plan_harness} harness timed out after {}ms before producing a valid ReviewArtifact.v1 ({reason}){transcript_hint}",
+                output.elapsed_ms
+            ));
+        }
         if attempt >= MAX_REASK_RETRIES {
             break;
         }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -130,6 +130,7 @@ const ARTIFACT_ENUM_AND_REFERENCE_RULES: &[&str] = &[
     "lifecycle_state must be completed, completed_degraded, failed, skipped, cancelled, or stale",
     "verdict must be PASS, WARN, FAIL, or SKIP",
     "severity must be info, minor, major, or critical",
+    "findings[].confidence must be a JSON number from 0.0 to 1.0, never a label such as low, medium, or high",
     "comments[].kind must be inline or contextual",
     "comments[].intent must be finding, note, question, or summary",
     "anchor.kind must be inline, file, change, or run",
@@ -138,6 +139,7 @@ const ARTIFACT_ENUM_AND_REFERENCE_RULES: &[&str] = &[
     "citations[].kind must be url, paper, doc, command, artifact, or repo",
     "receipts[].role must be master, reviewer, critic, researcher, or synthesizer",
     "receipts[].status must be completed, timeout, error, or skipped",
+    "all cost_usd fields must be JSON numbers or null, never strings",
     "findings[].citations[] values must name top-level citations[].id values",
     "findings[].suggested_fixes[] values must name top-level suggested_fixes[].id values",
     "comments[].finding_id values must name existing findings[].id values",
@@ -233,7 +235,7 @@ Required ReviewArtifact.v1 fields:
 	- suggested_fixes: array of full SuggestedFix objects
 	- citations: array of full Citation objects; URL citations require observed_at
 - receipts: include at least receipt-master with role "master", harness "opencode", status "completed", verdict, and a non-placeholder summary of what evidence you inspected
-- run: include engine_version "cerberus-opencode", config_digest "sha256:prompt-only", started_at "0", finished_at "0", duration_ms 0, cost_usd null, and coverage
+- run: include engine_version "cerberus-opencode", config_digest "sha256:prompt-only", started_at "0", finished_at "0", duration_ms 0, cost_usd null or a JSON number, and coverage
 - errors: array
 
 Coverage requirements:
@@ -391,6 +393,18 @@ mod tests {
         // The raw-stdout / first-character marker contract is gone: emission is a file now.
         assert!(!message.contains("first character must be"));
         assert!(!master.contains("first output character must be"));
+    }
+
+    #[test]
+    fn prompts_instruct_numeric_confidence() {
+        let request = minimal_request();
+        let capabilities = ContextCapabilities::from_request(&request);
+        let message =
+            build_opencode_message(&request, &capabilities, "sha256:test", out_path()).unwrap();
+        assert!(
+            message.contains("findings[].confidence must be a JSON number from 0.0 to 1.0"),
+            "the production prompt must prevent confidence labels like high/medium/low"
+        );
     }
 
     #[test]
@@ -578,7 +592,7 @@ mod tests {
                 started_at: "0".to_string(),
                 finished_at: "1".to_string(),
                 duration_ms: 1,
-                cost_usd: Some("0.01".to_string()),
+                cost_usd: Some(0.01),
                 coverage: Coverage {
                     files_reviewed: vec!["src/lib.rs".to_string()],
                     files_with_findings: vec!["src/lib.rs".to_string()],

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -155,17 +155,12 @@ fn artifact_usage(artifact: &ReviewArtifact) -> Option<Usage> {
 }
 
 fn artifact_cost_usd(artifact: &ReviewArtifact) -> Option<f64> {
-    artifact
-        .run
-        .cost_usd
-        .as_deref()
-        .and_then(|cost| cost.parse::<f64>().ok())
-        .or_else(|| {
-            artifact
-                .receipts
-                .iter()
-                .find_map(|receipt| receipt.usage.as_ref().and_then(|usage| usage.cost_usd))
-        })
+    artifact.run.cost_usd.or_else(|| {
+        artifact
+            .receipts
+            .iter()
+            .find_map(|receipt| receipt.usage.as_ref().and_then(|usage| usage.cost_usd))
+    })
 }
 
 fn transcript_elapsed_ms(transcript: &str) -> Option<u64> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -501,16 +501,42 @@ pub struct ReviewTelemetry {
     pub cost_usd: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RunInfo {
     pub engine_version: String,
     pub config_digest: String,
     pub started_at: String,
     pub finished_at: String,
     pub duration_ms: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cost_usd: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "optional_f64_from_number_or_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cost_usd: Option<f64>,
     pub coverage: Coverage,
+}
+
+fn optional_f64_from_number_or_string<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let Some(value) = Option::<serde_json::Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    match value {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::Number(number) => number.as_f64().map(Some).ok_or_else(|| {
+            serde::de::Error::custom("cost_usd number cannot be represented as f64")
+        }),
+        serde_json::Value::String(raw) => raw
+            .parse::<f64>()
+            .map(Some)
+            .map_err(|_| serde::de::Error::custom("cost_usd string must parse as f64")),
+        other => Err(serde::de::Error::custom(format!(
+            "cost_usd must be a number, numeric string, or null, got {other}"
+        ))),
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -537,4 +563,30 @@ pub enum ErrorScope {
     Adapter,
     Harness,
     Validation,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_cost_usd_accepts_legacy_string_but_serializes_number() {
+        let run: RunInfo = serde_json::from_value(serde_json::json!({
+            "engine_version": "test",
+            "config_digest": "sha256:test",
+            "started_at": "0",
+            "finished_at": "1",
+            "duration_ms": 1,
+            "cost_usd": "0.42",
+            "coverage": {
+                "files_reviewed": [],
+                "files_with_findings": []
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(run.cost_usd, Some(0.42));
+        let serialized = serde_json::to_value(&run).unwrap();
+        assert_eq!(serialized["cost_usd"], serde_json::json!(0.42));
+    }
 }


### PR DESCRIPTION
## Summary
- make timed-out OpenCode attempts without a valid artifact terminal instead of launching full-timeout re-asks
- clarify model-facing artifact contract for numeric confidence/cost fields
- make `run.cost_usd` numeric while accepting legacy string artifacts on read
- move backlog `021` to `_done` and mark `022` child 1 complete

## Verification
- `./scripts/verify.sh`
- live GLM default path:

```sh
cargo run --locked -- review \
  --request fixtures/requests/diff-only.json \
  --harness opencode \
  --model openrouter/z-ai/glm-5.2 \
  --allow-env OPENROUTER_API_KEY \
  --out target/cerberus/live-glm52-021/default-after-fix/artifact.json \
  --transcript target/cerberus/live-glm52-021/default-after-fix/transcript.txt \
  --receipt-bundle target/cerberus/live-glm52-021/default-after-fix/receipt-bundle.json
```

Result: exit 0, validation `passed`, trusted_for_posting `true`, model `openrouter/z-ai/glm-5.2`, latency `59845ms`, single initial attempt, no re-ask.

## Factory epic
- Continues `backlog.d/022-fix-broken-basics.md`; closes child 1 / backlog 021.