### PR TITLE
feat(review): emit reviewer plan receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ surface, runs deterministic fixture reviews, smokes both the OpenCode and OMP
 harness paths through local fake binaries, exercises base+head context and
 local runtime probes, and runs `review-pr` through a fake `gh` adapter.
 Evidence is written to `target/cerberus/`, including execution plans,
-transcripts, artifacts, rendered Markdown, post plans, post results, context
-tier receipts, evaluation receipt bundles, and fake GitHub API transcripts.
+reviewer plans, transcripts, artifacts, rendered Markdown, post plans, post
+results, context tier receipts, evaluation receipt bundles, and fake GitHub API
+transcripts.
 
 ## CLI
 
@@ -120,8 +121,8 @@ disposable review worktrees; OMP is a local fallback.
 
 `review-pr` is orchestration over acquisition, review, rendering, and GitHub
 projection. It writes `request.json`, `artifact.json`, `review.md`,
-`execution_plan.json`, `transcript.txt`, `receipt-bundle.json`, and
-`post-plan.json` under `--out-dir`. `--dry-run` reads existing GitHub
+`execution_plan.json`, `reviewer_plan.json`, `transcript.txt`,
+`receipt-bundle.json`, and `post-plan.json` under `--out-dir`. `--dry-run` reads existing GitHub
 comments/checks through `gh api` and prints the exact create/update plan
 without writing. `--post` applies that plan and writes `post-result.json`.
 Because dry-run still reads GitHub state, `review-pr` refuses ambient/keyring
@@ -157,6 +158,11 @@ latency, capability tier, artifact/transcript URIs, and validation outcome
 without embedding prompt files, request files, secret names, or transcript
 excerpts. Daedalus or another lab can score those bundles without Cerberus
 owning model or harness evaluation.
+
+`ReviewerPlanReceipt.v1` is the orchestration sidecar. The current path records
+diff understanding, available and skipped context, the single-master lane
+decision, and the synthesis/validation contract. Dynamic child lanes will extend
+that receipt rather than bypassing `ReviewArtifact.v1`.
 
 ## Crucible producer handoff
 

--- a/backlog.d/024-orchestrator-master-agent-evolution.md
+++ b/backlog.d/024-orchestrator-master-agent-evolution.md
@@ -1,6 +1,6 @@
 # Evolve Cerberus into an orchestrator master agent
 
-Priority: P1 | Status: ready | Estimate: L | Factory epic: 3
+Priority: P1 | Status: active | Estimate: L | Factory epic: 3
 
 ## Goal
 
@@ -28,8 +28,12 @@ pushed anywhere.
 
 ## Children
 
-1. Introduce a reviewer-plan receipt: diff understanding, lane decision, budget,
-   and synthesis notes.
+1. **In flight:** introduce a reviewer-plan receipt: diff understanding, lane
+   decision, budget, and synthesis notes. First slice adds
+   `cerberus.reviewer_plan.v1`, writes it beside `review`, persisted
+   `review-diff`, and `review-pr` artifacts, links it from
+   `ReviewReceiptBundle.v1`, and pins the no-lane single-master path in
+   `./scripts/verify.sh`.
 2. Add a substrate interface for launching scoped reviewer lanes without
    encoding static personas in Rust.
 3. Add synthesis prompt/schema instructions that merge lane evidence into one

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -762,29 +762,36 @@ test -s target/cerberus/review.md
 test -s target/cerberus/review-rendered.md
 test -s target/cerberus/execution_plan.json
 test -s target/cerberus/transcript.txt
+test -s target/cerberus/reviewer_plan.json
 test -s target/cerberus/git-range-request.json
 test -s target/cerberus/git-range-artifact.json
 test -s target/cerberus/git-range-review.md
 test -s target/cerberus/git-range-execution_plan.json
+test -s target/cerberus/git-range-reviewer_plan.json
 test -s target/cerberus/mcp.stdout
 test -s target/cerberus/git-range-opencode-artifact.json
 test -s target/cerberus/git-range-opencode-review.md
 test -s target/cerberus/git-range-opencode-execution_plan.json
 test -s target/cerberus/git-range-opencode-transcript.txt
