### PR TITLE
test: pin the untested safety guards (008)

### DIFF
--- a/backlog.d/008-pin-untested-safety-guards.md
+++ b/backlog.d/008-pin-untested-safety-guards.md
@@ -1,15 +1,17 @@
 # Pin the untested safety guards with regression tests
 
-Priority: P1 · Status: pending · Estimate: M
+Priority: P1 · Status: oracle satisfied 2026-07-02, child 5 deferred (operator decision) · Estimate: M
 
 ## Goal
 Every spec falsifier and safety footgun is pinned by a test that fails if the guard is removed — closing the gaps where a silent regression currently passes green.
 
 ## Oracle
-- [ ] A test spawns a child that outlives its timeout and asserts status `"timeout"` AND that the grandchild process is dead (exercises `kill_process_tree`/`setpgid`, `harness.rs:871,883` — currently zero coverage).
-- [ ] Bounded-output is proven on the production path `read_capped_file` (`harness.rs:918`), not the `#[cfg(test)]` reimplementation `cap_bytes` (`:899`); the >64MB truncation branch executes in a test.
-- [ ] `external_research = RequireCitations` enforcement (`validation.rs:178-184`) has a test that fails without it.
-- [ ] Each `validate_request` reject branch (`validation.rs:65-92`), including `DiffDigestMismatch`, has a test.
+- [x] A test spawns a child that outlives its timeout and asserts status `"timeout"` AND that the grandchild process is dead — `harness::tests::timeout_kills_the_whole_process_group_not_just_the_direct_child`. SIGKILL can't be trapped, so it uses a pid-file (grandchild backgrounds `sleep 30`, writes its own pid, gets checked via `kill(pid, 0)` after the timeout fires) rather than a trap handler. Mutation-verified: temporarily reverted `kill_process_tree` to `child.kill()` only, confirmed the test fails with the grandchild pid still alive, then restored.
+- [x] Bounded-output is proven on the production path `read_capped_file` directly (no `cap_bytes` reimplementation exists in the codebase today — already gone before this ticket) — `harness::tests::read_capped_file_truncates_the_middle_of_oversized_output` writes a real 65MB file with distinguishable head/tail markers and asserts the truncation-marker branch executes and the result never exceeds `OUTPUT_CAPTURE_CAP`.
+- [x] `external_research = RequireCitations` enforcement has two tests: `rejects_finding_without_citation_when_policy_requires_one` and `accepts_finding_with_citation_when_policy_requires_one`.
+- [x] Every `validate_request` reject branch, including `DiffDigestMismatch`, is covered by one table-driven test (`validate_request_rejects_each_known_violation`, 8 cases, one per `ValidationError` variant `validate_request` can return) — replaces the two narrower pre-existing tests it subsumes.
+
+Child 5 ("(Defense-in-depth) warn/deny when `--allow-env` forwards `GH_TOKEN`/`AWS_*`/`*_API_KEY`") was explicitly bracketed as defense-in-depth and is not in the oracle above; it also requires an operator judgment call (warn vs. deny, exact pattern list) rather than pure test-writing, so it's left unstarted per the overnight contract's "skip operator-decision items, note them" rule.
 
 ## Verification System
 - Claim: removing any safety/validation guard breaks at least one test.

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1465,6 +1465,99 @@ mod tests {
         assert_eq!(output.stdout.len(), 200000);
     }
 
