### PR TITLE
feat: add stack-aware review doctrine

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -395,6 +395,32 @@ mod tests {
     }
 
     #[test]
+    fn prompts_embed_stack_aware_review_doctrine() {
+        let request = minimal_request();
+        let capabilities = ContextCapabilities::from_request(&request);
+        let master =
+            build_master_prompt(&request, &capabilities, "sha256:test", out_path()).unwrap();
+        let message =
+            build_opencode_message(&request, &capabilities, "sha256:test", out_path()).unwrap();
+
+        for prompt in [&master, &message] {
+            assert!(
+                prompt.contains("Stack-aware review"),
+                "doctrine: stack-aware review section must be embedded"
+            );
+            assert!(
+                prompt.contains("Distinguish defects introduced by this PR from defects already present in lower stack PRs"),
+                "doctrine: reviewers must separate current-slice findings from lower-stack findings"
+            );
+            assert!(
+                prompt
+                    .contains("Verify the PR base and stack order before judging merge readiness"),
+                "doctrine: reviewers must inspect base/stack order"
+            );
+        }
+    }
+
+    #[test]
     fn prompts_instruct_file_emission_not_raw_stdout() {
         let request = minimal_request();
         let capabilities = ContextCapabilities::from_request(&request);

--- a/src/review_doctrine.md
+++ b/src/review_doctrine.md
@@ -32,4 +32,18 @@ Model-boundary judgment (mandatory dimension — heuristic-where-a-model-belongs
 - Did this change add a model call where deterministic code should own the behavior instead — scoring, policy, persistence, approval, sandboxing, security enforcement, or anything else an eval or an oracle-checkable test can verify directly?
 - This is architectural judgment about where a product boundary sits, not a rule engine: do not fail a review solely because a model call exists near policy code, or because a heuristic exists near natural-language input — ground the finding in the specific behavior the diff actually changed.
 
+Stack-aware review: when the request is part of a stacked PR chain, review the
+current PR as a slice, not as the whole feature.
+- Verify the PR base and stack order before judging merge readiness. The bottom
+  PR should target the default branch; upper PRs should target the previous
+  stack branch until lower slices merge.
+- Distinguish defects introduced by this PR from defects already present in lower stack PRs.
+  Findings should land on the first PR that introduced the problem.
+- Treat missing lower-stack context as residual risk, not as proof of a bug in
+  the upper PR.
+- Call out partitioning mistakes explicitly: "belongs in lower PR",
+  "upper PR depends on an unmerged behavior", or "base branch appears wrong".
+- For merge-readiness comments, require bottom-up merge order and a final
+  default-branch sync check after the last PR lands.
+
 Report discipline: prefer a few high-conviction findings over a long list of nits; calibrate severity honestly; ground every finding in a line you inspected.


### PR DESCRIPTION
## Summary
- Add a "Stack-aware review" section to `src/review_doctrine.md`: verify PR base/stack order, attribute defects to the introducing slice, treat missing lower-stack context as residual risk (not a bug in the upper PR), and require bottom-up merge order with a final default-branch sync check.
- Pin the doctrine's presence in both the master and OpenCode prompts via `prompt::tests::prompts_embed_stack_aware_review_doctrine`.

Companion to the weave repo's `docs/stacked-diff-discipline.md` (weave-018): reviewers now get instructions matching the discipline agent lanes use when publishing stacked PRs.

## Verification
- `./scripts/verify.sh` (includes the new test, gitleaks scan, full workspace test suite)

Agent: codex-weave-018
Agent-Surface: Claude Code
Agent-Model: claude-sonnet-5
Agent-Task: weave-018