### PR TITLE
[codex] Pin OpenCode live smoke

### DIFF
--- a/.github/workflows/opencode-live-smoke.yml
+++ b/.github/workflows/opencode-live-smoke.yml
@@ -1,0 +1,112 @@
+name: OpenCode Live Smoke
+
+on:
+  schedule:
+    - cron: "23 10 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: opencode-live-smoke
+  cancel-in-progress: false
+
+jobs:
+  live-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check smoke secret
+        id: preflight
+        env:
+          CERBERUS_SMOKE_OPENROUTER_KEY: ${{ secrets.CERBERUS_SMOKE_OPENROUTER_KEY }}
+        run: |
+          if [ -z "$CERBERUS_SMOKE_OPENROUTER_KEY" ]; then
+            echo "::notice::CERBERUS_SMOKE_OPENROUTER_KEY is not set; live OpenCode smoke skipped cleanly."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Rust
+        if: steps.preflight.outputs.skip != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build outputs
+        if: steps.preflight.outputs.skip != 'true'
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Node
+        if: steps.preflight.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install pinned OpenCode
+        if: steps.preflight.outputs.skip != 'true'
+        run: |
+          OPENCODE_VERSION="$(node -p "require('./config/opencode-version.json').version")"
+          npm install -g "opencode-ai@$OPENCODE_VERSION"
+          opencode --version
+
+      - name: Run live OpenCode smoke
+        id: smoke
+        if: steps.preflight.outputs.skip != 'true'
+        continue-on-error: true
+        env:
+          CERBERUS_SMOKE_OPENROUTER_KEY: ${{ secrets.CERBERUS_SMOKE_OPENROUTER_KEY }}
+          CERBERUS_SMOKE_OPENROUTER_MODEL: ${{ vars.CERBERUS_SMOKE_OPENROUTER_MODEL || 'openrouter/z-ai/glm-5.2' }}
+          CERBERUS_SMOKE_TIMEOUT_SECONDS: "300"
+        run: ./scripts/opencode-live-smoke.sh
+
+      - name: Upload smoke evidence
+        if: steps.smoke.outcome == 'failure' || steps.smoke.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencode-live-smoke
+          path: target/cerberus/live-opencode-smoke
+          if-no-files-found: ignore
+
+      - name: File or update failure issue
+        if: steps.smoke.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.sha }}
+          CERBERUS_SMOKE_OPENROUTER_MODEL: ${{ vars.CERBERUS_SMOKE_OPENROUTER_MODEL || 'openrouter/z-ai/glm-5.2' }}
+        run: |
+          title="Cerberus live OpenCode smoke failure"
+          body_file="$(mktemp)"
+          {
+            echo "The scheduled Cerberus live OpenCode smoke failed."
+            echo
+            echo "- Run: $RUN_URL"
+            echo "- Commit: $HEAD_SHA"
+            echo "- Pin: \`$(node -p "require('./config/opencode-version.json').version")\`"
+            echo "- Model: \`${CERBERUS_SMOKE_OPENROUTER_MODEL:-openrouter/z-ai/glm-5.2}\`"
+            echo
+            echo "The workflow artifact \`opencode-live-smoke\` contains stdout, stderr, rendered review, and artifact files when Cerberus got that far."
+          } > "$body_file"
+          issue_number="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$issue_number" ]; then
+            gh issue edit "$issue_number" --body-file "$body_file"
+            gh issue comment "$issue_number" --body-file "$body_file"
+          else
+            gh issue create --title "$title" --body-file "$body_file"
+          fi
+
+      - name: Keep skip visible
+        if: steps.preflight.outputs.skip == 'true'
+        run: |
+          echo "Live OpenCode smoke skipped because CERBERUS_SMOKE_OPENROUTER_KEY is not provisioned." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail after reporting
+        if: steps.smoke.outcome == 'failure'
+        run: exit 1

--- a/config/opencode-version.json
+++ b/config/opencode-version.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "cerberus.opencode_pin.v1",
+  "version": "1.2.6",
+  "install": "npm install -g opencode-ai@1.2.6",
+  "bump_procedure": "docs/opencode-substrate.md#bumping-the-opencode-pin"
+}