+test -s target/cerberus/git-range-opencode-reviewer_plan.json
 test -s target/cerberus/context-tiers/local-runtime-request.json
 test -s target/cerberus/context-tiers/local-runtime-opencode-artifact.json
 test -s target/cerberus/context-tiers/local-runtime-opencode-execution_plan.json
 test -s target/cerberus/context-tiers/local-runtime-opencode-transcript.txt
+test -s target/cerberus/context-tiers/local-runtime-opencode-reviewer_plan.json
 test -s target/cerberus/opencode-artifact.json
 test -s target/cerberus/opencode-execution_plan.json
 test -s target/cerberus/opencode-transcript.txt
+test -s target/cerberus/opencode-reviewer_plan.json
 test -s target/cerberus/omp-artifact.json
 test -s target/cerberus/omp-execution_plan.json
 test -s target/cerberus/omp-transcript.txt
+test -s target/cerberus/omp-reviewer_plan.json
 test -s target/cerberus/review-pr-dry-run/request.json
 test -s target/cerberus/review-pr-dry-run/artifact.json
 test -s target/cerberus/review-pr-dry-run/review.md
 test -s target/cerberus/review-pr-dry-run/execution_plan.json
+test -s target/cerberus/review-pr-dry-run/reviewer_plan.json
 test -s target/cerberus/review-pr-dry-run/transcript.txt
 test -s target/cerberus/review-pr-dry-run/post-plan.json
 test -s target/cerberus/review-pr-post-first/post-result.json
@@ -818,6 +825,26 @@ grep -q '"workspace_mode": "diff_packet"' target/cerberus/omp-execution_plan.jso
 grep -q '<request-file>' target/cerberus/opencode-execution_plan.json
 grep -q '<request-file>' target/cerberus/git-range-opencode-execution_plan.json
 grep -q '<prompt-file>' target/cerberus/omp-execution_plan.json
+python3 - <<'PY'
+import json
+
+with open("target/cerberus/reviewer_plan.json", encoding="utf-8") as fh:
+    plan = json.load(fh)
+assert plan["schema_version"] == "cerberus.reviewer_plan.v1"
+assert plan["lane_decision"]["mode"] == "single_master"
+assert len(plan["child_lanes"]) == 0
+assert plan["master_lane"]["expected_output"] == "ReviewArtifact.v1"
+assert plan["diff_understanding"]["changed_surfaces"][0]["path"] == "src/ratio.rs"
+
+with open(
+    "target/cerberus/context-tiers/local-runtime-opencode-reviewer_plan.json",
+    encoding="utf-8",
+) as fh:
+    local_plan = json.load(fh)
+assert local_plan["diff_understanding"]["available_context"]["local_runtime"] is True
+assert local_plan["master_lane"]["allowed_context_tier"] == "local_runtime"
+assert "local_runtime" not in local_plan["diff_understanding"]["skipped_context"]
+PY
 grep -q '"schema_version": "cerberus.review_receipt_bundle.v1"' target/cerberus/receipts/opencode.json
 grep -q '"harness": "opencode"' target/cerberus/receipts/opencode.json
 grep -q '"model": "fake/opencode-reviewer"' target/cerberus/receipts/opencode.json
@@ -826,6 +853,7 @@ grep -q '"completion_tokens": 45' target/cerberus/receipts/opencode.json
 grep -q '"cost_usd": 0.0042' target/cerberus/receipts/opencode.json
 grep -q '"validation": {' target/cerberus/receipts/opencode.json
 grep -q '"trusted_for_posting": true' target/cerberus/receipts/opencode.json
+grep -q '"reviewer_plan_uri": "target/cerberus/reviewer_plan.json"' target/cerberus/receipts/fixture.json
 grep -q '"capability_tier": "diff_only"' target/cerberus/receipts/fixture.json
 grep -q '"capability_tier": "repo_base_and_head"' target/cerberus/receipts/git-range-opencode.json
 grep -q '"capability_tier": "local_runtime"' target/cerberus/receipts/local-runtime-opencode.json

--- a/spec.md
+++ b/spec.md
@@ -214,6 +214,13 @@ secret or private file paths. Prompt schema instructions are checked against
 the Rust `ReviewArtifact.v1` contract so the compact substrate prompt cannot
 silently drift from validation.
 
