### PR TITLE
feat(harness): warn-only out-of-range line citation check (007 item 1)

### DIFF
--- a/backlog.d/007-citation-anchor-resolution.md
+++ b/backlog.d/007-citation-anchor-resolution.md
@@ -1,6 +1,6 @@
 # Verify citation & anchor resolution (cheap deterministic oracle)
 
-Priority: P2 · Status: item 3 fixed 2026-07-02 (was NOT already done, ticket's own claim was stale); items 1-2 need scoping · Estimate: S (items 1-2 are actually M+, see note)
+Priority: P2 · Status: item 3 done; item 1 shipped warn-only 2026-07-02; item 2 still needs scoping · Estimate: S (item 2 is actually M+, see note)
 
 ## Goal
 Reject confabulated or stale citations cheaply: every cited anchor/citation must resolve to real content — without Rust pretending to judge whether a finding is *faithful* (that's evals; see 015).
@@ -10,39 +10,49 @@ Reject confabulated or stale citations cheaply: every cited anchor/citation must
 - No new frozen taxonomy; `category` stays agent-free-form.
 
 ## Oracle
-- [ ] Inline/file anchor path is in the change (already enforced); extend to: the line number is in range for the cited file when the workspace is available (repo_head+).
+- [x] Inline/file anchor path is in the change (already enforced); extend to: the line number is in range for the cited file when the workspace is available (repo_head+). **Shipped warn-only 2026-07-02** — see the note below for why blocking behavior stayed a deferred decision while the warn half did not need to be.
 - [ ] When an anchor carries `hunk_digest` or a citation carries `excerpt`/`digest`, it matches the actual bytes at that location; a fabricated/stale quote fails validation.
 - [x] The substrate honors `policy.external_research`: web tools are not granted when `external_research == Forbid`, so granted capability matches the declared tier. **The ticket's "(dogfound, PR #466)" annotation was wrong/stale — PR #466 is "Deliver self-review tracer bullet, VISION, and groomed backlog," unrelated to webfetch gating. Live-checked `write_opencode_config` before touching it: `webfetch`/`websearch` were hardcoded to `"allow"` unconditionally, with no policy parameter at all — Forbid was a prompt instruction the model could ignore, not an actual permission boundary.** Fixed 2026-07-02: `write_opencode_config` now takes `external_research_allowed: bool` and sets `webfetch`/`websearch` to `"deny"` when `policy.external_research == Forbid`. New test `opencode_config_denies_web_tools_when_external_research_is_forbidden` pins it.
-- [ ] Every check is a real oracle — removing the model, a non-AI process still decides pass/fail. No heuristic stands in for meaning.
+- [x] Every check *implemented so far* is a real oracle — removing the model, a non-AI process still decides pass/fail: the webfetch permission check (item 3) is a boolean policy comparison, and the line-range check (item 1) is an integer comparison against a file's real line count. No heuristic stands in for meaning. Item 2 (not yet implemented) will need the same discipline once it exists.
 
 ## Notes
 **Why:** ADR 0003 + research (2026-06-23). The original 007 ("enforce groundedness in Rust") conflated *resolution* (a real oracle — keep, cheap, un-Goodhart-able) with *faithfulness* (no oracle — moved to evals/harness, 015). `validation.rs` already does the path-in-change check; this extends it to line/quote resolution, killing hallucinated citations for ~zero cost. Replaces the prior P0 "enforce groundedness" framing.
 
-**2026-07-02 scoping note (overnight pass) — why items 1-2 are unstarted, not attempted:**
-Both require real filesystem access to the cited file's actual bytes at validation
-time, and that's a bigger, more design-heavy change than the "S" estimate suggests:
-- `validate_artifact_for_request` is a pure function over `&ReviewRequest`/
-  `&ReviewArtifact` today — zero filesystem I/O. Adding it means either
-  threading an `Option<&Path>` workspace parameter through a **public, `pub use`
-  re-exported** function signature (breaks every external caller, not just this
-  repo's own `main.rs`/`mcp.rs` call sites), or a parallel `validate_*_with_workspace`
-  entry point.
-- The workspace path that would need to stay live is `request.context.workspaces.head.path`
-  — the *caller-supplied* checkout, not Cerberus's own disposable tempdir (that one is
-  already dropped by the time validation runs, confirmed by reading `run_command_substrate`:
-  its `tempfile::Builder::new().tempdir()` goes out of scope and deletes itself when the
-  function returns, before `main.rs` ever calls `validate_artifact_for_request`). Whether
-  the caller-supplied path is guaranteed to still exist/be unchanged at validation time
-  for every caller (`review`, `review-diff`, `review-pr`, MCP) needs a decision, not an
-  assumption.
-- `hunk_digest`/`excerpt`/`digest` have **no defined hashing/normalization convention
-  anywhere in the codebase today** (checked `schema.rs`, `prompt.rs`, `validation.rs`,
-  `docs/adr/`) — only a field name the model is told exists. Implementing "matches the
-  actual bytes" means inventing that convention from scratch (exact byte range, line
-  ending normalization, whitespace handling), which is a real design decision, not a
-  wire-up of an existing spec.
+**2026-07-02 scoping note (first overnight pass) — why items 1-2 looked entirely blocked:**
+Both looked like they required real filesystem access to the cited file's actual bytes
+at *validation* time (`validate_artifact_for_request`), which is a pure function over
+`&ReviewRequest`/`&ReviewArtifact` with zero filesystem I/O today. Threading a workspace
+parameter through it would mean either changing a **public, `pub use` re-exported**
+function signature (breaks every external caller), or a parallel entry point — a real
+design decision, not a mechanical follow-up. Cerberus's own disposable tempdir is also
+already dropped by the time validation runs (confirmed via `run_command_substrate`'s
+`tempfile::Builder` going out of scope when the function returns, before `main.rs` ever
+calls `validate_artifact_for_request`).
 
-Per the overnight contract's "skip operator-decision items, note them" rule. A future
-pass should scope: (a) whether `validate_artifact_for_request`'s public signature may
-change, (b) the hunk_digest/excerpt hashing convention, (c) fail-open vs fail-closed
-when the workspace path is stale/missing at validation time.
+**2026-07-02 second pass, same night — found a safe half for item 1:** the premise above
+was right for a *blocking* check, but wrong for a *warn-only* one. The review workspace
+(`RunWorkspace`/`workspace.path()`) is still alive inside `run_command_substrate`, right
+after the artifact is read back and before the tempdir drops — no signature change to
+`validate_artifact_for_request` needed, because the check doesn't have to live there.
+Shipped `harness::out_of_range_line_citation_warnings`: walks every inline anchor's cited
+line number against the real file's line count in the still-live workspace, and prints a
+non-blocking `warning:` line to stderr when it's out of range (silently skips when the
+file can't be read at all — diff-only mode, where there is no real checkout to check
+against, and a genuinely-missing-file case `validation.rs`'s path-in-change check already
+owns). Live-verified: a real git-range review whose cited line exceeded the file's real
+length printed the warning and still exited 0; `./scripts/verify.sh`'s own fixture (whose
+`src/ratio.rs:3` citation is genuinely in-range for the 6-line file it commits) stays
+silent. Scoped to `run_command_substrate` (opencode/omp) only — `container.rs`'s
+archive-workspace path could reuse the same function (it also has a real, still-live
+checkout at the point its artifact is read back) but wasn't wired in this pass, to keep
+the diff focused; a natural, small follow-up.
+
+**Item 2 is still genuinely blocked, unchanged from the first pass:**
+`hunk_digest`/`excerpt`/`digest` have **no defined hashing/normalization convention
+anywhere in the codebase today** (checked `schema.rs`, `prompt.rs`, `validation.rs`,
+`docs/adr/`) — only a field name the model is told exists. Implementing "matches the
+actual bytes" means inventing that convention from scratch (exact byte range, line
+ending normalization, whitespace handling), which is a real design decision, not a
+wire-up of an existing spec. Unlike item 1, there's no warn-only version that sidesteps
+this — the convention has to exist before anything can be compared against it. Left for
+explicit scoping.

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -14,8 +14,8 @@ use uuid::Uuid;
 use crate::digest::{request_digest, sha256_digest};
 use crate::prompt::{build_master_prompt, build_opencode_message};
 use crate::schema::{
-    ContextArtifact, ContextCapabilities, ExternalResearchPolicy, LifecycleState, ReceiptStatus,
-    ReviewArtifact, ReviewRequest, ReviewTelemetry, RuntimeTarget,
+    Anchor, AnchorKind, ContextArtifact, ContextCapabilities, ExternalResearchPolicy,
+    LifecycleState, ReceiptStatus, ReviewArtifact, ReviewRequest, ReviewTelemetry, RuntimeTarget,
 };
 use crate::telemetry::{omp_telemetry, opencode_telemetry};
 use crate::validation::validate_artifact_for_request;
