### PR TITLE
fix(review-pr): require explicit token for GitHub reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ cerberus render --artifact target/cerberus/artifact.json \
 cerberus review-pr --number 123 --repo owner/name \
   --harness opencode \
   --out-dir target/cerberus/review-pr \
+  --gh-token-env CERBERUS_GH_TOKEN \
   --dry-run
 
 cerberus review-pr --number 123 --repo owner/name \
@@ -123,9 +124,10 @@ projection. It writes `request.json`, `artifact.json`, `review.md`,
 `post-plan.json` under `--out-dir`. `--dry-run` reads existing GitHub
 comments/checks through `gh api` and prints the exact create/update plan
 without writing. `--post` applies that plan and writes `post-result.json`.
-Posting refuses ambient/keyring `gh` auth: pass exactly one explicit token
-source, either `--gh-token-file <path>` or `--gh-token-env <VAR>`. If the token
-is a GitHub App installation token, Cerberus posts as that app identity; token
+Because dry-run still reads GitHub state, `review-pr` refuses ambient/keyring
+`gh` auth for both reads and writes: pass exactly one explicit token source,
+either `--gh-token-file <path>` or `--gh-token-env <VAR>`. If the token is a
+GitHub App installation token, Cerberus posts as that app identity; token
 minting remains the caller/CI boundary.
 
 ## MCP
@@ -194,7 +196,8 @@ prior Cerberus output instead of duplicating it.
 
 For an operator-gated live smoke, set `CERBERUS_LIVE_REVIEW_PR=1`,
 `CERBERUS_LIVE_REVIEW_REPO=owner/name`, and
-`CERBERUS_LIVE_REVIEW_NUMBER=<pull request number>` before running
-`./scripts/verify.sh`. The live smoke defaults to `--dry-run` and
-`--summary-target status`; set `CERBERUS_LIVE_REVIEW_POST=1` only when the
+`CERBERUS_LIVE_REVIEW_NUMBER=<pull request number>` plus exactly one of
+`CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE` or `CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV`
+before running `./scripts/verify.sh`. The live smoke defaults to `--dry-run`
+and `--summary-target status`; set `CERBERUS_LIVE_REVIEW_POST=1` only when the
 target PR is intentionally allowed to receive Cerberus output.

--- a/backlog.d/022-fix-broken-basics.md
+++ b/backlog.d/022-fix-broken-basics.md
@@ -1,6 +1,6 @@
 # Fix the broken basics before expanding Cerberus
 
-Priority: P0 | Status: ready | Estimate: M | Factory epic: 1
+Priority: P0 | Status: selected P0 slices shipped; residual safety/DX work remains | Estimate: M | Factory epic: 1
 
 ## Goal
 
@@ -11,18 +11,18 @@ evidence to decide whether a review is worth trusting.
 
 ## Oracle
 
-- [ ] The documented OpenCode/OpenRouter review path emits a valid
+- [x] The documented OpenCode/OpenRouter review path emits a valid
       `ReviewArtifact.v1` and `ReviewReceiptBundle.v1` for the small diff-only
       fixture without a `step_start`-only timeout.
-- [ ] Timeout failures name the harness/model/stage and point to the transcript
+- [x] Timeout failures name the harness/model/stage and point to the transcript
       or failed artifact path; silent hangs are not acceptable.
-- [ ] The next successful `master` Verify run triggers a green Release workflow
+- [x] The next successful `master` Verify run triggers a green Release workflow
       and creates a GitHub release. The release path must not push generated
       changelog commits back to protected `master`.
-- [ ] GitHub projection is proven against a live sandbox PR or an equivalent
+- [x] GitHub projection is proven against a live sandbox PR or an equivalent
       wiremock contract for create/update/idempotence across summary, review,
       and inline-comment surfaces.
-- [ ] `review-pr --dry-run` either refuses ambient GitHub auth before any live
+- [x] `review-pr --dry-run` either refuses ambient GitHub auth before any live
       read, or README and help text state that dry-run reads may use ambient
       `gh` auth while posting still refuses it.
 - [ ] Existing safety and operator-visibility tickets that protect publication
@@ -34,21 +34,31 @@ evidence to decide whether a review is worth trusting.
 1. **Done:** `021-glm52-artifact-timeout.md` moved to `_done/` after the live
    default GLM 5.2 path emitted a valid artifact and receipt in one initial
    attempt.
