### PR TITLE
test: pin Crucible producer manifest schema

### DIFF
--- a/docs/schemas/cerberus.crucible_producer_manifest.v1.schema.json
+++ b/docs/schemas/cerberus.crucible_producer_manifest.v1.schema.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/misty-step/cerberus/blob/master/docs/schemas/cerberus.crucible_producer_manifest.v1.schema.json",
+  "title": "Cerberus Crucible Producer Manifest v1",
+  "description": "Producer-owned handoff packet that points Crucible at a Cerberus ReviewArtifact and ReviewReceiptBundle without embedding Crucible scoring decisions.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "consumer",
+    "request",
+    "artifact",
+    "receipt_bundle",
+    "grader_input",
+    "validation",
+    "boundary"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "cerberus.crucible_producer_manifest.v1"
+    },
+    "consumer": {
+      "const": "crucible"
+    },
+    "request": {
+      "type": "object",
+      "required": [
+        "request_id",
+        "request_digest"
+      ],
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request_digest": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "artifact": {
+      "type": "object",
+      "required": [
+        "artifact_id",
+        "artifact_uri",
+        "artifact_digest",
+        "schema_version",
+        "finding_count",
+        "comment_count",
+        "capability_tier",
+        "context_capabilities"
+      ],
+      "properties": {
+        "artifact_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifact_uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifact_digest": {
+          "type": "string",
+          "minLength": 1
+        },
+        "schema_version": {
+          "const": "cerberus.review_artifact.v1"
+        },
+        "finding_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "comment_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "capability_tier": {
+          "type": "string",
+          "enum": [
+            "metadata_only",
+            "diff_only",
+            "repo_head",
+            "repo_base_and_head",
+            "local_runtime",
+            "remote_runtime"
+          ]
+        },
+        "context_capabilities": {
+          "$ref": "#/$defs/context_capabilities"
+        }
+      },
+      "additionalProperties": false
+    },
+    "receipt_bundle": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "receipt_bundle_uri",
+        "receipt_bundle_digest"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "cerberus.review_receipt_bundle.v1"
+        },
+        "receipt_bundle_uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "receipt_bundle_digest": {
+          "type": "string",
+          "minLength": 1
+        },
+        "transcript_uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "execution_plan_uri": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "grader_input": {
+      "type": "object",
+      "required": [
+        "format",
+        "artifact_uri",
+        "findings_path",
+        "finding_id_path"
+      ],
+      "properties": {
+        "format": {
+          "const": "cerberus.review_artifact.v1"
+        },
+        "artifact_uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "findings_path": {
+          "const": "findings"
+        },
+        "finding_id_path": {
+          "const": "findings[].id"
+        }
+      },
+      "additionalProperties": false
+    },
+    "validation": {
+      "type": "object",
+      "required": [
+        "status",
+        "trusted_for_grading"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "passed",
+            "failed"
+          ]
+        },
+        "trusted_for_grading": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "boundary": {
+      "type": "object",
+      "required": [
+        "scorer_owner",
+        "includes_score",
+        "note"
+      ],
+      "properties": {
+        "scorer_owner": {
+          "const": "crucible"
+        },
+        "includes_score": {
+          "const": false
+        },
+        "note": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "context_capabilities": {
+      "type": "object",
+      "required": [
+        "diff",
+        "repo_head",
+        "repo_base",
+        "local_runtime",
+        "remote_runtime",
+        "external_research"
+      ],
+      "properties": {
+        "diff": {
+          "type": "boolean"
+        },
+        "repo_head": {
+          "type": "boolean"
+        },
+        "repo_base": {
+          "type": "boolean"
+        },
+        "local_runtime": {
+          "type": "boolean"
+        },
+        "remote_runtime": {
+          "type": "boolean"
+        },
+        "external_research": {
+          "type": "string",
+          "enum": [
+            "forbid",
+            "allow",
+            "require_citations"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/fixtures/contracts/cerberus.crucible_producer_manifest.v1.valid.json
+++ b/fixtures/contracts/cerberus.crucible_producer_manifest.v1.valid.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "cerberus.crucible_producer_manifest.v1",
+  "consumer": "crucible",
+  "request": {
+    "request_id": "req-fixture",
+    "request_digest": "sha256:requestfixture"
+  },
+  "artifact": {
+    "artifact_id": "artifact-fixture",
+    "artifact_uri": "artifact.json",
+    "artifact_digest": "sha256:artifactfixture",
+    "schema_version": "cerberus.review_artifact.v1",
+    "finding_count": 1,
+    "comment_count": 0,
+    "capability_tier": "repo_head",
+    "context_capabilities": {
+      "diff": true,
+      "repo_head": true,
+      "repo_base": false,
+      "local_runtime": false,
+      "remote_runtime": false,
+      "external_research": "forbid"
+    }
+  },
+  "receipt_bundle": {
+    "schema_version": "cerberus.review_receipt_bundle.v1",
+    "receipt_bundle_uri": "receipt-bundle.json",
+    "receipt_bundle_digest": "sha256:receiptfixture",
+    "transcript_uri": "transcript.txt",
+    "execution_plan_uri": "execution_plan.json"
+  },
+  "grader_input": {
+    "format": "cerberus.review_artifact.v1",
+    "artifact_uri": "artifact.json",
+    "findings_path": "findings",
+    "finding_id_path": "findings[].id"
+  },
+  "validation": {
+    "status": "passed",
+    "trusted_for_grading": true
+  },
+  "boundary": {
+    "scorer_owner": "crucible",
+    "includes_score": false,
+    "note": "Cerberus produced the validated review artifact and redacted receipts only; Crucible owns grading."
+  }
+}

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -140,6 +140,7 @@ mod tests {
     use super::*;
     use crate::receipt::{build_review_receipt_bundle, ReceiptBundleInput};
     use crate::schema::{ReviewTelemetry, REVIEW_ARTIFACT_SCHEMA};
+    use serde_json::Value;
 
     #[test]
     fn manifest_points_crucible_at_the_artifact_findings_array() {
@@ -213,6 +214,68 @@ mod tests {
         assert!(!manifest.validation.trusted_for_grading);
     }
 
+    #[test]
+    fn committed_manifest_schema_matches_builder_contract() {
+        let schema: Value = serde_json::from_str(include_str!(
+            "../docs/schemas/cerberus.crucible_producer_manifest.v1.schema.json"
+        ))
+        .unwrap();
+        assert_eq!(
+            schema["properties"]["schema_version"]["const"],
+            CRUCIBLE_PRODUCER_MANIFEST_SCHEMA
+        );
+        assert_schema_requires(
+            &schema,
+            &[
+                "schema_version",
+                "consumer",
+                "request",
+                "artifact",
+                "receipt_bundle",
+                "grader_input",
+                "validation",
+                "boundary",
+            ],
+        );
+
+        let fixture: CrucibleProducerManifest = serde_json::from_str(include_str!(
+            "../fixtures/contracts/cerberus.crucible_producer_manifest.v1.valid.json"
+        ))
+        .unwrap();
+        assert_eq!(fixture.schema_version, CRUCIBLE_PRODUCER_MANIFEST_SCHEMA);
+
+        let manifest = gradeable_manifest();
+        let value = serde_json::to_value(&manifest).unwrap();
+        for path in [
+            "schema_version",
+            "consumer",
+            "request.request_id",
+            "request.request_digest",
+            "artifact.artifact_id",
+            "artifact.artifact_uri",
+            "artifact.artifact_digest",
+            "artifact.schema_version",
+            "artifact.context_capabilities",
+            "receipt_bundle.schema_version",
+            "receipt_bundle.receipt_bundle_uri",
+            "receipt_bundle.receipt_bundle_digest",
+            "grader_input.format",
+            "grader_input.artifact_uri",
+            "grader_input.findings_path",
+            "grader_input.finding_id_path",
+            "validation.status",
+            "validation.trusted_for_grading",
+            "boundary.scorer_owner",
+            "boundary.includes_score",
+            "boundary.note",
+        ] {
+            assert!(
+                value_at_path(&value, path).is_some(),
+                "manifest missing required path {path}: {value}"
+            );
+        }
+    }
+
     fn request() -> ReviewRequest {
         serde_json::from_str(include_str!("../fixtures/requests/diff-only.json")).unwrap()
     }
@@ -223,5 +286,52 @@ mod tests {
             r#"{"diff":true,"repo_head":false,"repo_base":false,"local_runtime":false,"remote_runtime":false,"external_research":"forbid"}"#,
         );
         serde_json::from_str(&raw).unwrap()
+    }
+
+    fn gradeable_manifest() -> CrucibleProducerManifest {
+        let request = request();
+        let artifact = artifact();
+        let telemetry = ReviewTelemetry::default();
+        let bundle = build_review_receipt_bundle(ReceiptBundleInput {
+            request: &request,
+            artifact: &artifact,
+            harness: "fixture",
+            telemetry: &telemetry,
+            transcript: "elapsed_ms: 9",
+            artifact_uri: "target/cerberus/crucible-producer/artifact.json".to_string(),
+            transcript_uri: Some("target/cerberus/crucible-producer/transcript.txt".to_string()),
+            execution_plan_uri: Some(
+                "target/cerberus/crucible-producer/execution_plan.json".to_string(),
+            ),
+            reviewer_plan_uri: None,
+            validation_failed: false,
+        })
+        .unwrap();
+
+        build_crucible_producer_manifest(CrucibleProducerManifestInput {
+            request: &request,
+            artifact: &artifact,
+            receipt_bundle: &bundle,
+            receipt_bundle_uri: "target/cerberus/crucible-producer/receipt-bundle.json".to_string(),
+        })
+        .unwrap()
+    }
+
+    fn assert_schema_requires(schema: &Value, fields: &[&str]) {
+        let required = schema["required"].as_array().unwrap();
+        for field in fields {
+            assert!(
+                required.iter().any(|required| required == field),
+                "schema required list missing {field}: {schema}"
+            );
+        }
+    }
+
+    fn value_at_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+        let mut current = value;
+        for segment in path.split('.') {
+            current = current.get(segment)?;
+        }
+        Some(current)
     }
 }


### PR DESCRIPTION
## Summary
- Add the producer-owned `cerberus.crucible_producer_manifest.v1` JSON Schema under `docs/schemas/`.
- Add a valid producer manifest fixture for consumers to pin.
- Add a producer-side contract test that checks schema-required fields and generated manifest compatibility.

## Verification
- `cargo test committed_manifest_schema_matches_builder_contract`
- `./scripts/verify.sh`

## Agent
- Agent: Codex
- Agent-Surface: Codex CLI
- Agent-Model: GPT-5
- Agent-Task: seam-contracts factory lane