@@ -290,12 +290,68 @@ pub(crate) fn run_command_substrate(
         write_failure_transcript(failure_transcript, &transcript)?;
         return Err(err);
     }
+    // Backlog 007 item 1 (warn-only): the workspace is still alive here, so
+    // this is the one place left to cheaply catch a confabulated line
+    // citation before the disposable worktree/archive is dropped.
+    for warning in out_of_range_line_citation_warnings(&artifact, workspace.path()) {
+        eprintln!("warning: {warning}");
+    }
     Ok(HarnessRun {
         artifact,
         transcript,
         execution_plan: plan,
         telemetry,
     })
+}
+
+/// Backlog 007 item 1 (warn-only -- see the ticket's scoping note for why
+/// blocking behavior, and the hunk_digest/excerpt byte-matching half of this
+/// ticket, stay deferred design decisions this slice does not make). While
+/// the review workspace is still alive, checks each inline anchor's cited
+/// line number against the actual file's real line count. A citation beyond
+/// the file's length is a concrete, cheap-to-catch sign of a confabulated
+/// citation. An unreadable file (path outside the workspace, deleted,
+/// binary) is silently skipped -- that is a different, already-enforced
+/// concern (`validation.rs`'s path-in-change check), not this one.
+fn out_of_range_line_citation_warnings(
+    artifact: &ReviewArtifact,
+    workspace_root: &Path,
+) -> Vec<String> {
+    let mut line_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut warnings = Vec::new();
+    let mut check = |anchor: &Anchor, source: String| {
+        if anchor.kind != AnchorKind::Inline {
+            return;
+        }
+        let Some(path) = &anchor.path else {
+            return;
+        };
+        let Some(cited_line) = anchor.end_line.or(anchor.line) else {
+            return;
+        };
+        let line_count = *line_counts.entry(path.clone()).or_insert_with(|| {
+            fs::read_to_string(workspace_root.join(path))
+                .map(|content| content.lines().count())
+                .unwrap_or(usize::MAX)
+        });
+        if line_count == usize::MAX {
+            return;
+        }
+        if cited_line as usize > line_count {
+            warnings.push(format!(
+                "{source} cites {path}:{cited_line}, but the file only has {line_count} lines -- possible confabulated citation"
+            ));
+        }
+    };
+    for finding in &artifact.findings {
+        for anchor in &finding.anchors {
+            check(anchor, format!("finding {}", finding.id));
+        }
+    }
+    for comment in &artifact.comments {
+        check(&comment.anchor, format!("comment {}", comment.id));
+    }
+    warnings
 }
 
 /// Read and parse the artifact the agent emitted to its out-path. A missing or
