### PR TITLE
refactor(harness): remove dead empty-diff cwd fallback (017)

### DIFF
--- a/backlog.d/_done/017-remove-dead-empty-diff-cwd-fallback.md
+++ b/backlog.d/_done/017-remove-dead-empty-diff-cwd-fallback.md
@@ -1,6 +1,6 @@
 # Remove the dead empty-diff fallback workspace and its cwd plumbing
 
-Priority: P3 · Status: pending · Estimate: S
+Priority: P3 · Status: done (2026-07-02) · Estimate: S
 
 ## Goal
 Delete the `fallback_empty_diff` workspace branch (and the `cwd`/`RunPolicy.cwd`/`--cwd` plumbing that exists only to feed it) so the review harness can never write `review-artifact.json` into a real checkout.
@@ -13,9 +13,9 @@ Backlog 016 moved emission to a file the agent writes inside `workspace.path()`.
 - Keep `--cwd` only if a real consumer needs it; otherwise delete it with the rest.
 
 ## Oracle
-- [ ] The empty-diff case routes to a private temp dir (or is rejected outright), never the real cwd; a unit test calling the kernel directly with an empty diff proves no file lands outside a tempdir.
-- [ ] `fallback_cwd` / `RunPolicy.cwd` / `--cwd` are removed if they have no other consumer (or a stated reason to keep each).
-- [ ] `./scripts/verify.sh` green; no behavior change for diff-bearing requests.
+- [x] The empty-diff case routes to a private temp dir, never the real cwd. `RunWorkspace::prepare` now always uses the `packet` tempdir it already creates for any diff-only request; the empty-diff case just gets a distinct `workspace_mode` label (`empty_diff_packet`) for observability. `harness::tests::empty_diff_request_still_resolves_to_a_private_tempdir_workspace` calls `RunWorkspace::prepare` directly with an empty diff and asserts the resolved path lives under the tempdir. Mutation-verified: temporarily made the empty-diff branch return `/tmp` directly, confirmed the test fails, restored.
+- [x] `fallback_cwd` / `RunPolicy.cwd` / `--cwd` removed — no other consumer existed. Removed `fallback_cwd` param from `RunWorkspace::prepare`, `cwd` param from `run_fixture_substrate`/`run_command_substrate`, `RunPolicy.cwd` field, and the `--cwd` flag from `review`/`review-pr` (it had zero effect on real non-empty-diff behavior even before this change — `ExecutionPlan.cwd` was always `workspace.path()`, never the flag's value). Also renamed the now-accurately-named `with_packet` helper (was `with_packet_or_fallback`).
+- [x] `./scripts/verify.sh` green; no behavior change for diff-bearing requests — confirmed, full suite + gate pass unchanged.
 
 ## Notes
 Surfaced by the 016 diverse-provider review (fresh-context critic, non-blocking). Fail-closed today, so this is hardening + a small deletion, not a bug fix.

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -82,7 +82,6 @@ pub(crate) struct HarnessRun {
 
 pub(crate) fn run_fixture_substrate(
     request: &ReviewRequest,
-    cwd: &Path,
     timeout: Duration,
     config: &FixtureSubstrateConfig,
 ) -> Result<HarnessRun> {
@@ -95,7 +94,7 @@ pub(crate) fn run_fixture_substrate(
         .prefix("cerberus-fixture-")
         .tempdir()
         .context("create private fixture tempdir")?;
-    let workspace = RunWorkspace::prepare(request, cwd, temp.path())?;
+    let workspace = RunWorkspace::prepare(request, temp.path())?;
     let mut child_request = request_with_workspace_paths(request, &workspace);
     let runtime_receipts =
         run_local_runtime_probes(&mut child_request, &workspace, temp.path(), timeout)?;
@@ -146,7 +145,6 @@ pub(crate) enum CommandSubstrateConfig<'a> {
 pub(crate) fn run_command_substrate(
     substrate: CommandSubstrateConfig<'_>,
     request: &ReviewRequest,
-    cwd: &Path,
     timeout: Duration,
     failure_transcript: Option<&Path>,
 ) -> Result<HarnessRun> {
@@ -165,7 +163,7 @@ pub(crate) fn run_command_substrate(
             .with_context(|| format!("create child state dir {}", child_state_dir.display()))?;
         set_private_directory_permissions(child_state_dir)?;
     }
-    let workspace = RunWorkspace::prepare(request, cwd, temp.path())?;
+    let workspace = RunWorkspace::prepare(request, temp.path())?;
     let mut child_request = request_with_workspace_paths(request, &workspace);
     let runtime_receipts =
         run_local_runtime_probes(&mut child_request, &workspace, temp.path(), timeout)?;
@@ -550,7 +548,7 @@ struct WorktreeCleanup {
 }
 
 impl RunWorkspace {
-    fn prepare(request: &ReviewRequest, fallback_cwd: &Path, temp_root: &Path) -> Result<Self> {
+    fn prepare(request: &ReviewRequest, temp_root: &Path) -> Result<Self> {
         if let Some(head) = &request.context.workspaces.head {
             let base = request
                 .context
@@ -594,21 +592,17 @@ impl RunWorkspace {
         set_private_permissions(&request_path)?;
         set_private_permissions(&diff_path)?;
 
-        if request.change.diff.body.trim().is_empty() {
-            // Degenerate path: an empty diff has nothing to review. The agent now
-            // emits its artifact into the workspace, so this fallback would write
-            // review-artifact.json into the real cwd. That is gated shut today —
-            // validate_request rejects an empty diff before any binary reaches the
-            // kernel — so it is unreachable in practice; only a library caller that
-            // skips validation could hit it. Removing the dead fallback/cwd
-            // plumbing is tracked in backlog 017.
-            Ok(Self::with_packet_or_fallback(
-                fallback_cwd.to_path_buf(),
-                "fallback_empty_diff",
-            ))
+        // An empty diff has nothing to review; validate_request rejects it before
+        // any binary reaches the kernel, so a real CLI run never hits this. Only a
+        // library caller that skips validation could — and even then it gets the
+        // same private packet dir as any other diff-only run, never a real cwd
+        // (backlog 017).
+        let mode = if request.change.diff.body.trim().is_empty() {
+            "empty_diff_packet"
         } else {
-            Ok(Self::with_packet_or_fallback(packet, "diff_packet"))
-        }
+            "diff_packet"
+        };
+        Ok(Self::with_packet(packet, mode))
     }
 
     fn prepare_worktree(
@@ -668,7 +662,7 @@ impl RunWorkspace {
         }
     }
 
-    fn with_packet_or_fallback(path: PathBuf, mode: &str) -> Self {
+    fn with_packet(path: PathBuf, mode: &str) -> Self {
         Self {
             path,
             base_path: None,
@@ -1222,6 +1216,34 @@ mod tests {
             "policy": {}
         }))
         .unwrap()
+    }
+
+    // Backlog 017: an empty diff has nothing to review and validate_request
+    // rejects it before any real CLI path reaches the kernel -- but a library
+    // caller of ReviewKernel::review that skips validation could still hit
+    // this. Before this ticket, that case resolved the workspace to the
+    // caller's real cwd; since file emission writes review-artifact.json
+    // straight into the resolved workspace, that would have dropped the file
+    // into a real checkout. Pins that it now always resolves under the
+    // private per-run tempdir, the same as any other diff-only request.
+    #[test]
+    fn empty_diff_request_still_resolves_to_a_private_tempdir_workspace() {
+        let mut request = test_request();
+        request.change.diff.body = String::new();
+        let temp = tempfile::Builder::new()
+            .prefix("cerberus-empty-diff-test-")
+            .tempdir()
+            .unwrap();
+
+        let workspace = RunWorkspace::prepare(&request, temp.path()).unwrap();
+
+        assert!(
+            workspace.path().starts_with(temp.path()),
+            "empty-diff workspace {} must live under the private tempdir {}, never a real caller cwd",
+            workspace.path().display(),
+            temp.path().display()
+        );
+        assert_eq!(workspace.mode, "empty_diff_packet");
     }
 
     #[test]

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -26,7 +26,6 @@ pub enum ReviewSubstrate {
 
 #[derive(Debug, Clone)]
 pub struct RunPolicy {
-    pub cwd: PathBuf,
     pub timeout: Duration,
     pub failure_transcript: Option<PathBuf>,
 }
@@ -54,19 +53,17 @@ impl ReviewKernel {
     pub fn review(&self, request: &ReviewRequest, run_policy: &RunPolicy) -> Result<ReviewRun> {
         let run = match &self.substrate {
             ReviewSubstrate::Fixture(config) => {
-                run_fixture_substrate(request, &run_policy.cwd, run_policy.timeout, config)?
+                run_fixture_substrate(request, run_policy.timeout, config)?
             }
             ReviewSubstrate::Opencode(config) => run_command_substrate(
                 CommandSubstrateConfig::Opencode(config),
                 request,
-                &run_policy.cwd,
                 run_policy.timeout,
                 run_policy.failure_transcript.as_deref(),
             )?,
             ReviewSubstrate::Omp(config) => run_command_substrate(
                 CommandSubstrateConfig::Omp(config),
                 request,
-                &run_policy.cwd,
                 run_policy.timeout,
                 run_policy.failure_transcript.as_deref(),
             )?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,10 +314,6 @@ struct ReviewArgs {
     substrate: SubstrateArgs,
     #[command(flatten)]
     scoped_key: ScopedKeyArgs,
-    /// Working directory for a diff-only request's disposable packet
-    /// workspace. Defaults to the current directory.
-    #[arg(long)]
-    cwd: Option<PathBuf>,
     /// Wall-clock budget for the review, in seconds. Defaults to the
     /// request's own `policy.timeout_ms`.
     #[arg(long)]
@@ -427,10 +423,6 @@ struct ReviewPrArgs {
     substrate: SubstrateArgs,
     #[command(flatten)]
     scoped_key: ScopedKeyArgs,
-    /// Working directory for a diff-only request's disposable packet
-    /// workspace. Defaults to the current directory.
-    #[arg(long)]
-    cwd: Option<PathBuf>,
     /// Write a redacted ReviewReceiptBundle.v1 here instead of the default
     /// `<out-dir>/receipt-bundle.json`.
     #[arg(long)]
@@ -667,7 +659,6 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
         markdown,
         substrate,
         scoped_key,
-        cwd,
         timeout_seconds,
         execution_plan,
         transcript,
@@ -693,7 +684,6 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
     let _scoped_key_guard =
         mint_scoped_openrouter_key(scoped_key_client.as_ref(), &mut request, &scoped_key)?;
     validate_request(&request)?;
-    let cwd = cwd.unwrap_or(std::env::current_dir().context("read current directory")?);
     let transcript_path = transcript.or_else(|| {
         receipt_bundle
             .as_ref()
@@ -706,7 +696,6 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
     require_child_env_for_substrate(&request, &substrate)?;
     let kernel = ReviewKernel::new(substrate);
     let run_policy = RunPolicy {
-        cwd,
         timeout,
         failure_transcript: transcript_path.clone(),
     };
@@ -902,12 +891,10 @@ fn review_diff(args: ReviewDiffArgs) -> Result<ExitCode> {
     let _scoped_key_guard =
         mint_scoped_openrouter_key(scoped_key_client.as_ref(), &mut request, &args.scoped_key)?;
     validate_request(&request)?;
-    let cwd = std::env::current_dir().context("read current directory")?;
     let substrate = review_substrate(args.substrate)?;
     require_child_env_for_substrate(&request, &substrate)?;
     let kernel = ReviewKernel::new(substrate);
     let run_policy = RunPolicy {
-        cwd,
         timeout: Duration::from_millis(request.policy.timeout_ms),
         failure_transcript: None,
     };
@@ -985,14 +972,10 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
         &head_sha,
     )?;
 
-    let cwd = args
-        .cwd
-        .unwrap_or(std::env::current_dir().context("read current directory")?);
     let substrate = review_substrate(args.substrate)?;
     require_child_env_for_substrate(&request, &substrate)?;
     let kernel = ReviewKernel::new(substrate);
     let run_policy = RunPolicy {
-        cwd,
         timeout: Duration::from_millis(request.policy.timeout_ms),
         failure_transcript: Some(transcript_path.clone()),
     };

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -225,7 +225,6 @@ fn review_git_range(arguments: Value) -> Result<Value> {
 
     let kernel = ReviewKernel::new(substrate);
     let run_policy = RunPolicy {
-        cwd: std::env::current_dir().context("read current directory")?,
         timeout: Duration::from_millis(request.policy.timeout_ms),
         failure_transcript: None,
     };

--- a/tests/review_kernel.rs
+++ b/tests/review_kernel.rs
@@ -11,7 +11,6 @@ fn kernel_review_runs_fixture_through_small_typed_boundary() {
         "fixtures/harness/valid-review.txt",
     )));
     let policy = RunPolicy {
-        cwd: PathBuf::from("."),
         timeout: Duration::from_secs(5),
         failure_transcript: None,
     };


### PR DESCRIPTION
## Summary
Backlog 017 (P3, "remove the dead empty-diff fallback workspace and its cwd plumbing").

`RunWorkspace::prepare`'s empty-diff branch resolved the review workspace to the caller's real `cwd` instead of the private packet tempdir every other diff-only request gets. Since file emission writes `review-artifact.json` straight into the resolved workspace (backlog 016), that would have dropped the artifact into a real checkout. Unreachable from any CLI path today (`validate_request` rejects an empty diff before the kernel runs), but a latent footgun for any library caller of `ReviewKernel::review` that skips validation.

**Fix**: the empty-diff case now gets the same packet tempdir as any other diff-only request, just a distinct `workspace_mode` label (`empty_diff_packet`) for observability. Removed the `cwd`/`fallback_cwd` plumbing that existed only to feed the dead branch: `RunPolicy.cwd`, the `--cwd` flag on `review`/`review-pr`, and the `cwd` params on `run_fixture_substrate`/`run_command_substrate`/`RunWorkspace::prepare`. `--cwd` had zero effect on real non-empty-diff behavior even before this change — `ExecutionPlan.cwd` was always `workspace.path()`, never the flag's value.

## Test plan
- [x] New test `empty_diff_request_still_resolves_to_a_private_tempdir_workspace` drives `RunWorkspace::prepare` directly with an empty diff and asserts the resolved path lives under the tempdir
- [x] Mutation-verified: temporarily made the branch return `/tmp` directly, confirmed the test fails, restored
- [x] `cargo test --locked` green, no behavior change for diff-bearing requests
- [x] `./scripts/verify.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)