+    // Backlog 008: bounded output was previously proven only by a
+    // #[cfg(test)]-only reimplementation of the cap logic, never the
+    // production read_capped_file path. Drives real bytes past the cap
+    // through the actual function so a regression (e.g. someone "simplifies"
+    // away the truncation branch) fails a test, not just a code review.
+    #[test]
+    fn read_capped_file_truncates_the_middle_of_oversized_output() {
+        use std::io::Write;
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let head_marker = b"HEAD_MARKER_BEGIN";
+        let tail_marker = b"TAIL_MARKER_END";
+        let total_len = OUTPUT_CAPTURE_CAP + 1_000_000;
+        {
+            let mut writer = std::io::BufWriter::new(file.reopen().unwrap());
+            writer.write_all(head_marker).unwrap();
+            let filler_len = total_len - head_marker.len() - tail_marker.len();
+            writer.write_all(&vec![b'x'; filler_len]).unwrap();
+            writer.write_all(tail_marker).unwrap();
+            writer.flush().unwrap();
+        }
+
+        let bytes = read_capped_file(file.path()).unwrap();
+
+        assert_eq!(
+            bytes.len(),
+            OUTPUT_CAPTURE_CAP,
+            "capped output must never exceed the cap regardless of input size"
+        );
+        assert!(
+            bytes.starts_with(head_marker),
+            "the head of the output must survive truncation"
+        );
+        assert!(
+            bytes.ends_with(tail_marker),
+            "the tail of the output must survive truncation"
+        );
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(
+            text.contains("[cerberus truncated middle]"),
+            "truncation must be visible in the captured output, not silent"
+        );
+    }
+
+    // Backlog 008: the orphan-kill machinery (setpgid at spawn + kill(-pid)
+    // on timeout) had zero coverage — a silent regression here leaves a
+    // credential-holding grandchild process running unbounded after Cerberus
+    // reports done, violating VISION's "no orphan children" non-negotiable.
+    //
+    // SIGKILL cannot be trapped/caught by a handler (that's the point of it),
+    // so a trap-based marker doesn't work here. Instead: the direct child
+    // backgrounds a grandchild (`sleep 30`) and writes its pid to a file.
+    // kill_process_tree sends SIGKILL to the whole *process group*
+    // (`libc::kill(-pid, ...)`), and a plain, non-interactive `sh -c` script
+    // does not put background jobs in their own group, so the grandchild
+    // inherits the group `configure_process_group` set up for the direct
+    // child. If a regression narrowed the kill back down to just the direct
+    // child's pid, the grandchild would survive as a live orphan.
+    #[cfg(unix)]
+    #[test]
+    fn timeout_kills_the_whole_process_group_not_just_the_direct_child() {
+        let pidfile = tempfile::NamedTempFile::new().unwrap();
+        let pidfile_path = pidfile.path().to_path_buf();
+
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            &format!("sleep 30 & echo $! > {}; wait", pidfile_path.display()),
+        ]);
+        configure_process_group(&mut command);
+
+        let output = run_with_timeout(command, Duration::from_millis(500)).unwrap();
+        assert_eq!(output.status, "timeout");
+
+        // Give the OS a moment to finish delivering the signal.
+        std::thread::sleep(Duration::from_millis(200));
+
+        let grandchild_pid: libc::pid_t = std::fs::read_to_string(&pidfile_path)
+            .unwrap()
+            .trim()
+            .parse()
+            .expect("grandchild pid file should contain a pid before the timeout fires");
+        // SAFETY: signal 0 sends nothing; it only probes whether the pid is
+        // alive and signalable, which is safe on any pid value.
+        let still_alive = unsafe { libc::kill(grandchild_pid, 0) == 0 };
+        assert!(
+            !still_alive,
+            "grandchild (sleep) pid {grandchild_pid} survived the timeout — \
+             kill_process_tree/setpgid did not kill the whole process group, \
+             only the direct shell child"
+        );
+    }
+
     fn minimal_artifact_json() -> String {
         serde_json::json!({
             "schema_version": "cerberus.review_artifact.v1",

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -343,36 +343,99 @@ mod tests {
         validate_artifact_for_request(&artifact_for(&request), &request).unwrap();
     }
 
+    // Backlog 008: validate_request can return 8 distinct ValidationError
+    // variants, but only 2 (LocalRuntimeRequiresPolicy,
+    // BaseWorkspaceRequiresHead) had a test driving them. One table, one
+    // case per variant, so adding a new validate_request check without a
+    // matching case is an easy diff to spot in review.
     #[test]
-    fn rejects_local_runtime_without_policy() {
-        let mut request = request();
-        request.context.local_runtime.push(RuntimeTarget {
-            kind: "command".to_string(),
-            command: "true".to_string(),
-            args: Vec::new(),
-            cwd: None,
-        });
+    fn validate_request_rejects_each_known_violation() {
+        struct Case {
+            name: &'static str,
+            mutate: fn(&mut ReviewRequest),
+            matches: fn(&ValidationError) -> bool,
+        }
 
-        assert!(matches!(
-            validate_request(&request),
-            Err(ValidationError::LocalRuntimeRequiresPolicy)
-        ));
-    }
+        let cases: &[Case] = &[
+            Case {
+                name: "unsupported request schema",
+                mutate: |r| r.schema_version = "cerberus.review_request.v999".to_string(),
+                matches: |e| {
+                    matches!(
+                        e,
+                        ValidationError::UnsupportedRequestSchema(v)
+                            if v == "cerberus.review_request.v999"
+                    )
+                },
+            },
+            Case {
+                name: "missing request id",
+                mutate: |r| r.request_id = "   ".to_string(),
+                matches: |e| matches!(e, ValidationError::MissingRequestId),
+            },
+            Case {
+                name: "missing title",
+                mutate: |r| r.change.title = "   ".to_string(),
+                matches: |e| matches!(e, ValidationError::MissingTitle),
+            },
+            Case {
+                name: "unsupported diff format",
+                mutate: |r| r.change.diff.format = "context".to_string(),
+                matches: |e| matches!(e, ValidationError::UnsupportedDiffFormat(f) if f == "context"),
+            },
+            Case {
+                name: "missing diff body",
+                mutate: |r| r.change.diff.body = "   ".to_string(),
+                matches: |e| matches!(e, ValidationError::MissingDiff),
+            },
+            Case {
+                name: "diff digest mismatch",
+                mutate: |r| r.change.diff.digest = Some("sha256:wrong".to_string()),
+                matches: |e| {
+                    matches!(
+                        e,
+                        ValidationError::DiffDigestMismatch { actual, .. }
+                            if actual == "sha256:wrong"
+                    )
+                },
+            },
+            Case {
+                name: "local runtime without policy",
+                mutate: |r| {
+                    r.context.local_runtime.push(RuntimeTarget {
+                        kind: "command".to_string(),
+                        command: "true".to_string(),
+                        args: Vec::new(),
+                        cwd: None,
+                    })
+                },
+                matches: |e| matches!(e, ValidationError::LocalRuntimeRequiresPolicy),
+            },
+            Case {
+                name: "base workspace without head workspace",
+                mutate: |r| {
+                    r.context.workspaces.base = Some(WorkspaceRef {
+                        kind: WorkspaceKind::Checkout,
+                        path: "/tmp/base".to_string(),
+                        ref_name: Some("main".to_string()),
+                        sha: Some("abc123".to_string()),
+                    })
+                },
+                matches: |e| matches!(e, ValidationError::BaseWorkspaceRequiresHead),
+            },
+        ];
 
-    #[test]
-    fn rejects_base_workspace_without_head_workspace() {
-        let mut request = request();
-        request.context.workspaces.base = Some(WorkspaceRef {
-            kind: WorkspaceKind::Checkout,
-            path: "/tmp/base".to_string(),
-            ref_name: Some("main".to_string()),
-            sha: Some("abc123".to_string()),
-        });
-
-        assert!(matches!(
-            validate_request(&request),
-            Err(ValidationError::BaseWorkspaceRequiresHead)
-        ));
+        for case in cases {
+            let mut mutated = request();
+            (case.mutate)(&mut mutated);
+            let err = validate_request(&mutated)
+                .expect_err(&format!("case {:?} should have been rejected", case.name));
+            assert!(
+                (case.matches)(&err),
+                "case {:?}: unexpected error {err:?}",
+                case.name
+            );
+        }
     }
 
     #[test]
@@ -498,6 +561,65 @@ mod tests {
                 suggested_fix_id,
             }) if scope == "finding f-1" && suggested_fix_id == "missing-fix"
         ));
+    }
+
+    // Backlog 008: RequireCitations was a policy the schema and validator
+    // both modeled, but nothing ever drove it through validate_artifact_for_request
+    // in a test — a regression here would let an uncited external-research
+    // finding through silently.
+    #[test]
+    fn rejects_finding_without_citation_when_policy_requires_one() {
+        let mut request = request();
+        request.policy.external_research = ExternalResearchPolicy::RequireCitations;
+        let mut artifact = artifact_for(&request);
+        artifact.findings.push(Finding {
+            id: "f-1".to_string(),
+            severity: Severity::Major,
+            category: "correctness".to_string(),
+            title: "uncited external-research finding".to_string(),
+            description: "claims something from outside the diff".to_string(),
+            evidence: "no citation attached".to_string(),
+            confidence: 0.6,
+            anchors: vec![inline_anchor()],
+            citations: Vec::new(),
+            suggested_fixes: Vec::new(),
+        });
+
+        assert!(matches!(
+            validate_artifact_for_request(&artifact, &request),
+            Err(ValidationError::ExternalResearchMissingCitation(id)) if id == "f-1"
+        ));
+    }
+
+    #[test]
+    fn accepts_finding_with_citation_when_policy_requires_one() {
+        let mut request = request();
+        request.policy.external_research = ExternalResearchPolicy::RequireCitations;
+        let mut artifact = artifact_for(&request);
+        artifact.findings.push(Finding {
+            id: "f-1".to_string(),
+            severity: Severity::Major,
+            category: "correctness".to_string(),
+            title: "cited external-research finding".to_string(),
+            description: "claims something from outside the diff".to_string(),
+            evidence: "backed by a citation".to_string(),
+            confidence: 0.6,
+            anchors: vec![inline_anchor()],
+            citations: vec!["c-1".to_string()],
+            suggested_fixes: Vec::new(),
+        });
+        artifact.citations.push(Citation {
+            id: "c-1".to_string(),
+            kind: CitationKind::Doc,
+            title: Some("relevant doc".to_string()),
+            uri: None,
+            observed_at: None,
+            digest: None,
+            excerpt: None,
+            used_by: vec!["f-1".to_string()],
+        });
+
+        validate_artifact_for_request(&artifact, &request).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Backlog 008 (P1, "pin the untested safety guards with regression tests"). All 4 oracle items:

1. **Orphan-child-kill test**: `harness::tests::timeout_kills_the_whole_process_group_not_just_the_direct_child`. SIGKILL can't be trapped by a handler, so this uses a pid-file approach instead of the trap-marker design I initially tried: the direct child backgrounds a grandchild (`sleep 30`), writes its own pid to a file, and after the timeout fires the test checks `kill(pid, 0)` to prove the whole process group — not just the direct child — actually died. **Mutation-verified**: temporarily narrowed `kill_process_tree` to `child.kill()` only, confirmed the test fails with the grandchild pid still alive, then restored the real guard.
2. **Bounded-output on the production path**: `harness::tests::read_capped_file_truncates_the_middle_of_oversized_output` writes a real 65MB file with distinguishable head/tail markers and drives it through the actual `read_capped_file` (no separate `#[cfg(test)]` `cap_bytes` reimplementation exists in the codebase — already gone before this ticket).
3. **`RequireCitations` enforcement**: `rejects_finding_without_citation_when_policy_requires_one` + `accepts_finding_with_citation_when_policy_requires_one`.
4. **Table-driven `validate_request` rejection tests**: `validate_request_rejects_each_known_violation`, 8 cases covering every `ValidationError` variant `validate_request` can return (including `DiffDigestMismatch`), replacing the 2 narrower pre-existing tests it subsumes.

Child 5 (warn/deny on `--allow-env` forwarding `GH_TOKEN`/`AWS_*`/`*_API_KEY`) is explicitly bracketed as defense-in-depth in the ticket and isn't in its oracle; it also needs an operator call (warn vs. deny, exact pattern list) rather than pure test-writing — left unstarted, ticket stays in `backlog.d/` (not moved to `_done/`), matching how 013's M3 was left.

## Test plan
- [x] `cargo test --locked` green (125 tests)
- [x] `./scripts/verify.sh` green
- [x] Mutation-survival check on the orphan-kill guard (see above) — the new test genuinely fails without the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)