@@ -1215,6 +1271,7 @@ pub(crate) fn set_private_directory_permissions(_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::{Comment, CommentIntent, CommentKind, Finding, Severity};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
@@ -1674,6 +1731,105 @@ mod tests {
             "errors": []
         })
         .to_string()
+    }
+
+    fn anchored_finding(id: &str, path: &str, line: u32) -> Finding {
+        Finding {
+            id: id.to_string(),
+            severity: Severity::Major,
+            category: "correctness".to_string(),
+            title: "title".to_string(),
+            description: "description".to_string(),
+            evidence: "evidence".to_string(),
+            confidence: 0.8,
+            anchors: vec![Anchor {
+                kind: AnchorKind::Inline,
+                path: Some(path.to_string()),
+                line: Some(line),
+                start_line: None,
+                end_line: None,
+                hunk_digest: None,
+            }],
+            citations: Vec::new(),
+            suggested_fixes: Vec::new(),
+        }
+    }
+
+    fn artifact_with_findings(findings: Vec<Finding>) -> ReviewArtifact {
+        serde_json::from_str::<ReviewArtifact>(&minimal_artifact_json())
+            .map(|mut artifact| {
+                artifact.findings = findings;
+                artifact
+            })
+            .unwrap()
+    }
+
+    // Backlog 007 item 1: pins the warn-only out-of-range line citation
+    // check. Deliberately does NOT test hunk_digest/excerpt byte-matching
+    // (item 2) or blocking behavior -- both stay deferred design decisions
+    // per the ticket's scoping note.
+    #[test]
+    fn out_of_range_line_citation_warnings_flags_a_line_beyond_the_files_length() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("file.txt"), "one\ntwo\nthree\n").unwrap();
+        let artifact = artifact_with_findings(vec![anchored_finding("f-1", "file.txt", 10)]);
+
+        let warnings = out_of_range_line_citation_warnings(&artifact, temp.path());
+
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("file.txt:10"));
+        assert!(warnings[0].contains("3 lines"));
+    }
+
+    #[test]
+    fn out_of_range_line_citation_warnings_is_silent_for_in_range_citations() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("file.txt"), "one\ntwo\nthree\n").unwrap();
+        let artifact = artifact_with_findings(vec![anchored_finding("f-1", "file.txt", 2)]);
+
+        assert!(out_of_range_line_citation_warnings(&artifact, temp.path()).is_empty());
+    }
+
+    #[test]
+    fn out_of_range_line_citation_warnings_is_silent_when_the_file_is_unreadable() {
+        // Simulates diff-only mode, where the workspace is a request/diff
+        // packet, not a real checkout -- the cited file genuinely does not
+        // exist at this path, and that is a different, already-enforced
+        // concern (validation.rs's path-in-change check), not this one.
+        let temp = tempfile::tempdir().unwrap();
+        let artifact =
+            artifact_with_findings(vec![anchored_finding("f-1", "does/not/exist.txt", 999)]);
+
+        assert!(out_of_range_line_citation_warnings(&artifact, temp.path()).is_empty());
+    }
+
+    #[test]
+    fn out_of_range_line_citation_warnings_checks_comment_anchors_too() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("file.txt"), "one\ntwo\n").unwrap();
+        let mut artifact = artifact_with_findings(Vec::new());
+        artifact.comments.push(Comment {
+            id: "c-1".to_string(),
+            kind: CommentKind::Inline,
+            intent: CommentIntent::Note,
+            finding_id: None,
+            body: "body".to_string(),
+            anchor: Anchor {
+                kind: AnchorKind::Inline,
+                path: Some("file.txt".to_string()),
+                line: Some(50),
+                start_line: None,
+                end_line: None,
+                hunk_digest: None,
+            },
+            dedupe_key: None,
+            suggested_fixes: Vec::new(),
+        });
+
+        let warnings = out_of_range_line_citation_warnings(&artifact, temp.path());
+
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("comment c-1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Backlog 007 item 1 (line-in-range for cited files). This looked entirely blocked in a prior session by the same problem as item 2: `validate_artifact_for_request` has no filesystem access and is a public, re-exported function, so threading a workspace parameter through it would be a breaking signature change — a real design decision.

That premise held for a *blocking* check, but not a *warn-only* one. The review workspace is still alive inside `run_command_substrate` right after the artifact is read back, before the tempdir drops — no `validate_artifact_for_request` change needed, because the check doesn't have to live there.

`harness::out_of_range_line_citation_warnings` walks every inline anchor's cited line number (findings and comments) against the real file's line count in the still-live workspace, printing a non-blocking `warning:` line to stderr when a citation exceeds the file's actual length. Silently skips when the file can't be read (diff-only mode has no real checkout to check against; a genuinely-missing-file case `validation.rs`'s path-in-change check already owns).

Scoped to `run_command_substrate` (opencode/omp) only — `container.rs`'s archive-workspace path could reuse the same function but wasn't wired in this pass, noted as a natural follow-up.

**Item 2 (hunk_digest/excerpt byte-matching) is unchanged, still blocked**: no defined hashing/normalization convention exists anywhere in the codebase, and unlike item 1 there's no warn-only version that sidesteps inventing one.

## Test plan
- [x] 4 new unit tests: flags an out-of-range line, stays silent for in-range citations, stays silent when the file is unreadable (diff-only mode), checks comment anchors too
- [x] Live-verified via a real git-range review whose cited line exceeded the file's real length — warning printed, exit code still 0
- [x] Confirmed `./scripts/verify.sh`'s own fixture (`src/ratio.rs:3`, genuinely in-range for the 6-line file it commits) stays silent — full gate run has zero "confabulated" hits
- [x] `cargo test --locked` green
- [x] `./scripts/verify.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)