--- a/docs/opencode-substrate.md
+++ b/docs/opencode-substrate.md
@@ -1,0 +1,33 @@
+# OpenCode substrate operations
+
+Cerberus treats OpenCode as a production substrate, not an ambient developer
+tool. The exact CLI version is pinned in `config/opencode-version.json`; any
+`--harness opencode` run probes `opencode --version` before launching the
+reviewer and fails before model execution when the installed version drifts.
+
+## Live smoke key
+
+The scheduled live smoke uses the GitHub secret
+`CERBERUS_SMOKE_OPENROUTER_KEY`. Operators must provision this as a narrowly
+scoped, spend-capped OpenRouter key for this smoke only. Do not reuse a broad
+developer `OPENROUTER_API_KEY` or a key shared with another service.
+
+If the secret is absent, the workflow exits successfully and writes a notice so
+new forks and fresh repositories stay green until the operator provisions the
+key.
+
+## Bumping the OpenCode pin
+
+1. Install the candidate version locally.
+2. Update `config/opencode-version.json` so `version` and `install` name the
+   same exact version.
+3. Run the loud-fail demo by pointing Cerberus at an older fake OpenCode binary;
+   the error must name the expected version, observed version, pin file, and
+   this bump procedure.
+4. Run `./scripts/opencode-live-smoke.sh` with a spend-capped
+   `CERBERUS_SMOKE_OPENROUTER_KEY`.
+5. Run `./scripts/verify.sh`.
+6. Open a PR with the smoke transcript or issue/run URL in the body.
+
+The bump is intentionally a code-reviewable PR because an OpenCode contract
+change can break production while the fixture gate stays green.

--- a/fixtures/bin/fake-opencode
+++ b/fixtures/bin/fake-opencode
@@ -6,6 +6,11 @@ if [[ "${GH_TOKEN:-}" != "" ]]; then
   exit 64
 fi
 
+if [[ "${1:-}" == "--version" || "${1:-}" == "-v" ]]; then
+  printf '%s\n' "1.2.6"
+  exit 0
+fi
+
 if [[ "$*" == *"Avoid divide by zero"* ]]; then
   echo "private request material leaked through argv" >&2
   exit 65

--- a/fixtures/live-smoke/base/src/ratio.rs
+++ b/fixtures/live-smoke/base/src/ratio.rs
@@ -1,0 +1,6 @@
+pub fn ratio(numerator: i64, denominator: i64) -> Option<i64> {
+    if denominator == 0 {
+        return None;
+    }
+    Some(numerator / denominator)
+}

--- a/fixtures/live-smoke/head/src/ratio.rs
+++ b/fixtures/live-smoke/head/src/ratio.rs
@@ -1,0 +1,3 @@
+pub fn ratio(numerator: i64, denominator: i64) -> i64 {
+    numerator / denominator
+}

