### PR TITLE
fix(harness): deny webfetch/websearch when external_research is Forbid (007)

### DIFF
--- a/backlog.d/007-citation-anchor-resolution.md
+++ b/backlog.d/007-citation-anchor-resolution.md
@@ -1,6 +1,6 @@
 # Verify citation & anchor resolution (cheap deterministic oracle)
 
-Priority: P2 · Status: pending · Estimate: S
+Priority: P2 · Status: item 3 fixed 2026-07-02 (was NOT already done, ticket's own claim was stale); items 1-2 need scoping · Estimate: S (items 1-2 are actually M+, see note)
 
 ## Goal
 Reject confabulated or stale citations cheaply: every cited anchor/citation must resolve to real content — without Rust pretending to judge whether a finding is *faithful* (that's evals; see 015).
@@ -12,8 +12,37 @@ Reject confabulated or stale citations cheaply: every cited anchor/citation must
 ## Oracle
 - [ ] Inline/file anchor path is in the change (already enforced); extend to: the line number is in range for the cited file when the workspace is available (repo_head+).
 - [ ] When an anchor carries `hunk_digest` or a citation carries `excerpt`/`digest`, it matches the actual bytes at that location; a fabricated/stale quote fails validation.
-- [ ] (dogfound, PR #466) the substrate honors `policy.external_research`: web tools are not granted when `external_research == Forbid`, so granted capability matches the declared tier.
+- [x] The substrate honors `policy.external_research`: web tools are not granted when `external_research == Forbid`, so granted capability matches the declared tier. **The ticket's "(dogfound, PR #466)" annotation was wrong/stale — PR #466 is "Deliver self-review tracer bullet, VISION, and groomed backlog," unrelated to webfetch gating. Live-checked `write_opencode_config` before touching it: `webfetch`/`websearch` were hardcoded to `"allow"` unconditionally, with no policy parameter at all — Forbid was a prompt instruction the model could ignore, not an actual permission boundary.** Fixed 2026-07-02: `write_opencode_config` now takes `external_research_allowed: bool` and sets `webfetch`/`websearch` to `"deny"` when `policy.external_research == Forbid`. New test `opencode_config_denies_web_tools_when_external_research_is_forbidden` pins it.
 - [ ] Every check is a real oracle — removing the model, a non-AI process still decides pass/fail. No heuristic stands in for meaning.
 
 ## Notes
 **Why:** ADR 0003 + research (2026-06-23). The original 007 ("enforce groundedness in Rust") conflated *resolution* (a real oracle — keep, cheap, un-Goodhart-able) with *faithfulness* (no oracle — moved to evals/harness, 015). `validation.rs` already does the path-in-change check; this extends it to line/quote resolution, killing hallucinated citations for ~zero cost. Replaces the prior P0 "enforce groundedness" framing.
+
+**2026-07-02 scoping note (overnight pass) — why items 1-2 are unstarted, not attempted:**
+Both require real filesystem access to the cited file's actual bytes at validation
+time, and that's a bigger, more design-heavy change than the "S" estimate suggests:
+- `validate_artifact_for_request` is a pure function over `&ReviewRequest`/
+  `&ReviewArtifact` today — zero filesystem I/O. Adding it means either
+  threading an `Option<&Path>` workspace parameter through a **public, `pub use`
+  re-exported** function signature (breaks every external caller, not just this
+  repo's own `main.rs`/`mcp.rs` call sites), or a parallel `validate_*_with_workspace`
+  entry point.
+- The workspace path that would need to stay live is `request.context.workspaces.head.path`
+  — the *caller-supplied* checkout, not Cerberus's own disposable tempdir (that one is
+  already dropped by the time validation runs, confirmed by reading `run_command_substrate`:
+  its `tempfile::Builder::new().tempdir()` goes out of scope and deletes itself when the
+  function returns, before `main.rs` ever calls `validate_artifact_for_request`). Whether
+  the caller-supplied path is guaranteed to still exist/be unchanged at validation time
+  for every caller (`review`, `review-diff`, `review-pr`, MCP) needs a decision, not an
+  assumption.
+- `hunk_digest`/`excerpt`/`digest` have **no defined hashing/normalization convention
+  anywhere in the codebase today** (checked `schema.rs`, `prompt.rs`, `validation.rs`,
+  `docs/adr/`) — only a field name the model is told exists. Implementing "matches the
+  actual bytes" means inventing that convention from scratch (exact byte range, line
+  ending normalization, whitespace handling), which is a real design decision, not a
+  wire-up of an existing spec.
+
+Per the overnight contract's "skip operator-decision items, note them" rule. A future
+pass should scope: (a) whether `validate_artifact_for_request`'s public signature may
+change, (b) the hunk_digest/excerpt hashing convention, (c) fail-open vs fail-closed
+when the workspace path is stale/missing at validation time.

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -14,8 +14,8 @@ use uuid::Uuid;
 use crate::digest::{request_digest, sha256_digest};
 use crate::prompt::{build_master_prompt, build_opencode_message};
 use crate::schema::{
-    ContextArtifact, ContextCapabilities, LifecycleState, ReceiptStatus, ReviewArtifact,
-    ReviewRequest, ReviewTelemetry, RuntimeTarget,
+    ContextArtifact, ContextCapabilities, ExternalResearchPolicy, LifecycleState, ReceiptStatus,
+    ReviewArtifact, ReviewRequest, ReviewTelemetry, RuntimeTarget,
 };
 use crate::telemetry::{omp_telemetry, opencode_telemetry};
 use crate::validation::validate_artifact_for_request;
@@ -183,6 +183,7 @@ pub(crate) fn run_command_substrate(
         write_opencode_config(
             &child_config,
             &opencode_allowed_paths(&workspace, &runtime_receipts),
+            child_request.policy.external_research != ExternalResearchPolicy::Forbid,
         )?;
     }
 
@@ -482,7 +483,11 @@ fn request_with_workspace_paths(
     child_request
 }
 
-fn write_opencode_config(config_home: &Path, workspace_paths: &[PathBuf]) -> Result<()> {
+fn write_opencode_config(
+    config_home: &Path,
+    workspace_paths: &[PathBuf],
+    external_research_allowed: bool,
+) -> Result<()> {
     let config_dir = config_home.join("opencode");
     fs::create_dir_all(&config_dir)
         .with_context(|| format!("create OpenCode config dir {}", config_dir.display()))?;
@@ -500,14 +505,25 @@ fn write_opencode_config(config_home: &Path, workspace_paths: &[PathBuf]) -> Res
     // vars reach the child), not from denying tools. Untrusted-PR isolation
     // (network egress + credential handling) is a separate container profile
     // tracked in backlog 013.
+    //
+    // web tools are the one exception: granted capability must match the
+    // request's declared context.external_research tier (backlog 007), so
+    // policy.external_research == Forbid actually denies webfetch/websearch
+    // at the permission layer instead of relying on a prompt instruction the
+    // model could ignore.
+    let web_permission = if external_research_allowed {
+        "allow"
+    } else {
+        "deny"
+    };
     let config = serde_json::json!({
         "$schema": "https://opencode.ai/config.json",
         "permission": {
             "external_directory": external_directory,
             "edit": "allow",
             "bash": "allow",
-            "webfetch": "allow",
-            "websearch": "allow"
+            "webfetch": web_permission,
+            "websearch": web_permission
         }
     });
     let config_path = config_dir.join("opencode.json");
@@ -1386,7 +1402,7 @@ mod tests {
         let workspace = temp.path().join("repo-head");
         fs::create_dir(&workspace).unwrap();
 
-        write_opencode_config(temp.path(), std::slice::from_ref(&workspace)).unwrap();
+        write_opencode_config(temp.path(), std::slice::from_ref(&workspace), true).unwrap();
 
         let config_path = temp.path().join("opencode/opencode.json");
         let config: Value =
@@ -1413,6 +1429,42 @@ mod tests {
                 .and_then(Value::as_str),
             Some("allow")
         );
+    }
+
+    // Backlog 007: granted capability must match the request's declared
+    // context.external_research tier. Before this test the config
+    // unconditionally granted webfetch/websearch regardless of policy --
+    // Forbid was a prompt instruction the model could ignore, not an actual
+    // permission boundary.
+    #[test]
+    fn opencode_config_denies_web_tools_when_external_research_is_forbidden() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("repo-head");
+        fs::create_dir(&workspace).unwrap();
+
+        write_opencode_config(temp.path(), std::slice::from_ref(&workspace), false).unwrap();
+
+        let config_path = temp.path().join("opencode/opencode.json");
+        let config: Value =
+            serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
+        for tool in ["webfetch", "websearch"] {
+            assert_eq!(
+                config
+                    .pointer(&format!("/permission/{tool}"))
+                    .and_then(Value::as_str),
+                Some("deny"),
+                "external_research == Forbid must deny {tool} at the permission layer"
+            );
+        }
+        for tool in ["edit", "bash"] {
+            assert_eq!(
+                config
+                    .pointer(&format!("/permission/{tool}"))
+                    .and_then(Value::as_str),
+                Some("allow"),
+                "{tool} is unrelated to external_research and must stay allowed"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Backlog 007 (P2, "verify citation & anchor resolution"), oracle item 3. Live-checked the ticket's claim that this was already handled via PR #466 before touching it — that PR is unrelated ("Deliver self-review tracer bullet, VISION, and groomed backlog"), and `write_opencode_config` had `webfetch`/`websearch` hardcoded to `"allow"` unconditionally, no policy parameter at all. `external_research == Forbid` was a prompt instruction the model could ignore, not an actual permission boundary — granted capability didn't match the declared tier.

**Fix**: `write_opencode_config` now takes `external_research_allowed: bool` and sets `webfetch`/`websearch` to `"deny"` when `policy.external_research == Forbid`, so the OpenCode permission layer enforces the declared tier instead of relying on the prompt alone.

The other two oracle items (line-in-range and `hunk_digest`/`excerpt` byte verification against real file content) need `validate_artifact_for_request` to gain filesystem access it doesn't have today (a public-API signature question) plus an undefined hashing convention to invent from scratch — genuine design decisions, not wire-ups of an existing spec. Left unstarted with a scoping note in the ticket rather than rushed; ticket stays in `backlog.d/`, not moved to `_done/`.

## Test plan
- [x] New test `opencode_config_denies_web_tools_when_external_research_is_forbidden` — confirms `webfetch`/`websearch` are `"deny"` when forbidden, `edit`/`bash` stay `"allow"` (unrelated to this policy)
- [x] `cargo test --locked` green
- [x] `./scripts/verify.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)