-2. Fix the release workflow. Live evidence on 2026-07-01: Release run
-   `28544516079` still failed because `@semantic-release/git` tried to push
-   generated `CHANGELOG.md` back to protected `master`; `release.yml` already
-   invokes Landmark, but `.releaserc.json` still carries the protected-branch
-   write hazard.
+2. **Done:** release workflow fixed in PR #487. Live evidence on 2026-07-01:
+   `master` Verify run `28551881723` triggered Release run `28551914709`, which
+   created `v2.60.0`; the next GLM-fix merge also triggered green Release run
+   `28552884422`.
 3. Finish the publication-safety pieces from `008-pin-untested-safety-guards.md`
    and `009-operator-visibility-and-errors.md` that guard timeout/orphan kill,
    bounded output, request validation, cost/time/coverage rendering, CLI help,
    and actionable Checks 403 fallback guidance.
-4. Add live or protocol-level proof for `src/post.rs` create/update/idempotence.
-   The current repo gate exercises fake GitHub only; README documents the live
-   smoke behind `CERBERUS_LIVE_REVIEW_PR=1`.
-5. Decide and implement the `review-pr --dry-run` ambient-auth behavior. Posting
-   safety shipped in `_done/014-post-as-cerberus-github-app.md`; dry-run still
-   reads existing PR state before an explicit posting token is required.
+4. **Done:** `src/post.rs` has protocol-level proof in `./scripts/verify.sh`
+   for check-run, summary, and inline-comment create/update/page-2 marker
+   idempotence. Live proof on PR #489 used the fixture PASS artifact with
+   `--summary-target status`: dry-run planned `create-commit-status` +
+   `create-summary-comment`; first `--post` created status `49835544553` and
+   summary comment `4860678694`; second `--post` created status `49835550120`
+   and PATCHed the same summary comment. Evidence paths:
+   `target/cerberus/live-post-pr-489/dry-run/post-plan.json`,
+   `target/cerberus/live-post-pr-489/post-first/post-result.json`,
+   `target/cerberus/live-post-pr-489/post-second/post-result.json`.
+5. **Done:** dry-run now follows the same explicit-token rule as posting.
+   `review-pr` resolves exactly one `--gh-token-file` or `--gh-token-env` before
+   PR acquisition, stale-head checks, existing-state reads, or posting. The gate
+   sets `GH_TOKEN=ambient-should-not-count` and verifies no fake-GitHub process
+   runs when dry-run lacks an explicit token; explicit-token dry-run logs
+   `AUTH gh_token=present github_token=absent` for PR reads and existing-state
+   GETs.
 
 ## Notes
 