+The orchestrator stage is represented in `reviewer_plan.json`
+(`cerberus.reviewer_plan.v1`). It records diff understanding, available and
+skipped context, the single-master or child-lane decision, the master lane
+scope, and synthesis/validation notes. In the MVP path this receipt records
+`single_master` with no child lanes; future dynamic lanes extend this receipt
+and still synthesize into one validated `ReviewArtifact.v1`.
+
 ## Master Reviewer Prompt Contract
 
 The master prompt tells Cerberus:
@@ -315,9 +322,10 @@ and Harbor export.
 
 `review-pr` is a convenience orchestrator over the existing acquisition and
 review boundaries. It must write the same request, execution plan, transcript,
-artifact, Markdown, and `ReviewReceiptBundle.v1` receipts as the separate
-commands, then produce a `PostPlan.v1`. Dry-run mode reads existing GitHub
-state but does not write. Posting mode applies the post plan through `gh api`.
+reviewer plan, artifact, Markdown, and `ReviewReceiptBundle.v1` receipts as the
+separate commands, then produce a `PostPlan.v1`. Dry-run mode reads existing
+GitHub state but does not write. Posting mode applies the post plan through
+`gh api`.
 
 GitHub projection is not part of `ReviewArtifact.v1`. The post plan maps the
 artifact to a per-head-SHA summary, contextual PR issue comment, and PR review
@@ -325,12 +333,13 @@ comments. Inline review comments are emitted only when the artifact anchor maps
 to a changed new-side line in the PR diff; every unmappable inline comment is
 included in contextual summary output instead.
 
-`--post` requires an explicit caller-injected GitHub token source
-(`--gh-token-file` or `--gh-token-env`) and refuses ambient/keyring `gh` auth.
-The token may be a GitHub App installation token, fine-grained token, or other
-caller-owned credential with the required destination permissions. Cerberus does
-not mint GitHub App JWTs or installation tokens; that remains the consumer or CI
-boundary. Dry-run and artifact emission may still run without an explicit token.
+`review-pr` requires an explicit caller-injected GitHub token source
+(`--gh-token-file` or `--gh-token-env`) for both dry-run reads and posting, and
+refuses ambient/keyring `gh` auth. The token may be a GitHub App installation
+token, fine-grained token, or other caller-owned credential with the required
+destination permissions. Cerberus does not mint GitHub App JWTs or installation
+tokens; that remains the consumer or CI boundary. Pure artifact emission remains
+available through non-GitHub `review` and `review-diff`.
 
 `--summary-target check-run` creates or updates a Cerberus check run when the
 injected token has Checks write access. `--summary-target status` posts a
@@ -378,6 +387,7 @@ Evidence packet:
 - `target/cerberus/artifact.json`
 - `target/cerberus/review.md`
 - `target/cerberus/execution_plan.json`
+- `target/cerberus/reviewer_plan.json`
 - `target/cerberus/receipts/*.json`
 - `target/cerberus/crucible-producer/producer-manifest.json`
 - `target/cerberus/review-pr/post-plan.json`

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -7,6 +7,7 @@ use crate::harness::{
     run_command_substrate, run_fixture_substrate, CommandSubstrateConfig, ExecutionPlan,
     FixtureSubstrateConfig, OmpSubstrateConfig, OpenCodeSubstrateConfig,
 };
+use crate::orchestration::{build_reviewer_plan, ReviewerPlanReceipt};
 use crate::schema::{ReviewArtifact, ReviewRequest, ReviewTelemetry};
 
 #[derive(Debug, Clone)]
@@ -33,6 +34,7 @@ pub struct ReviewRun {
     pub artifact: ReviewArtifact,
     pub transcript: String,
     pub execution_plan: ExecutionPlan,
+    pub reviewer_plan: ReviewerPlanReceipt,
     pub telemetry: ReviewTelemetry,
 }
 
@@ -67,10 +69,12 @@ impl ReviewKernel {
                 run_policy.failure_transcript.as_deref(),
             )?,
         };
