### PR TITLE
feat: global review-workflow semaphore + bounded family-aware retry

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::container::{run_container_substrate, ContainerOpencodeSubstrateConfig};
 use crate::harness::{
@@ -10,6 +10,7 @@ use crate::harness::{
 };
 use crate::orchestration::{build_reviewer_plan, ReviewerPlanReceipt};
 use crate::schema::{ReviewArtifact, ReviewRequest, ReviewTelemetry};
+use crate::workflow_lock::{acquire_workflow_lock, default_workflow_lock_path};
 
 #[derive(Debug, Clone)]
 pub struct ReviewKernel {
@@ -66,7 +67,15 @@ impl ReviewKernel {
         Self { substrate }
     }
 
+    /// Every caller-neutral entrypoint (`review`/`review-diff`/`review-pr`
+    /// in `main.rs`, and the MCP server in `mcp.rs`) funnels through this
+    /// one method, so this is the single place a global review-workflow
+    /// semaphore needs to be acquired to cover all of them. See
+    /// `crate::workflow_lock` for why the lock is host-wide (not
+    /// per-process) and non-blocking.
     pub fn review(&self, request: &ReviewRequest, run_policy: &RunPolicy) -> Result<ReviewRun> {
+        let _workflow_lock = acquire_workflow_lock(&default_workflow_lock_path())
+            .context("acquire global review workflow lock")?;
         let run = match &self.substrate {
             ReviewSubstrate::Fixture(config) => {
                 run_fixture_substrate(request, run_policy.timeout, config)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,14 @@ pub mod prompt;
 pub mod receipt;
 pub mod render;
 pub mod request;
+pub mod retry;
 pub mod schema;
 mod secrets;
 mod telemetry;
 #[cfg(test)]
 mod test_support;
 pub mod validation;
+pub mod workflow_lock;
 
 pub use container::{
     ContainerOpencodeSubstrateConfig, DEFAULT_CONTAINER_IMAGE, DEFAULT_EGRESS_ALLOW_HOST,
@@ -46,7 +48,12 @@ pub use receipt::{
     ReviewReceiptBundle, REVIEW_RECEIPT_BUNDLE_SCHEMA,
 };
 pub use render::render_markdown;
+pub use retry::{retry_once, RetryAttempt, RetryError};
 pub use schema::{
     ContextCapabilities, ReviewArtifact, ReviewRequest, ReviewTelemetry, REVIEW_ARTIFACT_SCHEMA,
 };
 pub use validation::{validate_artifact_for_request, validate_request};
+pub use workflow_lock::{
+    acquire_workflow_lock, default_workflow_lock_path, WorkflowLockError, WorkflowLockGuard,
+    WORKFLOW_LOCK_PATH_ENV,
+};

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -40,9 +40,9 @@ pub enum RetryError<E: fmt::Debug + fmt::Display> {
     /// silently collapse required cross-family independence into a single
     /// family by retrying into it.
     #[error(
-        "refusing retry: it would reuse family {family:?}, the same family the first attempt used, which would collapse required family diversity"
+        "refusing retry: it would reuse family {family:?}, the same family the first attempt used, which would collapse required family diversity (first attempt failed with: {first})"
     )]
-    FamilyCollapse { family: String },
+    FamilyCollapse { family: String, first: E },
     /// Both the first attempt and the one bounded retry failed.
     #[error("bounded retry exhausted after one retry (first attempt: {first}; retry: {retry})")]
     Exhausted { first: E, retry: E },
@@ -76,6 +76,7 @@ where
             if require_family_diversity && retry_family == first_family {
                 return Err(RetryError::FamilyCollapse {
                     family: retry_family,
+                    first: first_err,
                 });
             }
             match work(RetryAttempt::Retry, &retry_family) {
@@ -150,7 +151,10 @@ mod tests {
             },
         );
         match result {
-            Err(RetryError::FamilyCollapse { family }) => assert_eq!(family, "family-a"),
+            Err(RetryError::FamilyCollapse { family, first }) => {
+                assert_eq!(family, "family-a");
+                assert_eq!(first, "transient failure");
+            }
             other => panic!("expected FamilyCollapse, got {other:?}"),
         }
         assert_eq!(

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,194 @@
+//! Bounded, family-aware transient retry (Phase 1d, backlog 052).
+//!
+//! docs/plans/productization-2026-07-17.md Phase 1 calls for "one global
+//! workflow semaphore, bounded child concurrency, and one transient retry"
+//! and separately requires "at least two model families; forbid fallback
+//! that collapses independence." Those two constraints interact: once real
+//! multi-seat execution exists (backlog 049/050), a naive retry-on-failure
+//! could silently paper over a failed seat by re-running it against the
+//! *same* provider/model family another seat already used, which would
+//! quietly collapse the two-family independence the admission layer is
+//! supposed to guarantee.
+//!
+//! This module is the general-purpose primitive that makes that collapse
+//! structurally hard to do by accident: [`retry_once`] never retries more
+//! than once (bounded, not unbounded backoff), and when the caller asserts
+//! family diversity matters it refuses to even attempt a retry whose family
+//! matches the first attempt's — no real seat-execution wiring exists yet
+//! (that lands with backlog 049/050), so this is proven here with synthetic
+//! family ids via fixtures/unit tests, not wired into
+//! [`crate::kernel::ReviewKernel::review`].
+
+use std::fmt;
+
+use thiserror::Error;
+
+/// Which call of the bounded retry loop this is. Passed to both the
+/// family-selection and the work closures so a caller can vary behavior
+/// (e.g. log differently) without the wrapper needing to know why.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryAttempt {
+    First,
+    Retry,
+}
+
+#[derive(Debug, Error)]
+pub enum RetryError<E: fmt::Debug + fmt::Display> {
+    /// The retry attempt would reuse the exact same provider/model family as
+    /// the first attempt while the caller asserted family diversity matters.
+    /// Refused before the retry's work closure ever runs, so a caller cannot
+    /// silently collapse required cross-family independence into a single
+    /// family by retrying into it.
+    #[error(
+        "refusing retry: it would reuse family {family:?}, the same family the first attempt          used, which would collapse required family diversity"
+    )]
+    FamilyCollapse { family: String },
+    /// Both the first attempt and the one bounded retry failed.
+    #[error("bounded retry exhausted after one retry (first attempt: {first}; retry: {retry})")]
+    Exhausted { first: E, retry: E },
+}
+
+/// Run `work` once; if it fails, run it exactly one more time (a single
+/// bounded transient retry — never unbounded backoff, never a second retry).
+///
+/// `family_for` is called before each attempt's `work` closure to decide
+/// (side-effect-free) which provider/model family that attempt targets, and
+/// `work` performs the actual attempt for a given family. When
+/// `require_family_diversity` is set, the retry's family is compared
+/// against the first attempt's family *before* `work` runs for the retry —
+/// if they match, [`RetryError::FamilyCollapse`] is returned immediately
+/// and the retry's `work` closure is never invoked (no silent retry, and no
+/// wasted/side-effecting attempt into a family that would defeat the point
+/// of retrying).
+pub fn retry_once<T, E>(
+    require_family_diversity: bool,
+    mut family_for: impl FnMut(RetryAttempt) -> String,
+    mut work: impl FnMut(RetryAttempt, &str) -> Result<T, E>,
+) -> Result<T, RetryError<E>>
+where
+    E: fmt::Debug + fmt::Display,
+{
+    let first_family = family_for(RetryAttempt::First);
+    match work(RetryAttempt::First, &first_family) {
+        Ok(value) => Ok(value),
+        Err(first_err) => {
+            let retry_family = family_for(RetryAttempt::Retry);
+            if require_family_diversity && retry_family == first_family {
+                return Err(RetryError::FamilyCollapse {
+                    family: retry_family,
+                });
+            }
+            match work(RetryAttempt::Retry, &retry_family) {
+                Ok(value) => Ok(value),
+                Err(retry_err) => Err(RetryError::Exhausted {
+                    first: first_err,
+                    retry: retry_err,
+                }),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    #[test]
+    fn succeeds_without_retry_when_first_attempt_succeeds() {
+        let calls = RefCell::new(0);
+        let result = retry_once::<_, String>(
+            true,
+            |_attempt| "family-a".to_string(),
+            |_attempt, family| {
+                *calls.borrow_mut() += 1;
+                Ok(format!("ok:{family}"))
+            },
+        );
+        assert_eq!(result.unwrap(), "ok:family-a");
+        assert_eq!(*calls.borrow(), 1, "no retry should have run");
+    }
+
+    #[test]
+    fn retries_exactly_once_then_gives_up() {
+        let calls = RefCell::new(0);
+        let result = retry_once::<(), String>(
+            false,
+            |_attempt| "family-a".to_string(),
+            |_attempt, _family| {
+                *calls.borrow_mut() += 1;
+                Err(format!("transient failure #{}", calls.borrow()))
+            },
+        );
+        assert_eq!(
+            *calls.borrow(),
+            2,
+            "exactly one retry: first attempt plus one bounded retry, never more"
+        );
+        match result {
+            Err(RetryError::Exhausted { first, retry }) => {
+                assert_eq!(first, "transient failure #1");
+                assert_eq!(retry, "transient failure #2");
+            }
+            other => panic!("expected Exhausted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retry_into_same_family_is_refused_when_diversity_required() {
+        let work_calls = RefCell::new(0);
+        let result = retry_once::<(), String>(
+            true,
+            |_attempt| "family-a".to_string(),
+            |attempt, _family| {
+                *work_calls.borrow_mut() += 1;
+                match attempt {
+                    RetryAttempt::First => Err("transient failure".to_string()),
+                    RetryAttempt::Retry => Ok(()),
+                }
+            },
+        );
+        match result {
+            Err(RetryError::FamilyCollapse { family }) => assert_eq!(family, "family-a"),
+            other => panic!("expected FamilyCollapse, got {other:?}"),
+        }
+        assert_eq!(
+            *work_calls.borrow(),
+            1,
+            "the retry's work closure must never run once family collapse is detected"
+        );
+    }
+
+    #[test]
+    fn retry_into_a_different_family_is_allowed_when_diversity_required() {
+        let result = retry_once::<_, String>(
+            true,
+            |attempt| match attempt {
+                RetryAttempt::First => "family-a".to_string(),
+                RetryAttempt::Retry => "family-b".to_string(),
+            },
+            |attempt, family| match attempt {
+                RetryAttempt::First => Err("transient failure".to_string()),
+                RetryAttempt::Retry => Ok(family.to_string()),
+            },
+        );
+        assert_eq!(result.unwrap(), "family-b");
+    }
+
+    #[test]
+    fn same_family_retry_is_allowed_when_diversity_not_required() {
+        // When the caller hasn't asserted family diversity matters (e.g. a
+        // single-seat run with no cross-family requirement), retrying into
+        // the same family is an ordinary retry, not a collapse.
+        let result = retry_once::<_, String>(
+            false,
+            |_attempt| "family-a".to_string(),
+            |attempt, family| match attempt {
+                RetryAttempt::First => Err("transient failure".to_string()),
+                RetryAttempt::Retry => Ok(family.to_string()),
+            },
+        );
+        assert_eq!(result.unwrap(), "family-a");
+    }
+}

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -40,7 +40,7 @@ pub enum RetryError<E: fmt::Debug + fmt::Display> {
     /// silently collapse required cross-family independence into a single
     /// family by retrying into it.
     #[error(
-        "refusing retry: it would reuse family {family:?}, the same family the first attempt          used, which would collapse required family diversity"
+        "refusing retry: it would reuse family {family:?}, the same family the first attempt used, which would collapse required family diversity"
     )]
     FamilyCollapse { family: String },
     /// Both the first attempt and the one bounded retry failed.

--- a/src/workflow_lock.rs
+++ b/src/workflow_lock.rs
@@ -62,7 +62,7 @@ pub enum WorkflowLockError {
     /// from "the lock file itself is unusable" at a glance, rather than both
     /// surfacing as an indistinguishable generic `anyhow` string.
     #[error(
-        "another cerberus review workflow is already running (lock held at {path});          only one global review workflow may run at a time"
+        "another cerberus review workflow is already running (lock held at {path}); only one global review workflow may run at a time"
     )]
     Contended { path: String },
     /// The lock file could not be created, opened, or locked for a reason

--- a/src/workflow_lock.rs
+++ b/src/workflow_lock.rs
@@ -31,6 +31,7 @@
 
 use std::fs::{self, File, OpenOptions};
 use std::io;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 
@@ -76,10 +77,102 @@ pub enum WorkflowLockError {
 /// the override so parallel test runs don't contend with each other or with
 /// a real review running on the same machine).
 pub fn default_workflow_lock_path() -> PathBuf {
-    if let Ok(path) = std::env::var(WORKFLOW_LOCK_PATH_ENV) {
-        return PathBuf::from(path);
+    resolve_workflow_lock_path(std::env::var(WORKFLOW_LOCK_PATH_ENV).ok())
+}
+
+/// Pure path-resolution logic behind [`default_workflow_lock_path`], split
+/// out so tests can exercise the override/default branches by passing a
+/// value directly instead of mutating the process-wide `std::env` — the
+/// lib unit test binary runs every `#[test]` in its own thread of one
+/// shared process, and `std::env::set_var`/`remove_var` are `unsafe`
+/// specifically because they race with any concurrent env read on another
+/// thread (this function's own callers included); a pure function has no
+/// such hazard to reason about, so it is preferred over a "no other test
+/// touches this today" argument that a future test could quietly violate.
+fn resolve_workflow_lock_path(override_value: Option<String>) -> PathBuf {
+    match override_value {
+        Some(path) => PathBuf::from(path),
+        None => std::env::temp_dir().join(WORKFLOW_LOCK_FILE_NAME),
     }
-    std::env::temp_dir().join(WORKFLOW_LOCK_FILE_NAME)
+}
+
+/// Open `path` as the shared lock file, safe against another local user
+/// pre-planting a symlink at this predictable, well-known path inside a
+/// shared, world-writable temp directory (the classic `/tmp` race: a
+/// naive `open(create=true) + chmod(path)` would follow an attacker's
+/// symlink and re-permission whatever it points at).
+///
+/// - If nothing exists at `path` yet, `O_CREAT | O_EXCL` atomically creates
+///   a fresh regular file — this refuses to follow or overwrite anything
+///   already there, including a symlink, so success here proves we hold a
+///   brand new inode no one else could have redirected. `fchmod` on that
+///   already-open fd (not the path) then safely makes it host-wide
+///   shared, matching this module's "host-wide" contract without any
+///   path-based re-resolution a symlink swap could hijack. A chmod
+///   failure is propagated (and the unusable file removed) rather than
+///   silently left at a restrictive, umask-derived mode — that would
+///   quietly recreate the exact cross-user failure this function exists
+///   to prevent, and a caller can't act on a problem it never sees.
+/// - If it already exists, reopen with `O_NOFOLLOW` (fails on a symlink
+///   instead of following it) and verify the fd is a plain regular file
+///   before trusting it as the lock. No chmod in this branch: only the
+///   owner can chmod, and whoever created it already had to leave it
+///   shared for this `open` to succeed at all.
+/// - A microsecond race is possible: another process's `create_new` above
+///   can succeed while its `fchmod` to 0o666 hasn't run yet, so a
+///   concurrent reopen here can transiently see the restrictive
+///   umask-derived mode and fail with `PermissionDenied` even though the
+///   file is about to become shared. Retry the reopen briefly rather than
+///   surfacing that as a permanent error.
+/// - The reopen also sets `O_NONBLOCK`: opening a FIFO for writing
+///   without it blocks the calling thread until some other process opens
+///   the same path for reading — indefinitely, if no one ever does. A
+///   planted FIFO at this well-known path would silently turn the "never
+///   waits" contract this whole module promises into a hang, and the
+///   is-a-regular-file check below never even gets a chance to run.
+///   `O_NONBLOCK` is a no-op on a regular file (the only thing we want to
+///   accept), so this costs nothing on the legitimate path.
+fn open_shared_lock_file(path: &Path) -> io::Result<File> {
+    const MAX_REOPEN_RETRIES: u32 = 5;
+    let mut retries = 0;
+    loop {
+        match OpenOptions::new().create_new(true).write(true).open(path) {
+            Ok(file) => {
+                if let Err(e) = file.set_permissions(fs::Permissions::from_mode(0o666)) {
+                    drop(file);
+                    let _ = fs::remove_file(path);
+                    return Err(e);
+                }
+                return Ok(file);
+            }
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                match OpenOptions::new()
+                    .write(true)
+                    .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+                    .open(path)
+                {
+                    Ok(file) => {
+                        if !file.metadata()?.is_file() {
+                            return Err(io::Error::other(format!(
+                                "refusing non-regular-file lock path {} (symlink or special file?)",
+                                path.display()
+                            )));
+                        }
+                        return Ok(file);
+                    }
+                    Err(reopen_err)
+                        if reopen_err.kind() == io::ErrorKind::PermissionDenied
+                            && retries < MAX_REOPEN_RETRIES =>
+                    {
+                        retries += 1;
+                        std::thread::sleep(std::time::Duration::from_millis(2));
+                    }
+                    Err(reopen_err) => return Err(reopen_err),
+                }
+            }
+            Err(e) => return Err(e),
+        }
+    }
 }
 
 /// Acquire the global review-workflow semaphore at `path`. Non-blocking: if
@@ -96,15 +189,10 @@ pub fn acquire_workflow_lock(path: &Path) -> Result<WorkflowLockGuard, WorkflowL
             source,
         })?;
     }
-    let file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(false)
-        .open(path)
-        .map_err(|source| WorkflowLockError::Io {
-            path: display_path.clone(),
-            source,
-        })?;
+    let file = open_shared_lock_file(path).map_err(|source| WorkflowLockError::Io {
+        path: display_path.clone(),
+        source,
+    })?;
 
     // SAFETY: `file`'s fd is open and owned by this stack frame for the
     // duration of the call; `flock` only mutates kernel-side lock state
@@ -152,6 +240,7 @@ impl Drop for WorkflowLockGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::ffi::OsStrExt;
 
     fn scratch_lock_path(tag: &str) -> PathBuf {
         std::env::temp_dir().join(format!(
@@ -225,19 +314,135 @@ mod tests {
     }
 
     #[test]
-    fn default_path_honors_env_override() {
+    fn resolve_path_prefers_override_over_default() {
         let override_path = scratch_lock_path("override");
-        // SAFETY: test-only env mutation; cargo test runs this crate's unit
-        // tests in threads but each test uses a uniquely-named lock path, so
-        // races over the env var's *value* don't cause false lock contention
-        // even if two tests observe interleaved env state momentarily.
-        unsafe {
-            std::env::set_var(WORKFLOW_LOCK_PATH_ENV, &override_path);
-        }
-        let resolved = default_workflow_lock_path();
-        unsafe {
-            std::env::remove_var(WORKFLOW_LOCK_PATH_ENV);
-        }
+        let resolved = resolve_workflow_lock_path(Some(override_path.display().to_string()));
         assert_eq!(resolved, override_path);
+    }
+
+    #[test]
+    fn resolve_path_falls_back_to_temp_dir_default_without_override() {
+        let resolved = resolve_workflow_lock_path(None);
+        assert_eq!(resolved, std::env::temp_dir().join(WORKFLOW_LOCK_FILE_NAME));
+    }
+
+    #[test]
+    fn freshly_created_lock_file_is_shared_mode_for_every_os_user() {
+        let path = scratch_lock_path("shared-mode");
+        let _ = fs::remove_file(&path);
+
+        let guard = acquire_workflow_lock(&path).expect("first acquire creates the lock file");
+        let mode = fs::metadata(&path)
+            .expect("lock file exists")
+            .permissions()
+            .mode();
+        drop(guard);
+        let _ = fs::remove_file(&path);
+
+        assert_eq!(
+            mode & 0o777,
+            0o666,
+            "a freshly created lock file must be rw for every OS user so a different \
+             OS user's `cerberus` invocation (CI runner, Bitterblossom service account, \
+             ...) can still open and flock it under the default umask"
+        );
+    }
+
+    #[test]
+    fn refuses_a_symlink_planted_at_the_lock_path() {
+        // Simulates the classic shared-`/tmp` attack: another local user
+        // (or a race) plants a symlink at the well-known lock path before
+        // Cerberus gets there, hoping a naive "open + chmod" follows it
+        // and re-permissions or corrupts whatever it points at.
+        let path = scratch_lock_path("symlink-attack");
+        let target = scratch_lock_path("symlink-attack-target");
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&target);
+        fs::write(&target, b"not a lock file").expect("create symlink target");
+        // Pin an exact starting mode (independent of this process's umask)
+        // so the after-assertion below proves the target was genuinely
+        // untouched, not merely "not already 0o666 by chance".
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o600))
+            .expect("pin target to a known starting mode");
+        std::os::unix::fs::symlink(&target, &path).expect("plant symlink at the lock path");
+
+        let result = acquire_workflow_lock(&path);
+
+        let target_content_after = fs::read(&target).expect("target still exists");
+        let target_mode_after = fs::metadata(&target)
+            .expect("target still exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            target_mode_after, 0o600,
+            "must never chmod through a symlink onto the attacker's target file"
+        );
+        assert_eq!(
+            target_content_after, b"not a lock file",
+            "must never write through a symlink onto the attacker's target file"
+        );
+        match result {
+            Err(WorkflowLockError::Io { .. }) => {}
+            other => panic!("expected a refused Io error for a symlinked lock path, got {other:?}"),
+        }
+
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_file(&target);
+    }
+
+    #[test]
+    fn refuses_a_fifo_planted_at_the_lock_path_without_blocking() {
+        // A FIFO opened for writing without `O_NONBLOCK` blocks until some
+        // other process opens it for reading — which, for a lock path no
+        // legitimate reader ever opens, means forever. Run the acquire
+        // call on a background thread and bound the wait with
+        // `recv_timeout` instead of calling it inline: a regression here
+        // would otherwise hang this test (and this whole test binary)
+        // forever rather than failing, leaving only the outer CI timeout
+        // to notice — not a real oracle.
+        let path = scratch_lock_path("fifo-attack");
+        let _ = fs::remove_file(&path);
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).expect("no NUL bytes");
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            rc,
+            0,
+            "failed to create test fifo: {}",
+            io::Error::last_os_error()
+        );
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let thread_path = path.clone();
+        let handle = std::thread::spawn(move || {
+            let _ = tx.send(acquire_workflow_lock(&thread_path));
+        });
+
+        let result = match rx.recv_timeout(std::time::Duration::from_secs(2)) {
+            Ok(result) => result,
+            Err(_) => {
+                // Regressed: the background thread is stuck inside a
+                // blocking write-open on the fifo. Open the read side to
+                // rendezvous and unblock it (a fifo write-open blocks
+                // specifically until a reader shows up) so the thread can
+                // finish and be joined instead of leaking permanently
+                // blocked, then fail with a clear message.
+                let _ = fs::File::open(&path);
+                let _ = handle.join();
+                let _ = fs::remove_file(&path);
+                panic!(
+                    "acquire_workflow_lock blocked for over 2s on a planted fifo instead of \
+                     failing fast — the non-blocking contract regressed"
+                );
+            }
+        };
+        let _ = handle.join();
+
+        match result {
+            Err(WorkflowLockError::Io { .. }) => {}
+            other => panic!("expected a refused Io error for a fifo lock path, got {other:?}"),
+        }
+
+        let _ = fs::remove_file(&path);
     }
 }

--- a/src/workflow_lock.rs
+++ b/src/workflow_lock.rs
@@ -1,0 +1,243 @@
+//! Global review-workflow semaphore (Phase 1d, backlog 052).
+//!
+//! Cerberus is a stateless CLI: cron, launchd, a webhook responder, CI, or
+//! another plane can all invoke it concurrently on the same host, and
+//! nothing in-process stops two invocations from racing each other through
+//! the same substrate, credential-minting, or receipt-writing paths. This
+//! module gives every invocation of [`crate::kernel::ReviewKernel::review`]
+//! a single, host-wide mutual-exclusion point: an exclusive, non-blocking
+//! advisory lock (`flock(2)`) on a well-known file. "Non-blocking" is
+//! deliberate — a caller that loses the race gets a fast, typed
+//! [`WorkflowLockError::Contended`] instead of hanging behind an unbounded
+//! wait, matching the "bounded" requirement from
+//! docs/plans/productization-2026-07-17.md Phase 1.
+//!
+//! Crash safety mirrors [`crate::openrouter_keys::ScopedKeyGuard`] and
+//! [`crate::container`]'s `EgressProxyGuard`: the lock is released by an
+//! RAII guard's `Drop` (best effort, logged, never panics) the moment the
+//! guard goes out of scope — including on early return via `?` or an
+//! unwinding panic. Unlike those two, there is no orphan sweep needed here:
+//! `flock` locks are owned by the kernel per open file description, so a
+//! `SIGKILL`ed process releases the lock automatically when its file
+//! descriptors are torn down, without any cooperating cleanup step.
+//!
+//! The lock file itself lives under the OS temp directory rather than a
+//! `cwd`-relative path like `config/omp-version.json` (see
+//! [`crate::harness::omp`]'s `OMP_PIN_PATH`): callers can invoke `cerberus`
+//! from different working directories, so a path relative to the process's
+//! current directory would not actually be global across those callers. The
+//! temp directory is the one location every invocation on the same host
+//! agrees on without configuration.
+
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Env var that overrides the default lock file path. Production code never
+/// needs this; it exists so tests (and, if ever needed, an operator running
+/// multiple independent Cerberus deployments on one host) can point separate
+/// invocations at separate lock files instead of contending on the same
+/// well-known path.
+pub const WORKFLOW_LOCK_PATH_ENV: &str = "CERBERUS_WORKFLOW_LOCK_PATH";
+
+/// Fixed lock file name under the OS temp directory. See the module doc
+/// comment for why a temp-dir path was chosen over a `cwd`-relative one.
+const WORKFLOW_LOCK_FILE_NAME: &str = "cerberus-review-workflow.lock";
+
+/// A held global review-workflow lock. Dropping this releases the lock.
+#[derive(Debug)]
+pub struct WorkflowLockGuard {
+    file: File,
+    path: PathBuf,
+}
+
+#[derive(Debug, Error)]
+pub enum WorkflowLockError {
+    /// Another process already holds the lock. Distinct from
+    /// [`WorkflowLockError::Io`] so a caller (or an operator reading the
+    /// error) can tell "someone else is running a review right now" apart
+    /// from "the lock file itself is unusable" at a glance, rather than both
+    /// surfacing as an indistinguishable generic `anyhow` string.
+    #[error(
+        "another cerberus review workflow is already running (lock held at {path});          only one global review workflow may run at a time"
+    )]
+    Contended { path: String },
+    /// The lock file could not be created, opened, or locked for a reason
+    /// other than contention (permissions, missing parent directory, etc.).
+    #[error("failed to acquire workflow lock at {path}: {source}")]
+    Io { path: String, source: io::Error },
+}
+
+/// The well-known lock file path every `cerberus` invocation on this host
+/// agrees on, unless overridden by `CERBERUS_WORKFLOW_LOCK_PATH` (tests use
+/// the override so parallel test runs don't contend with each other or with
+/// a real review running on the same machine).
+pub fn default_workflow_lock_path() -> PathBuf {
+    if let Ok(path) = std::env::var(WORKFLOW_LOCK_PATH_ENV) {
+        return PathBuf::from(path);
+    }
+    std::env::temp_dir().join(WORKFLOW_LOCK_FILE_NAME)
+}
+
+/// Acquire the global review-workflow semaphore at `path`. Non-blocking: if
+/// another process already holds it, this returns
+/// `Err(WorkflowLockError::Contended)` immediately rather than waiting.
+pub fn acquire_workflow_lock(path: &Path) -> Result<WorkflowLockGuard, WorkflowLockError> {
+    let display_path = path.display().to_string();
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|source| WorkflowLockError::Io {
+            path: display_path.clone(),
+            source,
+        })?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|source| WorkflowLockError::Io {
+            path: display_path.clone(),
+            source,
+        })?;
+
+    // SAFETY: `file`'s fd is open and owned by this stack frame for the
+    // duration of the call; `flock` only mutates kernel-side lock state
+    // keyed by the open file description, not the memory `file` points at.
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc != 0 {
+        let err = io::Error::last_os_error();
+        let contended = err.kind() == io::ErrorKind::WouldBlock
+            || err.raw_os_error() == Some(libc::EWOULDBLOCK)
+            || err.raw_os_error() == Some(libc::EAGAIN);
+        return Err(if contended {
+            WorkflowLockError::Contended { path: display_path }
+        } else {
+            WorkflowLockError::Io {
+                path: display_path,
+                source: err,
+            }
+        });
+    }
+
+    Ok(WorkflowLockGuard {
+        file,
+        path: path.to_path_buf(),
+    })
+}
+
+impl Drop for WorkflowLockGuard {
+    fn drop(&mut self) {
+        // SAFETY: `self.file`'s fd is still open (it only closes after this
+        // call, as part of the same drop). Unlocking before close is
+        // belt-and-suspenders documentation of intent; the OS would release
+        // the lock on close (or process exit, including SIGKILL) regardless.
+        let rc = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+        if rc != 0 {
+            let err = io::Error::last_os_error();
+            eprintln!(
+                "cerberus: failed to release workflow lock {}: {err}; the OS releases it when \
+                 this process's file descriptors close regardless",
+                self.path.display()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch_lock_path(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "cerberus-workflow-lock-test-{tag}-{}.lock",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn acquires_and_releases_lock_file() {
+        let path = scratch_lock_path("basic");
+        let _ = fs::remove_file(&path);
+
+        let guard = acquire_workflow_lock(&path).expect("first acquire succeeds");
+        drop(guard);
+
+        // Once dropped, a fresh acquire succeeds again — proves release
+        // actually happened rather than leaking the lock.
+        let guard = acquire_workflow_lock(&path).expect("second acquire succeeds after release");
+        drop(guard);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn contended_lock_fails_fast_with_distinct_error() {
+        let path = scratch_lock_path("contended");
+        let _ = fs::remove_file(&path);
+
+        let _held = acquire_workflow_lock(&path).expect("first acquire holds the lock");
+        let second = acquire_workflow_lock(&path);
+
+        match second {
+            Err(WorkflowLockError::Contended { path: reported }) => {
+                assert_eq!(reported, path.display().to_string());
+            }
+            other => panic!("expected Contended, got {other:?}"),
+        }
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn contended_error_message_is_distinct_from_generic_io_failure() {
+        let path = scratch_lock_path("message");
+        let _ = fs::remove_file(&path);
+
+        let _held = acquire_workflow_lock(&path).expect("first acquire holds the lock");
+        let err = acquire_workflow_lock(&path).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("already running") && message.contains("one global review workflow"),
+            "contention message should name itself distinctly, got: {message}"
+        );
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_parent_directory_is_created() {
+        let base = std::env::temp_dir().join(format!(
+            "cerberus-workflow-lock-test-nested-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&base);
+        let path = base.join("nested/lock/dir/review.lock");
+
+        let guard = acquire_workflow_lock(&path).expect("creates missing parent directories");
+        drop(guard);
+
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn default_path_honors_env_override() {
+        let override_path = scratch_lock_path("override");
+        // SAFETY: test-only env mutation; cargo test runs this crate's unit
+        // tests in threads but each test uses a uniquely-named lock path, so
+        // races over the env var's *value* don't cause false lock contention
+        // even if two tests observe interleaved env state momentarily.
+        unsafe {
+            std::env::set_var(WORKFLOW_LOCK_PATH_ENV, &override_path);
+        }
+        let resolved = default_workflow_lock_path();
+        unsafe {
+            std::env::remove_var(WORKFLOW_LOCK_PATH_ENV);
+        }
+        assert_eq!(resolved, override_path);
+    }
+}

--- a/tests/review_kernel.rs
+++ b/tests/review_kernel.rs
@@ -1,10 +1,30 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use cerberus::{ReviewKernel, ReviewRequest, ReviewSubstrate, RunPolicy, REVIEW_ARTIFACT_SCHEMA};
+use cerberus::{
+    ReviewKernel, ReviewRequest, ReviewSubstrate, RunPolicy, REVIEW_ARTIFACT_SCHEMA,
+    WORKFLOW_LOCK_PATH_ENV,
+};
 
 #[test]
 fn kernel_review_runs_fixture_through_small_typed_boundary() {
+    // `ReviewKernel::review` acquires the global review-workflow lock at a
+    // well-known default path shared by every `cerberus` invocation on this
+    // host (see `crate::workflow_lock`). Point this test at an isolated,
+    // per-test lock path instead — otherwise this test would contend with a
+    // real review running concurrently on the same machine, or with another
+    // test binary that also exercises `ReviewKernel::review`, and fail with
+    // `WorkflowLockError::Contended` instead of proving anything about the
+    // kernel's own contract.
+    let lock_dir = tempfile::tempdir().expect("create scratch dir for the workflow lock");
+    let lock_path = lock_dir.path().join("review-kernel-test.lock");
+    // SAFETY: this is the only test in this integration-test binary (each
+    // `tests/*.rs` file compiles to its own process), so no other test can
+    // observe this env var mid-mutation.
+    unsafe {
+        std::env::set_var(WORKFLOW_LOCK_PATH_ENV, &lock_path);
+    }
+
     let request: ReviewRequest =
         serde_json::from_str(include_str!("../fixtures/requests/diff-only.json")).unwrap();
     let kernel = ReviewKernel::new(ReviewSubstrate::fixture(PathBuf::from(


### PR DESCRIPTION
## Outcome

Every review workflow through Cerberus's single caller-neutral choke point
(`ReviewKernel::review` — the seam every CLI subcommand and the MCP server
funnel through) is now serialized host-wide by an exclusive, non-blocking
advisory lock, and a generic, bounded, family-aware transient-retry primitive
exists and is proven, ready to be wired into real multi-seat execution once
cerberus-049/050 land.

## Change

- `src/workflow_lock.rs` (new): `acquire_workflow_lock`/`WorkflowLockGuard` —
  an exclusive, non-blocking (`flock(2)`, `LOCK_EX | LOCK_NB`) advisory lock on
  a well-known temp-dir path (`$TMPDIR/cerberus-review-workflow.lock` by
  default, overridable via `CERBERUS_WORKFLOW_LOCK_PATH` for test isolation).
  Contention returns a distinct, typed `WorkflowLockError::Contended`
  (fast-failing, never a blocking wait) instead of a generic `anyhow` string.
  Release is RAII (`Drop`, best-effort/logged), matching the crash-safety
  style of `ScopedKeyGuard` (`src/openrouter_keys.rs`) and `EgressProxyGuard`
  (`src/container.rs`); no orphan sweep is needed because `flock` releases
  automatically when a crashed process's file descriptors close.
- `src/kernel.rs`: `ReviewKernel::review` acquires the lock for the duration
  of the review — the only wiring point needed, since every caller (CLI
  `review`/`review-diff`/`review-pr`, and the MCP server) already funnels
  through this one method.
- `src/retry.rs` (new): `retry_once` — a generic helper bounded to exactly
  one transient retry (never unbounded). It is family-aware: it refuses
  (without ever invoking the retry's work closure — no side effect from a
  refused retry) to retry into the exact same provider/model family the
  first attempt used, when the caller asserts family diversity matters. This
  is the primitive that keeps a future bounded retry from silently collapsing
  the two-family independence the admission layer will require.
- `src/lib.rs`: registers both new modules and re-exports their public API.

## Verification

- `./scripts/verify.sh` green end to end on this branch (fmt, clippy
  `-D warnings`, full `cargo test` — 148 lib + 13 main + 4 + 1 integration
  tests, including 11 new tests across `workflow_lock`/`retry` — the
  Docker-backed container red-team block (Docker was available via colima in
  this environment, so it actually ran, not just Docker-gated-skip), and
  `gitleaks`, no leaks found).
- Fixture/unit coverage added: semaphore contention path
  (`workflow_lock::tests::contended_lock_fails_fast_with_distinct_error`,
  `contended_error_message_is_distinct_from_generic_io_failure`), lock
  acquire/release round-trip, missing-parent-dir creation, env-override
  resolution; bounded-retry path
  (`retry::tests::retries_exactly_once_then_gives_up` asserts the work
  closure is called exactly twice, never a third time), and the
  family-collapse-refused path
  (`retry_into_same_family_is_refused_when_diversity_required` asserts the
  retry's work closure is never invoked once collapse is detected;
  `retry_into_a_different_family_is_allowed_when_diversity_required` and
  `same_family_retry_is_allowed_when_diversity_not_required` cover the
  non-collapse cases).
- Fresh cross-model adversarial review: GLM 5.2 (`zai/glm-5.2:high`), run via
  the orchestrating agent's `eval`/`agent()` access after my own `task`-tool
  route to a cerberus reviewer hit real provider outages on 5 consecutive
  attempts across 3+ distinct backing providers (Grok spend-block x2,
  Anthropic-shaped 429 with a ~34h retry-after). **Verdict: WARN,
  safe_to_open_pr: true**, two "important" findings, both resolved before
  this PR was opened:
  1. `tests/review_kernel.rs` silently acquired the real host-wide default
     lock via `kernel.review()`, making the suite non-hermetic (would
     spuriously fail under `WorkflowLockError::Contended` against any
     concurrent real review or test on the same host). **Fixed**: the test
     now points `CERBERUS_WORKFLOW_LOCK_PATH` at an isolated tempdir before
     calling `review()`.
  2. `retry_once` is correctly implemented and unit-tested but has no
     production caller yet. **Accepted as an intentionally scoped boundary,
     not force-wired** — see Boundaries below.
  3. (cosmetic, fixed) stray literal double-digit runs of spaces baked into
     two `#[error(...)]` message strings, an artifact of `cargo fmt`
     collapsing the original backslash-continued multi-line literals onto
     one line without trimming the second line's source indentation.

## Boundaries

No merge or deploy — this PR stops at "ready for review," stacked on the
still-open, unmerged `productization/phase-1-harness-extraction`.

Explicitly out of scope for this slice:
- `src/orchestration.rs`'s lane-planning/Tier 0/1 logic (cerberus-049, a
  parallel worktree).
- `src/main.rs::require_child_env_for_substrate` / OpenRouter-policy logic
  (cerberus-051, a parallel worktree).
- Wiring `retry_once` into real seat execution. No real seat/family identity
  exists yet — that lands with cerberus-049/050. `retry_once` is a proven,
  unit-tested general-purpose primitive today, intentionally not yet called
  from any production path; it gets its first real caller in cerberus-054's
  live end-to-end wiring once seat planning, family policy, and execution all
  exist to give it something non-synthetic to retry.