--- a/backlog.d/_done/014-post-as-cerberus-github-app.md
+++ b/backlog.d/_done/014-post-as-cerberus-github-app.md
@@ -9,6 +9,11 @@ auth and requires exactly one explicit token source (`--gh-token-file` or
 subprocesses. `./scripts/verify.sh` covers no-token refusal, explicit-token
 fake-gh posting, and idempotent update behavior.
 
+**Follow-up 2026-07-01 (022):** dry-run was pulled under the same explicit-token
+rule because it reads PR state, existing comments, and status/check state
+through GitHub. The original posting-only boundary below is historical; current
+`review-pr` requires exactly one explicit token for dry-run and post.
+
 ## Goal
 When Cerberus posts a review to GitHub (`review-pr --post`), it uses an **explicit, caller-injected token** and **refuses to post under ambient/keyring (`gh`) user auth** — so it never silently posts as a human, and so a bot identity supplied by the caller (a GitHub App installation token) flows through cleanly, including check-runs.
 
@@ -22,7 +27,7 @@ The original ticket proposed creating a "Cerberus" GitHub App and baking `Cerber
 
 ## Oracle
 - [ ] `cerberus review-pr --post` posts **only** with an explicit injected token (`--gh-token-file <path>` or an explicit env var), and the `gh` subprocess uses that token — not the operator's keyring identity.
-- [ ] With no explicit token (only ambient/keyring `gh` auth available), `--post` **refuses**: exits non-zero with an actionable message, posts nothing. (Dry-run / artifact emission still work without a token.)
+- [ ] With no explicit token (only ambient/keyring `gh` auth available), `--post` **refuses**: exits non-zero with an actionable message, posts nothing. Superseded by 022: dry-run now also refuses without an explicit token because it performs GitHub reads; pure artifact emission remains available through non-GitHub `review`/`review-diff`.
 - [ ] When the injected token is a GitHub App installation token, the posted comment/check author is that App's `*[bot]` identity (verified out-of-band) and `--summary-target check-run` succeeds — Cerberus is token-agnostic, so this is the same code path as a PAT with `checks:write`.
 - [ ] `./scripts/verify.sh` green (fake-gh exercises the explicit-token path; the ambient-auth refusal is covered by a fixture that provides no token).
 - [ ] A consumer doc (`docs/` or README) shows how Bitterblossom / CI creates the "Cerberus" App (perms: `pull_requests:write`, `checks:write`, `statuses:write`, `contents:read`; webhook off), mints an installation token, and injects it into `cerberus review-pr --post`.
@@ -34,7 +39,7 @@ The original ticket proposed creating a "Cerberus" GitHub App and baking `Cerber
 
 ## Verification System
 - Claim: Cerberus posts to GitHub only with an explicit injected token and refuses ambient/keyring auth; a caller-supplied App token posts as `*[bot]` and creates check-runs through the same path.
-- Falsifier: `--post` succeeds using only keyring/user auth with no explicit token; a posted comment shows the operator's human account; check-run creation fails with a valid injected token; dry-run/emission breaks without a token.
+- Falsifier: `--post` succeeds using only keyring/user auth with no explicit token; a posted comment shows the operator's human account; check-run creation fails with a valid injected token. Historical note: dry-run no longer belongs in the no-token falsifier because 022 made GitHub reads explicit-token only.
 - Driver: `--gh-token-file <tok>` `review-pr --post` against a throwaway PR (or fake-gh) ⇒ posts; `--post` with no token ⇒ refuses non-zero.
 - Grader: posted author login is the injected identity; the no-token `--post` exits non-zero and wrote nothing; `verify.sh` green.
 - Evidence packet: posted comment/check author JSON + the refused-ambient-auth transcript.

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -483,7 +483,10 @@ fake_gh_state="target/cerberus/fake-gh-state"
 fake_gh_token="target/cerberus/fake-gh-token.txt"
 printf 'cerberus-fixture-token\n' > "$fake_gh_token"
 rm -rf "$fake_gh_state"
-CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" cargo run --locked -- review-pr \
+CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+CERBERUS_FAKE_GH_REQUIRE_TOKEN=1 \
+CERBERUS_FAKE_GH_LOG=target/cerberus/review-pr-dry-run-gh.log \
+cargo run --locked -- review-pr \
   --number 7 \
   --repo example/fixture \
   --gh-binary "$fake_gh" \
@@ -491,6 +494,7 @@ CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" cargo run --locked -- review-pr \
   --fixture-output fixtures/harness/valid-review.txt \
   --out-dir target/cerberus/review-pr-dry-run \
   --receipt-bundle target/cerberus/receipts/review-pr-dry-run.json \
+  --gh-token-file "$fake_gh_token" \
   --dry-run \
   > target/cerberus/review-pr-dry-run.stdout
 
@@ -500,6 +504,36 @@ grep -q '"path": "/repos/example/fixture/pulls/7/reviews"' target/cerberus/revie
 grep -q '"line": 3' target/cerberus/review-pr-dry-run/post-plan.json
 grep -q '"commit_id": "0123456789abcdef"' target/cerberus/review-pr-dry-run/post-plan.json
 grep -q 'comment-001' target/cerberus/review-pr-dry-run/review.md
+grep -q 'AUTH gh_token=present github_token=absent' target/cerberus/review-pr-dry-run-gh.log
+
+rm -rf "$fake_gh_state"
+mkdir -p target/cerberus/review-pr-dry-run-no-token
+printf 'stale post result\n' > target/cerberus/review-pr-dry-run-no-token/post-result.json
+printf 'stale post plan\n' > target/cerberus/review-pr-dry-run-no-token/post-plan.json
+if GH_TOKEN=ambient-should-not-count \
+  CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
+  CERBERUS_FAKE_GH_LOG=target/cerberus/review-pr-dry-run-no-token-gh.log \
+  cargo run --locked -- review-pr \
+    --number 7 \
+    --repo example/fixture \
+    --gh-binary "$fake_gh" \
+    --harness fixture \
+    --fixture-output fixtures/harness/valid-review.txt \
+    --out-dir target/cerberus/review-pr-dry-run-no-token \
+    --summary-target check-run \
+    --dry-run \
+    > target/cerberus/review-pr-dry-run-no-token.stdout \
+    2> target/cerberus/review-pr-dry-run-no-token.stderr; then
+  echo "expected review-pr dry-run to refuse ambient auth without explicit token" >&2
+  exit 1
+fi
+grep -q 'requires an explicit GitHub token' target/cerberus/review-pr-dry-run-no-token.stderr
+test ! -e target/cerberus/review-pr-dry-run-no-token/post-result.json
+test ! -e target/cerberus/review-pr-dry-run-no-token/post-plan.json
+if [[ -s target/cerberus/review-pr-dry-run-no-token-gh.log ]]; then
+  echo "review-pr dry-run read GitHub without explicit token" >&2
+  exit 1
+fi
 
 rm -rf "$fake_gh_state"
 mkdir -p target/cerberus/review-pr-post-no-token
@@ -639,6 +673,7 @@ if CERBERUS_FAKE_GH_STATE_DIR="$fake_gh_state" \
     --harness fixture \
     --fixture-output fixtures/harness/valid-review.txt \
     --out-dir target/cerberus/review-pr-stale-head \
+    --gh-token-file "$fake_gh_token" \
     --dry-run \
     > target/cerberus/review-pr-stale-head.stdout \
     2> target/cerberus/review-pr-stale-head.stderr; then
@@ -820,19 +855,20 @@ if [[ "${CERBERUS_LIVE_REVIEW_PR:-}" == "1" ]]; then
   : "${CERBERUS_LIVE_REVIEW_NUMBER:?set CERBERUS_LIVE_REVIEW_NUMBER=<pull request number>}"
   live_out="target/cerberus/live-review-pr"
   live_mode=(--dry-run)
+  live_token_args=()
+  if [[ -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE:-}" && -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV:-}" ]]; then
+    echo "set only one of CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE or CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV" >&2
+    exit 1
+  elif [[ -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE:-}" ]]; then
+    live_token_args+=(--gh-token-file "$CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE")
+  elif [[ -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV:-}" ]]; then
+    live_token_args+=(--gh-token-env "$CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV")
+  else
+    echo "live review requires CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE or CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV" >&2
+    exit 1
+  fi
   if [[ "${CERBERUS_LIVE_REVIEW_POST:-}" == "1" ]]; then
     live_mode=(--post)
-    if [[ -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE:-}" && -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV:-}" ]]; then
-      echo "set only one of CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE or CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV" >&2
-      exit 1
-    elif [[ -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE:-}" ]]; then
-      live_mode+=(--gh-token-file "$CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE")
-    elif [[ -n "${CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV:-}" ]]; then
-      live_mode+=(--gh-token-env "$CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV")
-    else
-      echo "live review posting requires CERBERUS_LIVE_REVIEW_GH_TOKEN_FILE or CERBERUS_LIVE_REVIEW_GH_TOKEN_ENV" >&2
-      exit 1
-    fi
   fi
   cargo run --locked -- review-pr \
     --number "$CERBERUS_LIVE_REVIEW_NUMBER" \
@@ -840,5 +876,6 @@ if [[ "${CERBERUS_LIVE_REVIEW_PR:-}" == "1" ]]; then
     --out-dir "$live_out" \
     --summary-target "${CERBERUS_LIVE_REVIEW_SUMMARY_TARGET:-status}" \
     --harness "${CERBERUS_LIVE_REVIEW_HARNESS:-opencode}" \
+    "${live_token_args[@]}" \
     "${live_mode[@]}"
 fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,10 +216,10 @@ struct ReviewPrArgs {
     summary_target: SummaryTarget,
     #[arg(long, default_value = "gh")]
     gh_binary: String,
-    /// Read the GitHub posting token from this file. Required for --post unless --gh-token-env is used.
+    /// Read the explicit GitHub token from this file. Required unless --gh-token-env is used.
     #[arg(long)]
     gh_token_file: Option<PathBuf>,
-    /// Read the GitHub posting token from this explicitly named env var. Required for --post unless --gh-token-file is used.
+    /// Read the explicit GitHub token from this named env var. Required unless --gh-token-file is used.
     #[arg(long)]
     gh_token_env: Option<String>,
     #[arg(long)]
@@ -611,21 +611,15 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     let post_result_path = args.out_dir.join("post-result.json");
     clean_review_pr_post_receipts(&post_plan_path, &post_result_path)?;
     remove_file_if_exists(&receipt_bundle_path)?;
-    let posting_token = if args.post {
-        Some(resolve_post_token(
-            args.gh_token_file.as_deref(),
-            args.gh_token_env.as_deref(),
-        )?)
-    } else {
-        None
-    };
+    let github_token =
+        resolve_github_token(args.gh_token_file.as_deref(), args.gh_token_env.as_deref())?;
     let gh_binary = args.gh_binary.clone();
 
     let request = build_pull_request(&PullRequestOptions {
         number: args.number,
         repo: Some(args.repo.clone()),
         gh_binary: gh_binary.clone(),
-        gh_token: posting_token.clone(),
+        gh_token: Some(github_token.clone()),
         head_workspace: args.head_workspace,
         base_workspace: args.base_workspace,
         common: RequestOptions {
@@ -649,7 +643,7 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
         args.number,
         &args.repo,
         &gh_binary,
-        posting_token.as_deref(),
+        Some(&github_token),
         &head_sha,
     )?;
 
@@ -673,7 +667,7 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
         args.number,
         &args.repo,
         &gh_binary,
-        posting_token.as_deref(),
+        Some(&github_token),
         &head_sha,
     )?;
     if validation_result.is_err() {
@@ -707,9 +701,7 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     write_text(&markdown_path, &render_markdown(&run.artifact))?;
 
     let mut github = GithubClient::new(gh_binary.clone());
-    if let Some(token) = &posting_token {
-        github = github.with_token(token.clone());
-    }
+    github = github.with_token(github_token.clone());
     let existing =
         github.read_existing_state(&args.repo, args.number, &head_sha, args.summary_target)?;
     let post_plan = build_post_plan(
@@ -727,7 +719,7 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
             args.number,
             &args.repo,
             &gh_binary,
-            posting_token.as_deref(),
+            Some(&github_token),
             &post_plan.head_sha,
         )?;
         write_review_receipt_bundle(
@@ -770,10 +762,10 @@ fn remove_file_if_exists(path: &Path) -> Result<()> {
     }
 }
 
-fn resolve_post_token(token_file: Option<&Path>, token_env: Option<&str>) -> Result<String> {
+fn resolve_github_token(token_file: Option<&Path>, token_env: Option<&str>) -> Result<String> {
     match (token_file, token_env) {
         (Some(_), Some(_)) => Err(anyhow!(
-            "review-pr --post accepts exactly one explicit GitHub token source: --gh-token-file or --gh-token-env"
+            "review-pr accepts exactly one explicit GitHub token source: --gh-token-file or --gh-token-env"
         )),
         (Some(path), None) => {
             let raw = fs::read_to_string(path)
@@ -781,7 +773,7 @@ fn resolve_post_token(token_file: Option<&Path>, token_env: Option<&str>) -> Res
             let token = raw.trim_end_matches(['\r', '\n']).to_string();
             if token.trim().is_empty() {
                 return Err(anyhow!(
-                    "GitHub token file {} is empty; refusing to post",
+                    "GitHub token file {} is empty; refusing to read or post",
                     path.display()
                 ));
             }
@@ -792,13 +784,13 @@ fn resolve_post_token(token_file: Option<&Path>, token_env: Option<&str>) -> Res
                 .with_context(|| format!("read explicit GitHub token env var {var}"))?;
             if token.trim().is_empty() {
                 return Err(anyhow!(
-                    "explicit GitHub token env var {var} is empty; refusing to post"
+                    "explicit GitHub token env var {var} is empty; refusing to read or post"
                 ));
             }
             Ok(token)
         }
         (None, None) => Err(anyhow!(
-            "review-pr --post requires an explicit GitHub token via --gh-token-file <path> or --gh-token-env <VAR>; ambient gh auth is refused for posting"
+            "review-pr requires an explicit GitHub token via --gh-token-file <path> or --gh-token-env <VAR>; ambient gh auth is refused for GitHub reads and posting"
         )),
     }
 }


### PR DESCRIPTION
## Summary

- require review-pr to resolve exactly one explicit GitHub token before PR acquisition, stale-head checks, existing-state reads, or posting
- document that dry-run is non-mutating but still an authenticated GitHub read
- extend verify.sh so explicit-token dry-run reads through fake-gh and ambient-only dry-run fails before fake-gh runs
- record the PR #489 live post proof in backlog 022

## Verification

- ./scripts/verify.sh
- inspected target/cerberus/review-pr-dry-run-gh.log: PR reads and existing-state GETs all used GH_TOKEN
- inspected target/cerberus/review-pr-dry-run-no-token.stderr: ambient-only dry-run refused before fake-gh log creation
- live dry-run on PR #489: target/cerberus/live-post-pr-489/dry-run/post-plan.json planned create-commit-status + create-summary-comment for head f05a90924c24771d54bd6998025c2e076257f4f3
- live post first on PR #489: target/cerberus/live-post-pr-489/post-first/post-result.json created status 49835544553 and summary comment 4860678694
- live post second on PR #489: target/cerberus/live-post-pr-489/post-second/post-result.json created status 49835550120 and PATCHed summary comment 4860678694
- GitHub API read after posting: one Cerberus summary marker on PR #489, comment 4860678694 updated at 2026-07-01T22:55:51Z

## Notes

The live post used the deterministic PASS fixture to avoid posting invented findings on this branch. The repo gate remains the protocol-level proof for inline review-comment create/update and page-2 marker discovery.

Agent: cerberus-factory-lane
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: backlog/022