--- a/scripts/opencode-live-smoke.sh
+++ b/scripts/opencode-live-smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ -z "${CERBERUS_SMOKE_OPENROUTER_KEY:-}" ]]; then
+  echo "::notice::CERBERUS_SMOKE_OPENROUTER_KEY is not set; skipping live OpenCode smoke"
+  exit 0
+fi
+
+smoke_model="${CERBERUS_SMOKE_OPENROUTER_MODEL:-openrouter/z-ai/glm-5.2}"
+opencode_binary="${CERBERUS_SMOKE_OPENCODE_BINARY:-opencode}"
+timeout_seconds="${CERBERUS_SMOKE_TIMEOUT_SECONDS:-300}"
+out_dir="${CERBERUS_SMOKE_OUT_DIR:-target/cerberus/live-opencode-smoke}"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+repo="$tmp_dir/repo"
+mkdir -p "$repo"
+git -C "$repo" init --quiet
+git -C "$repo" config user.email "cerberus-smoke@example.invalid"
+git -C "$repo" config user.name "Cerberus Smoke"
+cp -R fixtures/live-smoke/base/. "$repo/"
+git -C "$repo" add .
+git -C "$repo" commit --quiet -m "base safe ratio"
+base_sha="$(git -C "$repo" rev-parse HEAD)"
+cp -R fixtures/live-smoke/head/. "$repo/"
+git -C "$repo" add .
+git -C "$repo" commit --quiet -m "introduce ratio regression"
+head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+rm -rf "$out_dir"
+mkdir -p "$out_dir"
+
+OPENROUTER_API_KEY="$CERBERUS_SMOKE_OPENROUTER_KEY" cargo run --locked -- review-diff \
+  --repo-path "$repo" \
+  --base "$base_sha" \
+  --head "$head_sha" \
+  --title "Cerberus live OpenCode smoke fixture" \
+  --description "Tiny committed fixture diff that removes a divide-by-zero guard." \
+  --request-id "cerberus-live-opencode-smoke" \
+  --repo "misty-step/cerberus-live-smoke" \
+  --instruction "This is a scheduled live substrate smoke. Review the tiny diff and emit exactly one valid ReviewArtifact.v1. A WARN or PASS verdict is acceptable; the smoke validates substrate contract compatibility, not reviewer quality." \
+  --harness opencode \
+  --opencode-binary "$opencode_binary" \
+  --model "$smoke_model" \
+  --allow-env OPENROUTER_API_KEY \
+  --timeout-seconds "$timeout_seconds" \
+  --out "$out_dir/artifact.json" \
+  --markdown "$out_dir/review.md" \
+  > "$out_dir/stdout.md" \
+  2> "$out_dir/stderr.txt"
+
+test -s "$out_dir/artifact.json"
+test -s "$out_dir/review.md"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -133,6 +133,30 @@ if grep -q 'sha256:0000000000000000000000000000000000000000000000000000000000000
   exit 1
 fi
 
+cat > target/cerberus/fake-opencode-old <<'SH'
+#!/usr/bin/env sh
+if [ "${1:-}" = "--version" ]; then
+  printf '%s\n' "0.0.0"
+  exit 0
+fi
+exec "$CERBERUS_FAKE_OPENCODE" "$@"
+SH
+chmod +x target/cerberus/fake-opencode-old
+if CERBERUS_FAKE_OPENCODE="$PWD/fixtures/bin/fake-opencode" cargo run --locked -- review \
+  --request fixtures/requests/diff-only.json \
+  --harness opencode \
+  --opencode-binary "$PWD/target/cerberus/fake-opencode-old" \
+  --out target/cerberus/opencode-version-drift-artifact.json \
+  > target/cerberus/opencode-version-drift.stdout \
+  2> target/cerberus/opencode-version-drift.stderr; then
+  echo "expected OpenCode version drift to fail before review execution" >&2
+  exit 1
+fi
+grep -q 'OpenCode version drift' target/cerberus/opencode-version-drift.stderr
+grep -q 'config/opencode-version.json' target/cerberus/opencode-version-drift.stderr
+grep -q 'docs/opencode-substrate.md#bumping-the-opencode-pin' \
+  target/cerberus/opencode-version-drift.stderr
+
 if CERBERUS_FAKE_OPENCODE_TIMEOUT=1 CERBERUS_FAKE_OPENCODE_TIMEOUT_SECONDS=3 cargo run --locked -- review \
   --request fixtures/requests/diff-only.json \
   --harness opencode \

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -29,6 +29,7 @@ pub(crate) const ARTIFACT_FILENAME: &str = "review-artifact.json";
 /// first-retry recovery near 80% and second-retry above 99%; a third is wasted
 /// tokens. The loop is fail-closed: an artifact that never validates is an error.
 const MAX_REASK_RETRIES: usize = 2;
