### PR TITLE
test(request): cover binary-file diff parsing end-to-end (038)

### DIFF
--- a/backlog.d/_done/038-test-binary-file-diff-parsing.md
+++ b/backlog.d/_done/038-test-binary-file-diff-parsing.md
@@ -1,6 +1,6 @@
 # Test binary-file diff parsing end-to-end (numstat + --binary body)
 
-Priority: P2 · Status: ready · Estimate: S
+Priority: P2 · Status: done (2026-07-02) · Estimate: S
 
 ## Goal
 `parse_numstat` (`src/request.rs:453`) parses git's binary-file numstat line
@@ -11,16 +11,17 @@ has no test with a binary file in the diff, so this path has run unverified
 since it was written.
 
 ## Oracle
-- [ ] A unit test feeds `parse_numstat` a raw numstat line for a binary file
-      (`-\t-\timage.png`) and asserts `additions`/`deletions` are both `None`,
-      not a parse panic or a spurious `0`.
-- [ ] An end-to-end test (real git repo fixture, one binary file added or
-      modified) runs `build_git_range_request` and asserts the resulting
-      `ReviewRequest` contains the file with `additions: None,
-      deletions: None` and a valid (non-empty, UTF-8) `Diff.body` — confirming
-      `--binary`'s base85-encoded patch output survives the full pipeline
-      without corrupting the request JSON.
-- [ ] `./scripts/verify.sh` green.
+- [x] Unit test `parses_binary_numstat_line_as_no_line_counts` feeds
+      `parse_numstat` a raw binary numstat line and asserts
+      `additions`/`deletions` are both `None`.
+- [x] End-to-end test `build_git_range_request_handles_an_added_binary_file`
+      builds a real temp git repo, adds a 1024-byte binary file as a second
+      commit, runs `build_git_range_request`, and asserts the file entry has
+      `additions: None, deletions: None` and the request's `Diff.body`
+      contains git's `GIT binary patch` marker (empirically confirmed via a
+      manual `git diff --binary` run before writing the assertion, so it
+      matches real git output rather than a guess).
+- [x] `./scripts/verify.sh` green.
 
 ## Notes
 Verified live 2026-07-01: `grep -n "binary" src/request.rs` shows `--binary`

--- a/src/request.rs
+++ b/src/request.rs
@@ -649,6 +649,70 @@ mod tests {
         assert_eq!(stats.get("new.txt"), Some(&(Some(3), Some(0))));
     }
 
+    // Backlog 038: git's numstat line for a binary file uses `-`/`-` in place
+    // of line counts (there is nothing to count). `.parse::<u32>().ok()`
+    // silently yields None for "-", which is correct, but nothing exercised
+    // this path until now.
+    #[test]
+    fn parses_binary_numstat_line_as_no_line_counts() {
+        let stats = parse_numstat("-\t-\timage.png\n");
+        assert_eq!(stats.get("image.png"), Some(&(None, None)));
+    }
+
+    // Backlog 038: end-to-end proof that a real binary file survives the
+    // full build_git_range_request pipeline -- `--binary`'s base85-encoded
+    // patch output must round-trip through git diff -> UTF-8 lossy capture
+    // -> the request JSON without corrupting the file entry or the request.
+    #[test]
+    fn build_git_range_request_handles_an_added_binary_file() {
+        let repo = init_repo();
+        let base = commit_file(repo.path(), "hello\n", "initial");
+        let binary_bytes: Vec<u8> = (0..=255u8).cycle().take(1024).collect();
+        fs::write(repo.path().join("image.png"), &binary_bytes).unwrap();
+        run(repo.path(), "git", &["add", "image.png"]).unwrap();
+        run(repo.path(), "git", &["commit", "-q", "-m", "add binary"]).unwrap();
+        let head = git_output(repo.path(), &["rev-parse", "HEAD"]).unwrap();
+
+        let request = build_git_range_request(&GitRangeRequestOptions {
+            repo_path: repo.path().to_path_buf(),
+            base: base.clone(),
+            head: head.clone(),
+            base_workspace: None,
+            title: None,
+            description: None,
+            repo: None,
+            common: RequestOptions {
+                request_id: None,
+                instructions: Vec::new(),
+                local_runtime: Vec::new(),
+                allow_local_runtime: false,
+                allowed_env: Vec::new(),
+                timeout_ms: 120_000,
+            },
+        })
+        .unwrap();
+
+        let binary_file = request
+            .change
+            .files
+            .iter()
+            .find(|file| file.path == "image.png")
+            .expect("binary file present in the request's changed files");
+        assert_eq!(binary_file.status, FileStatus::Added);
+        assert_eq!(
+            binary_file.additions, None,
+            "binary files have no line-count, not a spurious 0"
+        );
+        assert_eq!(binary_file.deletions, None);
+
+        assert!(!request.change.diff.body.is_empty());
+        assert!(
+            request.change.diff.body.contains("GIT binary patch"),
+            "diff body should carry git's base85-encoded binary patch, not be silently empty: {}",
+            request.change.diff.body
+        );
+    }
+
     #[test]
     fn parses_github_remote_slugs() {
         assert_eq!(


### PR DESCRIPTION
## Summary
Backlog 038 (P2, "test binary-file diff parsing end-to-end"). `parse_numstat` parses git's binary-file numstat line (`-\t-\tpath`) via `.parse::<u32>().ok()`, which silently yields `additions: None, deletions: None` — correct, but nothing exercised this path.

- New unit test feeds `parse_numstat` a raw binary numstat line directly.
- New end-to-end test builds a real temp git repo, adds a 1024-byte binary file as a second commit, runs `build_git_range_request`, and asserts the file entry has `additions`/`deletions` both `None` and the request's diff body carries git's base85-encoded `GIT binary patch` content — confirming `--binary`'s output survives `git diff` → UTF-8 lossy capture → the request JSON without corrupting either the file entry or the diff body.

## Test plan
- [x] Verified the exact `GIT binary patch` marker text via a manual `git diff --binary` run before writing the assertion (not a guess)
- [x] `cargo test --locked` green
- [x] `./scripts/verify.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)