### PR TITLE
docs(backlog): close out 011 — oracle satisfied, matches how 008 was handled

### DIFF
--- a/backlog.d/_done/011-simplify-core.md
+++ b/backlog.d/_done/011-simplify-core.md
@@ -1,6 +1,6 @@
 # Simplify and de-duplicate the core
 
-Priority: P2 · Status: children 1-4 done (2026-07-02); 5-6 deferred, need human ratification · Estimate: M
+Priority: P2 · Status: done 2026-07-02 (oracle satisfied; children 5-6 remain PROPOSED, need spec ratification, not part of the oracle) · Estimate: M
 
 ## Goal
 Shrink the surface an editor must preserve: collapse a pass-through seam, de-duplicate display/test logic, and delete dead provenance — without changing the public `ReviewRequest.v1` / `ReviewArtifact.v1` / `ReviewKernel` seams.


### PR DESCRIPTION
## Summary
011's oracle (4 items) was already satisfied in a prior session; children 5-6 are explicitly PROPOSED deletions from the LOCKED schema/contract (spec.md), needing spec ratification, not part of the oracle itself.

Applying the same standard just used for backlog 008 this session (oracle satisfied + one deferred, out-of-oracle child == done, archived, deferred child noted): moved 011 to `_done/` too, for consistency.

## Test plan
- [x] `./scripts/verify.sh` green (docs-only change, ran the gate anyway per house rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)