+        let reviewer_plan = build_reviewer_plan(request, &run.execution_plan, &run.telemetry)?;
         Ok(ReviewRun {
             artifact: run.artifact,
             transcript: run.transcript,
             execution_plan: run.execution_plan,
+            reviewer_plan,
             telemetry: run.telemetry,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod digest;
 pub mod harness;
 pub mod kernel;
 pub mod mcp;
+pub mod orchestration;
 pub mod post;
 pub mod producer;
 pub mod prompt;
@@ -18,6 +19,7 @@ pub use harness::{
     FixtureSubstrateConfig, HarnessKind, OmpSubstrateConfig, OpenCodeSubstrateConfig,
 };
 pub use kernel::{ReviewKernel, ReviewRun, ReviewSubstrate, RunPolicy};
+pub use orchestration::{build_reviewer_plan, ReviewerPlanReceipt, REVIEWER_PLAN_SCHEMA};
 pub use post::{build_post_plan, GithubClient, PostPlan, SummaryTarget};
 pub use producer::{
     build_crucible_producer_manifest, CrucibleProducerManifest, CrucibleProducerManifestInput,

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,7 +468,9 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
     };
     let run = kernel.review(&request, &run_policy)?;
     let plan_path = execution_plan.unwrap_or_else(|| sibling_path(&out, "execution_plan.json"));
+    let reviewer_plan_path = reviewer_plan_path_for(&out);
     write_json(&plan_path, &run.execution_plan)?;
+    write_json(&reviewer_plan_path, &run.reviewer_plan)?;
     if let Some(transcript_path) = &transcript_path {
         write_text(transcript_path, &run.transcript)?;
     }
@@ -479,9 +481,12 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
             receipt_bundle,
             &request,
             &run,
-            &out,
-            transcript_path.as_deref(),
-            Some(&plan_path),
+            ReviewReceiptPaths {
+                artifact: &out,
+                transcript: transcript_path.as_deref(),
+                execution_plan: Some(&plan_path),
+                reviewer_plan: Some(&reviewer_plan_path),
+            },
             validation_result.is_err(),
         )?)
     } else {
@@ -584,6 +589,7 @@ fn review_diff(args: ReviewDiffArgs) -> Result<ExitCode> {
     // Optional persistence; stdout stays the primary deliverable for the caller.
     if let Some(out) = &args.out {
         write_json(out, &run.artifact)?;
+        write_json(&reviewer_plan_path_for(out), &run.reviewer_plan)?;
     }
     let markdown = render_markdown(&run.artifact);
     if let Some(path) = &args.markdown {
@@ -602,6 +608,7 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     let artifact_path = args.out_dir.join("artifact.json");
     let markdown_path = args.out_dir.join("review.md");
     let execution_plan_path = args.out_dir.join("execution_plan.json");
+    let reviewer_plan_path = args.out_dir.join("reviewer_plan.json");
     let transcript_path = args.out_dir.join("transcript.txt");
     let receipt_bundle_path = args
         .receipt_bundle
@@ -660,6 +667,7 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     };
     let run = kernel.review(&request, &run_policy)?;
     write_json(&execution_plan_path, &run.execution_plan)?;
+    write_json(&reviewer_plan_path, &run.reviewer_plan)?;
     write_text(&transcript_path, &run.transcript)?;
     write_json(&artifact_path, &run.artifact)?;
     let validation_result = validate_artifact_for_request(&run.artifact, &request);
@@ -675,9 +683,12 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
             &receipt_bundle_path,
             &request,
             &run,
-            &artifact_path,
-            Some(&transcript_path),
-            Some(&execution_plan_path),
+            ReviewReceiptPaths {
+                artifact: &artifact_path,
+                transcript: Some(&transcript_path),
+                execution_plan: Some(&execution_plan_path),
+                reviewer_plan: Some(&reviewer_plan_path),
+            },
             true,
         )?;
         validation_result?;
@@ -687,9 +698,12 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
             &receipt_bundle_path,
             &request,
             &run,
-            &artifact_path,
-            Some(&transcript_path),
-            Some(&execution_plan_path),
+            ReviewReceiptPaths {
+                artifact: &artifact_path,
+                transcript: Some(&transcript_path),
+                execution_plan: Some(&execution_plan_path),
+                reviewer_plan: Some(&reviewer_plan_path),
+            },
             false,
         )?;
         write_text(&markdown_path, &render_markdown(&run.artifact))?;
@@ -726,9 +740,12 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
             &receipt_bundle_path,
             &request,
             &run,
