### PR TITLE
docs(backlog): 024 oracle re-verified against live code, not moved to _done

### DIFF
--- a/backlog.d/024-orchestrator-master-agent-evolution.md
+++ b/backlog.d/024-orchestrator-master-agent-evolution.md
@@ -1,6 +1,6 @@
 # Evolve Cerberus into an orchestrator master agent
 
-Priority: P1 | Status: active | Estimate: L | Factory epic: 3
+Priority: P1 | Status: active — machinery built, not wired to a live caller (see 2026-07-02 verification note) | Estimate: L | Factory epic: 3
 
 ## Goal
 
@@ -12,19 +12,41 @@ pushed anywhere.
 
 ## Oracle
 
-- [ ] Every review run has an explicit diff-understanding stage that summarizes
+- [x] Every review run has an explicit diff-understanding stage that summarizes
       changed surfaces, risk shape, available context, and what was skipped.
+      Holds: `build_reviewer_plan` runs unconditionally inside
+      `ReviewKernel::review` (`kernel.rs:77`) on every real review.
 - [ ] The master emits a reviewer-team plan when it chooses lanes: scope,
       allowed context tier, model/substrate choice, cost budget, stop condition,
       and expected output shape.
+      **Does not hold end-to-end.** The plan schema/fields exist and are
+      written every run, but nothing lets the master *model* actually choose
+      lanes at runtime: `build_master_prompt` never instructs the model on how
+      to launch a lane (its only lane-related line is passive — "if lane
+      evidence is attached, use it as evidence"), `mcp.rs` exposes no
+      lane-launch tool, and `launch_planned_child_lanes`/
+      `ReviewerLaneSubstrate` have zero callers outside their own unit tests.
+      `lane_decision` is always `single_master` in practice today.
 - [ ] Lane evidence is captured as receipts and synthesized into a single
       validated `ReviewArtifact.v1`; child-lane claims cannot bypass artifact
       validation.
-- [ ] A cheap review still runs as a single master when the diff does not justify
+      **Proven only in unit tests, not live.** `synthesize_lane_receipts_into_artifact`
+      doesn't itself call `validate_artifact_for_request`; tests call validation
+      afterward on the same object, proving no bypass *in test*. Since the
+      function has no live caller (same gap as above), this has never run
+      through the real `harness.rs`/`main.rs` validation call sites end-to-end.
+- [x] A cheap review still runs as a single master when the diff does not justify
       lanes. Dynamic composition must reduce to the simple path.
+      Holds: `verify.sh` asserts `lane_decision.mode == "single_master"` and
+      zero child lanes on the fixture path.
 - [ ] `./scripts/verify.sh` covers the fixture path for no-lane and with-lane
       runs; one live local diff run leaves a receipt packet proving the stage
       boundaries.
+      **Does not hold.** `verify.sh` only exercises the no-lane fixture path —
+      no with-lane (or fabricated-lane-receipt) case, and no live model call
+      anywhere in the gate (every `--harness opencode` invocation pins the fake
+      binary), so no live receipt packet demonstrating the stage boundaries
+      exists today.
 
 ## Children
 
@@ -50,9 +72,31 @@ pushed anywhere.
    a no-op, arbitrary completed lane roles as generic reviewer receipts with the
    dynamic role preserved as `perspective`, and failed lanes as degraded
    artifacts with copied lane errors and residual risk.
+5. **Not started — the actual "master chooses lanes at runtime" wiring.**
+   Children 1-4 built the plan/launch/synthesis *machinery* and pinned it with
+   unit + fixture tests, but nothing on the model-facing surface can trigger
+   it: no prompt instruction tells the master how to request a lane, no MCP
+   tool exposes lane-launching, and `launch_planned_child_lanes`/
+   `synthesize_lane_receipts_into_artifact` have zero callers outside their
+   own tests. This is a real design decision (does the model request a lane
+   via a new MCP tool call? via a structured field in its own output that
+   Rust then acts on and re-invokes the model? something else?) — not a
+   quick mechanical follow-up, which is why it's left for explicit scoping
+   rather than picked up opportunistically. Also needs a with-lane (or
+   fabricated-lane-receipt) case in `verify.sh` and one live receipt packet
+   from a real diff run once the wiring exists.
 
 ## Notes
 
 This epic is intentionally downstream of `022` and `023`. The orchestration
 surface should not land before the documented single-master path and the
 dimension vocabulary are stable enough to measure.
+
+**2026-07-02 verification note (overnight backlog-hygiene pass):** children
+1-4's PRs (#490-492) are real and correctly described, but the ticket's own
+oracle was re-checked against live code (not just "children marked Done") and
+3 of 5 bullets don't hold end-to-end — see the inline oracle notes above.
+Verdict: **do not move to `_done/`**. The plan/receipt/synthesis *scaffolding*
+is solid and well-tested; the "master reviewer dynamically composes a team"
+behavior the epic's Goal describes does not exist yet from the model's
+perspective. Added child 5 to name the gap explicitly.


### PR DESCRIPTION
## Summary
Backlog hygiene task: confirm 024's oracle genuinely holds against live code (all 4 children are marked Done via PRs #490-492) before archiving it to `backlog.d/_done/`.

Re-checked each of the 5 oracle bullets independently rather than trusting the "children marked Done" status. Result: **2 of 5 hold, 3 do not hold end-to-end**. The plan/receipt/synthesis machinery from children 1-4 is real and well-tested, but nothing on the model-facing surface can actually trigger a lane launch today — no prompt instruction, no MCP tool, and the two key functions (`launch_planned_child_lanes`, `synthesize_lane_receipts_into_artifact`) have zero callers outside their own unit tests. `lane_decision` is always `single_master` in practice.

**Not moved to `_done/`.** Added child 5 naming the gap explicitly and noting it's a real design decision (how should the model request a lane — new MCP tool? structured output field Rust acts on?) rather than a quick mechanical follow-up, so it needs its own scoping.

## Test plan
- [x] `./scripts/verify.sh` green (docs-only change, ran the gate anyway per house rule)
- [x] Verification performed via direct code inspection (kernel.rs, orchestration.rs, prompt.rs, mcp.rs, verify.sh) rather than trusting PR descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)