+const OPENCODE_PIN_PATH: &str = "config/opencode-version.json";
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum HarnessKind {
@@ -202,6 +203,9 @@ pub(crate) fn run_command_substrate(
 
     let trusted_search_path = trusted_executable_search_path();
     let executable = resolve_executable_in(&binary, &trusted_search_path)?;
+    if matches!(substrate, CommandSubstrateConfig::Opencode(_)) {
+        verify_opencode_version_pin(&executable)?;
+    }
 
     let plan = ExecutionPlan {
         harness: plan_harness.to_string(),
@@ -520,6 +524,89 @@ fn command_for_substrate(
             Ok((config.binary.clone(), args, "omp", "private prompt file"))
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeVersionPin {
+    version: String,
+    install: String,
+    bump_procedure: String,
+}
+
+fn verify_opencode_version_pin(executable: &Path) -> Result<()> {
+    let pin = read_opencode_version_pin(Path::new(OPENCODE_PIN_PATH))?;
+    let output = Command::new(executable)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .env_clear()
+        .output()
+        .with_context(|| {
+            format!(
+                "probe OpenCode version with {} --version",
+                executable.display()
+            )
+        })?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "OpenCode version pin check failed: {} --version exited with {}; expected {} from {}. Install the pin with `{}` or follow {}.",
+            executable.display(),
+            output.status,
+            pin.version,
+            OPENCODE_PIN_PATH,
+            pin.install,
+            pin.bump_procedure
+        ));
+    }
+    let observed = parse_version_token(&output.stdout)
+        .or_else(|| parse_version_token(&output.stderr))
+        .ok_or_else(|| {
+            anyhow!(
+                "OpenCode version pin check failed: {} --version did not print a parseable version; expected {} from {}. Follow {} before running live reviews.",
+                executable.display(),
+                pin.version,
+                OPENCODE_PIN_PATH,
+                pin.bump_procedure
+            )
+        })?;
+    if observed != pin.version {
+        return Err(anyhow!(
+            "OpenCode version drift: expected {} from {}, but {} reported {}. Install the pin with `{}` or update the pin via {} before running live reviews.",
+            pin.version,
+            OPENCODE_PIN_PATH,
+            executable.display(),
+            observed,
+            pin.install,
+            pin.bump_procedure
+        ));
+    }
+    Ok(())
+}
+
+fn read_opencode_version_pin(path: &Path) -> Result<OpenCodeVersionPin> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("read OpenCode version pin {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("parse OpenCode version pin {}", path.display()))
+}
+
+fn parse_version_token(bytes: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(bytes)
+        .split_whitespace()
+        .find(|token| {
+            let token = token.strip_prefix('v').unwrap_or(token);
+            let mut parts = token.split('.');
+            matches!(
+                (parts.next(), parts.next(), parts.next()),
+                (Some(major), Some(minor), Some(patch))
+                    if major.chars().all(|c| c.is_ascii_digit())
+                        && minor.chars().all(|c| c.is_ascii_digit())
+                        && patch
+                            .chars()
+                            .take_while(|c| *c != '-' && *c != '+')
+                            .all(|c| c.is_ascii_digit())
+            )
+        })
+        .map(|token| token.strip_prefix('v').unwrap_or(token).to_string())
 }
 
 fn request_with_workspace_paths(


### PR DESCRIPTION
## What changed

- Added `config/opencode-version.json` pinning OpenCode to `1.2.6`.
- Added a harness startup probe for `--harness opencode`; version drift fails before model execution and names the bump procedure.
- Added `docs/opencode-substrate.md` with the bump process and the requirement for a narrowly scoped, spend-capped `CERBERUS_SMOKE_OPENROUTER_KEY`.
- Added a committed tiny live-smoke fixture and `scripts/opencode-live-smoke.sh`.
- Added a weekly/manual `.github/workflows/opencode-live-smoke.yml` that skips cleanly when the smoke key is absent and files/updates a GitHub issue on live smoke failure.

## Validation

- `./scripts/verify.sh`
- `actionlint .github/workflows/opencode-live-smoke.yml`
- `CERBERUS_SMOKE_OPENROUTER_KEY=dummy CERBERUS_SMOKE_OPENCODE_BINARY="$PWD/fixtures/bin/fake-opencode" CERBERUS_SMOKE_OPENROUTER_MODEL=openrouter/fake/opencode-reviewer ./scripts/opencode-live-smoke.sh`
- `act -l -W .github/workflows/opencode-live-smoke.yml`
- `npm view opencode-ai@1.2.6 version`

## Notes

- `act workflow_dispatch -W .github/workflows/opencode-live-smoke.yml -n` discovered the workflow but could not connect to Docker on this host.
- `CERBERUS_SMOKE_OPENROUTER_KEY` is not currently provisioned in repo secrets, so branch/manual dispatch should exercise the annotated skip path until the operator adds the spend-capped key.
