### PR TITLE
fix(container): actionable error when the docker binary is missing (037)

### DIFF
--- a/backlog.d/_done/037-actionable-docker-missing-error.md
+++ b/backlog.d/_done/037-actionable-docker-missing-error.md
@@ -1,6 +1,6 @@
 # Actionable error when Docker is missing or misconfigured for container-opencode
 
-Priority: P2 · Status: ready · Estimate: S
+Priority: P2 · Status: done (2026-07-03) · Estimate: S
 
 ## Goal
 `run_docker_with_timeout` (`src/container.rs:699`) spawns `docker run` via
@@ -11,15 +11,21 @@ unlike the parallel `git`/`gh` binary-missing path backlog 009 already fixed
 (`src/request.rs:744-758`, `missing_binary_names_the_install_or_flag_fix`).
 
 ## Oracle
-- [ ] A `docker run` spawn failure (binary not found) surfaces an error naming:
-      install Docker, or point `--container-binary` at the correct executable —
-      mirroring the existing `--*-binary` pattern in `request.rs`.
-- [ ] A new unit test in `container.rs` exercises `run_docker_with_timeout` (or
-      its caller) with a nonexistent binary name and asserts the error message
-      names the fix, following the shape of
-      `request.rs::missing_binary_names_the_install_or_flag_fix`.
-- [ ] No change to behavior when Docker is present and working.
-- [ ] `./scripts/verify.sh` green.
+- [x] A `docker run` spawn failure (binary not found) surfaces an error naming
+      install Docker or the correct flag to point at a different executable.
+      **Correction to this ticket's own text**: the flag is `--docker-binary`
+      (which selects the docker CLI itself), not `--container-binary` (which
+      selects the substrate binary run *inside* the container — a different
+      flag entirely). Verified against `main.rs`'s actual `SubstrateArgs`
+      field names before writing the message.
+- [x] New test `container::tests::missing_docker_binary_names_the_install_or_flag_fix`
+      exercises `run_docker_with_timeout` directly with a nonexistent binary
+      name and asserts the error names both the problem and the fix,
+      following the shape of `request.rs::missing_binary_names_the_install_or_flag_fix`.
+- [x] No change to behavior when Docker is present and working — the
+      `ErrorKind::NotFound` branch is new; every other spawn-error path falls
+      through to the pre-existing `.context(...)` behavior unchanged.
+- [x] `./scripts/verify.sh` green.
 
 ## Notes
 Verified live 2026-07-01: `container.rs:699`

--- a/src/container.rs
+++ b/src/container.rs
@@ -696,7 +696,16 @@ fn run_docker_with_timeout(
             .context("open docker stderr writer")?,
     ));
     let start = Instant::now();
-    let mut child = command.spawn().context("spawn docker run")?;
+    let mut child = command.spawn().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            anyhow!(
+                "{docker_binary} was not found on PATH ({err}); install Docker, or point \
+                 --docker-binary at the correct executable"
+            )
+        } else {
+            anyhow::Error::new(err).context(format!("spawn {docker_binary} run"))
+        }
+    })?;
     loop {
         if let Some(status) = child.try_wait().context("poll docker run")? {
             return Ok(DockerOutput {
@@ -1046,6 +1055,36 @@ mod tests {
     fn parse_host_port_rejects_whitespace() {
         assert!(parse_host_port("open router.ai:443").is_err());
         assert!(parse_host_port("openrouter.ai:443\ndeny_all off").is_err());
+    }
+
+    // Backlog 037: a missing/misnamed docker binary previously surfaced only
+    // the raw OS error ("No such file or directory"), unlike the
+    // request.rs::run_with_env pattern this mirrors
+    // (missing_binary_names_the_install_or_flag_fix), which names the fix.
+    #[test]
+    fn missing_docker_binary_names_the_install_or_flag_fix() {
+        let command = Command::new("cerberus-definitely-not-a-real-docker-binary");
+
+        let result = run_docker_with_timeout(
+            command,
+            "irrelevant-container-name",
+            "cerberus-definitely-not-a-real-docker-binary",
+            Duration::from_secs(5),
+        );
+        let err = match result {
+            Ok(_) => panic!("spawning a nonexistent docker binary should fail"),
+            Err(err) => err,
+        };
+
+        let message = err.to_string();
+        assert!(
+            message.contains("was not found on PATH"),
+            "should name the concrete problem: {message}"
+        );
+        assert!(
+            message.contains("--docker-binary") || message.contains("install Docker"),
+            "should name the concrete fix: {message}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Backlog 037 (P2, "actionable error when Docker is missing or misconfigured for container-opencode"). `run_docker_with_timeout` spawned `docker run` via a bare `.context(...)?` — a missing or misnamed docker binary surfaced only the raw OS error ("No such file or directory"), unlike the parallel `git`/`gh` binary-missing path backlog 009/007 already fixed.

Now distinguishes `ErrorKind::NotFound` and names the fix: install Docker, or point `--docker-binary` at the correct executable.

**Correction to the ticket's own text**: the correct flag is `--docker-binary` (selects the docker CLI itself), not `--container-binary` (selects the substrate binary run *inside* the container — a different flag). Verified against `main.rs`'s actual `SubstrateArgs` field names before writing the message.

## Test plan
- [x] New test `missing_docker_binary_names_the_install_or_flag_fix` drives a real spawn of a nonexistent binary name through `run_docker_with_timeout` and asserts the message names both the problem and the fix
- [x] `cargo test --locked` green
- [x] `./scripts/verify.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)