-            &artifact_path,
-            Some(&transcript_path),
-            Some(&execution_plan_path),
+            ReviewReceiptPaths {
+                artifact: &artifact_path,
+                transcript: Some(&transcript_path),
+                execution_plan: Some(&execution_plan_path),
+                reviewer_plan: Some(&reviewer_plan_path),
+            },
             false,
         )?;
         let result = github.apply_plan(&post_plan)?;
@@ -738,9 +755,12 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
             &receipt_bundle_path,
             &request,
             &run,
-            &artifact_path,
-            Some(&transcript_path),
-            Some(&execution_plan_path),
+            ReviewReceiptPaths {
+                artifact: &artifact_path,
+                transcript: Some(&transcript_path),
+                execution_plan: Some(&execution_plan_path),
+                reviewer_plan: Some(&reviewer_plan_path),
+            },
             false,
         )?;
         println!("{}", serde_json::to_string_pretty(&post_plan)?);
@@ -817,13 +837,18 @@ fn render(args: RenderArgs) -> Result<()> {
     Ok(())
 }
 
+struct ReviewReceiptPaths<'a> {
+    artifact: &'a Path,
+    transcript: Option<&'a Path>,
+    execution_plan: Option<&'a Path>,
+    reviewer_plan: Option<&'a Path>,
+}
+
 fn write_review_receipt_bundle(
     path: &Path,
     request: &ReviewRequest,
     run: &ReviewRun,
-    artifact_path: &Path,
-    transcript_path: Option<&Path>,
-    execution_plan_path: Option<&Path>,
+    paths: ReviewReceiptPaths<'_>,
     validation_failed: bool,
 ) -> Result<cerberus::ReviewReceiptBundle> {
     let bundle = build_review_receipt_bundle(ReceiptBundleInput {
@@ -832,9 +857,10 @@ fn write_review_receipt_bundle(
         harness: &run.execution_plan.harness,
         telemetry: &run.telemetry,
         transcript: &run.transcript,
-        artifact_uri: artifact_path.display().to_string(),
-        transcript_uri: transcript_path.map(|path| path.display().to_string()),
-        execution_plan_uri: execution_plan_path.map(|path| path.display().to_string()),
+        artifact_uri: paths.artifact.display().to_string(),
+        transcript_uri: paths.transcript.map(|path| path.display().to_string()),
+        execution_plan_uri: paths.execution_plan.map(|path| path.display().to_string()),
+        reviewer_plan_uri: paths.reviewer_plan.map(|path| path.display().to_string()),
         validation_failed,
     })?;
     write_json(path, &bundle)?;
@@ -871,6 +897,23 @@ fn sibling_path(out: &Path, filename: &str) -> PathBuf {
     out.parent()
         .map(|parent| parent.join(filename))
         .unwrap_or_else(|| PathBuf::from(filename))
+}
+
+fn reviewer_plan_path_for(out: &Path) -> PathBuf {
+    let file_name = out
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("artifact.json");
+    let reviewer_plan_name = if file_name == "artifact.json" {
+        "reviewer_plan.json".to_string()
+    } else if let Some(prefix) = file_name.strip_suffix("-artifact.json") {
+        format!("{prefix}-reviewer_plan.json")
+    } else if let Some(prefix) = file_name.strip_suffix(".json") {
+        format!("{prefix}-reviewer_plan.json")
+    } else {
+        format!("{file_name}-reviewer_plan.json")
+    };
+    sibling_path(out, &reviewer_plan_name)
 }
 
 #[allow(dead_code)]

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -1,0 +1,291 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::digest::request_digest;
+use crate::harness::ExecutionPlan;
+use crate::receipt::capability_tier;
+use crate::schema::{ChangedFile, ContextCapabilities, FileStatus, ReviewRequest, ReviewTelemetry};
+
+pub const REVIEWER_PLAN_SCHEMA: &str = "cerberus.reviewer_plan.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewerPlanReceipt {
+    pub schema_version: String,
+    pub request_id: String,
+    pub request_digest: String,
+    pub diff_understanding: DiffUnderstanding,
+    pub lane_decision: LaneDecision,
+    pub master_lane: ReviewerLanePlan,
+    pub child_lanes: Vec<ReviewerLanePlan>,
+    pub synthesis: SynthesisPlan,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DiffUnderstanding {
+    pub changed_surfaces: Vec<ChangedSurface>,
+    pub summary: String,
+    pub risk_shape: Vec<String>,
+    pub available_context: ContextCapabilities,
+    pub skipped_context: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChangedSurface {
+    pub path: String,
+    pub status: FileStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additions: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deletions: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub old_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaneDecision {
+    pub mode: LaneDecisionMode,
+    pub reason: String,
+    pub stop_condition: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_budget_usd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LaneDecisionMode {
+    SingleMaster,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewerLanePlan {
+    pub id: String,
+    pub role: String,
+    pub objective: String,
+    pub scope: Vec<String>,
+    pub allowed_context_tier: String,
+    pub substrate: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_budget_usd: Option<String>,
+    pub stop_condition: String,
+    pub expected_output: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SynthesisPlan {
+    pub strategy: String,
+    pub artifact_contract: String,
+    pub validation_gate: String,
+    pub notes: Vec<String>,
+}
+
+pub fn build_reviewer_plan(
+    request: &ReviewRequest,
+    execution_plan: &ExecutionPlan,
+    telemetry: &ReviewTelemetry,
+) -> Result<ReviewerPlanReceipt> {
+    let available_context = ContextCapabilities::from_request(request);
+    let changed_surfaces = changed_surfaces(&request.change.files);
+    let context_tier = capability_tier(&available_context).to_string();
+    let scope = if changed_surfaces.is_empty() {
+        vec!["diff packet".to_string()]
+    } else {
+        changed_surfaces
+            .iter()
+            .map(|surface| surface.path.clone())
+            .collect()
+    };
+
+    Ok(ReviewerPlanReceipt {
+        schema_version: REVIEWER_PLAN_SCHEMA.to_string(),
+        request_id: request.request_id.clone(),
+        request_digest: request_digest(request)?,
+        diff_understanding: DiffUnderstanding {
+            summary: diff_summary(&changed_surfaces),
+            risk_shape: risk_shape(&changed_surfaces, &available_context),
+            changed_surfaces,
+            skipped_context: skipped_context(&available_context),
+            available_context,
+        },
+        lane_decision: LaneDecision {
+            mode: LaneDecisionMode::SingleMaster,
+            reason: "The current orchestrator slice records the existing single-master path; child lane launch is disabled until the reviewer-lane substrate lands.".to_string(),
+            stop_condition: "Emit exactly one ReviewArtifact.v1 candidate and pass validate_artifact_for_request, or fail closed.".to_string(),
+            cost_budget_usd: None,
+        },
+        master_lane: ReviewerLanePlan {
+            id: "lane-master".to_string(),
+            role: "master".to_string(),
+            objective: "Review the change using the declared context and synthesize the final artifact.".to_string(),
+            scope,
+            allowed_context_tier: context_tier,
+            substrate: execution_plan.harness.clone(),
+            model: telemetry.model.clone(),
+            cost_budget_usd: None,
+            stop_condition: "Stop after a validated ReviewArtifact.v1 is emitted or the substrate fails.".to_string(),
+            expected_output: "ReviewArtifact.v1".to_string(),
+        },
+        child_lanes: Vec::new(),
+        synthesis: SynthesisPlan {
+            strategy: "single_master_synthesis".to_string(),
+            artifact_contract: "ReviewArtifact.v1".to_string(),
+            validation_gate: "validate_artifact_for_request".to_string(),
+            notes: vec![
+                "No child lanes were launched in this run.".to_string(),
+                "Future child-lane evidence must be synthesized into the same artifact and cannot bypass validation.".to_string(),
+            ],
+        },
+    })
+}
+
+fn changed_surfaces(files: &[ChangedFile]) -> Vec<ChangedSurface> {
+    files
+        .iter()
+        .map(|file| ChangedSurface {
+            path: file.path.clone(),
+            status: file.status.clone(),
+            additions: file.additions,
+            deletions: file.deletions,
+            old_path: file.old_path.clone(),
+        })
+        .collect()
+}
+
+fn diff_summary(changed_surfaces: &[ChangedSurface]) -> String {
+    let files = changed_surfaces.len();
+    let additions: u32 = changed_surfaces
+        .iter()
+        .filter_map(|surface| surface.additions)
+        .sum();
+    let deletions: u32 = changed_surfaces
+        .iter()
+        .filter_map(|surface| surface.deletions)
+        .sum();
+    format!("{files} changed file(s), +{additions}/-{deletions}")
+}
+
+fn risk_shape(
+    changed_surfaces: &[ChangedSurface],
+    capabilities: &ContextCapabilities,
+) -> Vec<String> {
+    let mut shape = vec![diff_summary(changed_surfaces)];
+    shape.push(format!("context tier: {}", capability_tier(capabilities)));
+    if capabilities.local_runtime {
+        shape.push("local runtime probes available".to_string());
+    }
+    if capabilities.external_research != Default::default() {
+        shape.push(format!(
+            "external research policy: {:?}",
+            capabilities.external_research
+        ));
+    }
+    shape
+}
+
+fn skipped_context(capabilities: &ContextCapabilities) -> Vec<String> {
+    let mut skipped = Vec::new();
+    if !capabilities.repo_head {
+        skipped.push("repo_head".to_string());
+    }
+    if !capabilities.repo_base {
+        skipped.push("repo_base".to_string());
+    }
+    if !capabilities.local_runtime {
+        skipped.push("local_runtime".to_string());
+    }
+    if !capabilities.remote_runtime {
+        skipped.push("remote_runtime".to_string());
+    }
+    if capabilities.external_research == Default::default() {
+        skipped.push("external_research".to_string());
+    }
+    skipped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness::ExecutionPlan;
+    use crate::schema::{
+        Change, Diff, ExternalResearchPolicy, FileStatus, ReviewPolicy, Source, SourceKind,
+    };
+
+    #[test]
+    fn reviewer_plan_records_single_master_diff_understanding() {
+        let request = ReviewRequest {
+            schema_version: crate::schema::REVIEW_REQUEST_SCHEMA.to_string(),
+            request_id: "req-1".to_string(),
+            source: Source {
+                kind: SourceKind::Fixture,
+                external_id: None,
+                repo: None,
+                uri: None,
+                metadata: serde_json::json!({}),
+            },
+            change: Change {
+                title: "change".to_string(),
+                description: None,
+                base_ref: None,
+                head_ref: None,
+                head_sha: None,
+                diff: Diff {
+                    format: "unified".to_string(),
+                    body: "diff --git a/src/lib.rs b/src/lib.rs\n".to_string(),
+                    digest: None,
+                },
+                files: vec![ChangedFile {
+                    path: "src/lib.rs".to_string(),
+                    status: FileStatus::Modified,
+                    old_path: None,
+                    additions: Some(3),
+                    deletions: Some(1),
+                }],
+            },
+            context: Default::default(),
+            policy: ReviewPolicy {
+                external_research: ExternalResearchPolicy::Forbid,
+                ..ReviewPolicy::default()
+            },
+        };
+        let plan = build_reviewer_plan(
+            &request,
+            &ExecutionPlan {
+                harness: "fixture".to_string(),
+                command: "fixture".to_string(),
+                args: Vec::new(),
+                cwd: ".".to_string(),
+                timeout_ms: 1000,
+                env_allowlist: Vec::new(),
+                context_capabilities: ContextCapabilities::from_request(&request),
+                prompt_transport: "fixture".to_string(),
+                private_material_in_argv: false,
+                workspace_mode: "diff_packet".to_string(),
+                runtime_transcripts: Vec::new(),
+            },
+            &ReviewTelemetry {
+                model: Some("fixture-model".to_string()),
+                ..ReviewTelemetry::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(plan.schema_version, REVIEWER_PLAN_SCHEMA);
+        assert_eq!(plan.lane_decision.mode, LaneDecisionMode::SingleMaster);
+        assert!(plan.child_lanes.is_empty());
+        assert_eq!(plan.master_lane.model.as_deref(), Some("fixture-model"));
+        assert_eq!(plan.master_lane.allowed_context_tier, "diff_only");
+        assert_eq!(
+            plan.diff_understanding.changed_surfaces[0].path,
+            "src/lib.rs"
+        );
+        assert!(plan
+            .diff_understanding
+            .skipped_context
+            .contains(&"repo_head".to_string()));
+        assert_eq!(
+            plan.synthesis.validation_gate,
+            "validate_artifact_for_request"
+        );
+    }
+}

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -157,6 +157,7 @@ mod tests {
             execution_plan_uri: Some(
                 "target/cerberus/crucible-producer/execution_plan.json".to_string(),
             ),
+            reviewer_plan_uri: None,
             validation_failed: false,
         })
         .unwrap();
@@ -195,6 +196,7 @@ mod tests {
             artifact_uri: "target/cerberus/crucible-producer/artifact.json".to_string(),
             transcript_uri: None,
             execution_plan_uri: None,
+            reviewer_plan_uri: None,
             validation_failed: true,
         })
         .unwrap();

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -31,6 +31,8 @@ pub struct ReviewReceiptBundle {
     pub transcript_uri: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_plan_uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reviewer_plan_uri: Option<String>,
     pub validation: ReceiptValidation,
 }
 
@@ -58,6 +60,7 @@ pub struct ReceiptBundleInput<'a> {
     pub artifact_uri: String,
     pub transcript_uri: Option<String>,
     pub execution_plan_uri: Option<String>,
+    pub reviewer_plan_uri: Option<String>,
     pub validation_failed: bool,
 }
 
@@ -97,6 +100,7 @@ pub fn build_review_receipt_bundle(input: ReceiptBundleInput<'_>) -> Result<Revi
         artifact_uri: input.artifact_uri,
         transcript_uri: input.transcript_uri,
         execution_plan_uri: input.execution_plan_uri,
+        reviewer_plan_uri: input.reviewer_plan_uri,
         validation,
     })
 }
@@ -124,7 +128,7 @@ fn receipt_validation(artifact: &ReviewArtifact, validation_failed: bool) -> Rec
     }
 }
 
-fn capability_tier(capabilities: &ContextCapabilities) -> &'static str {
+pub(crate) fn capability_tier(capabilities: &ContextCapabilities) -> &'static str {
     if capabilities.remote_runtime {
         "remote_runtime"
     } else if capabilities.local_runtime {
@@ -284,6 +288,7 @@ mod tests {
             artifact_uri: "target/cerberus/artifact.json".to_string(),
             transcript_uri: Some("target/cerberus/transcript.txt".to_string()),
             execution_plan_uri: Some("target/cerberus/execution_plan.json".to_string()),
+            reviewer_plan_uri: Some("target/cerberus/reviewer_plan.json".to_string()),
             validation_failed,
         }
     }
@@ -388,6 +393,24 @@ mod tests {
                 workspace_mode: "diff_packet".to_string(),
                 runtime_transcripts: Vec::new(),
             },
+            reviewer_plan: crate::orchestration::build_reviewer_plan(
+                request,
+                &ExecutionPlan {
+                    harness: "fixture".to_string(),
+                    command: "fixtures/harness/valid-review.txt".to_string(),
+                    args: Vec::new(),
+                    cwd: ".".to_string(),
+                    timeout_ms: 1000,
+                    env_allowlist: Vec::new(),
+                    context_capabilities: ContextCapabilities::from_request(request),
+                    prompt_transport: "fixture template".to_string(),
+                    private_material_in_argv: false,
+                    workspace_mode: "diff_packet".to_string(),
+                    runtime_transcripts: Vec::new(),
+                },
+                &Default::default(),
+            )
+            .unwrap(),
             telemetry: Default::default(),
         }
     }


### PR DESCRIPTION
## Summary

- add cerberus.reviewer_plan.v1 as the first orchestrator-evolution receipt
- write reviewer_plan sidecars beside review, persisted review-diff, and review-pr artifacts
- link reviewer_plan_uri from ReviewReceiptBundle.v1
- pin the no-lane single-master path and local-runtime context tier in verify.sh

## Verification

- ./scripts/verify.sh
- cargo test --locked
- local diff proof: cargo run --locked -- review-diff --base master --head HEAD --harness fixture --fixture-output fixtures/harness/pass-review.txt --out target/cerberus/live-024-reviewer-plan/artifact.json --markdown target/cerberus/live-024-reviewer-plan/review.md
- inspected target/cerberus/live-024-reviewer-plan/reviewer_plan.json: schema cerberus.reviewer_plan.v1, request git-range-master-3830923fa3a4, context tier repo_base_and_head, 10 changed surfaces, mode single_master, 0 child lanes, synthesis gate validate_artifact_for_request

## Notes

This intentionally does not launch child lanes yet. It creates the durable plan/receipt surface first so the next 024 slice can add lane substrate behavior against a checked artifact contract.

Agent: cerberus-factory-lane
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: backlog/024