### PR TITLE
feat: deny OpenRouter by default on the trusted review path (cerberus-051)

### DIFF
--- a/fixtures/openrouter-exceptions/any-scope.json
+++ b/fixtures/openrouter-exceptions/any-scope.json
@@ -1,0 +1,6 @@
+{
+  "scope": "any",
+  "reason": "Fixture exception for cerberus-051 unit/integration tests.",
+  "approved_by": "cerberus-051-test-fixture",
+  "digest": "sha256:42301a3ea4c0189c43b3cb22f9464fb0451b182d9e959df7026fe763f6bb1ca1"
+}

--- a/fixtures/openrouter-exceptions/opencode-fallback.json
+++ b/fixtures/openrouter-exceptions/opencode-fallback.json
@@ -1,0 +1,6 @@
+{
+  "scope": "opencode_fallback",
+  "reason": "Fixture exception scoped to the OpenCode fallback lane for cerberus-051 tests.",
+  "approved_by": "cerberus-051-test-fixture",
+  "digest": "sha256:98f3a73131b0b6c7405c460c854ca2acc3f7633aa124b1e83c602cbe1ca14429"
+}

--- a/fixtures/openrouter-exceptions/tampered.json
+++ b/fixtures/openrouter-exceptions/tampered.json
@@ -1,0 +1,6 @@
+{
+  "scope": "any",
+  "reason": "Fixture exception scoped to the OpenCode fallback lane for cerberus-051 tests.",
+  "approved_by": "cerberus-051-test-fixture",
+  "digest": "sha256:98f3a73131b0b6c7405c460c854ca2acc3f7633aa124b1e83c602cbe1ca14429"
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -34,6 +34,7 @@ grep -q 'possible values: opencode, omp, fixture, container-opencode' target/cer
 grep -q -- '--receipt-bundle' target/cerberus-review-help.txt
 grep -q -- '--producer-manifest' target/cerberus-review-help.txt
 grep -q -- '--openrouter-scoped-key' target/cerberus-review-help.txt
+grep -q -- '--openrouter-exception-file' target/cerberus-review-help.txt
 grep -q -- '--openrouter-provisioning-key-file' target/cerberus-review-help.txt
 grep -q -- '--openrouter-provisioning-key-env' target/cerberus-review-help.txt
 grep -q -- '--openrouter-key-limit-usd' target/cerberus-review-help.txt
@@ -61,6 +62,7 @@ grep -q -- '--gh-token-file' target/cerberus-review-pr-help.txt
 grep -q -- '--gh-token-env' target/cerberus-review-pr-help.txt
 grep -q -- '--remote-event' target/cerberus-review-pr-help.txt
 grep -q -- '--openrouter-scoped-key' target/cerberus-review-pr-help.txt
+grep -q -- '--openrouter-exception-file' target/cerberus-review-pr-help.txt
 cargo run --locked -- mcp --help > target/cerberus-mcp-help.txt
 grep -q 'Run the Cerberus MCP server over stdio' target/cerberus-mcp-help.txt
 
@@ -210,6 +212,96 @@ if cargo run --locked -- review \
   exit 1
 fi
 grep -q 'exactly one explicit' target/cerberus/scoped-key-both-sources.stderr
+
+# cerberus-051: subscription-first / OpenRouter-denied-by-default trusted
+# review policy. The admission check runs immediately after the substrate is
+# resolved, before any substrate binary is invoked, so these scenarios exit
+# fast against the fake opencode/omp binaries with no live network call.
+if cargo run --locked -- review \
+  --request fixtures/requests/diff-only.json \
+  --harness opencode \
+  --opencode-binary "$PWD/fixtures/bin/fake-opencode" \
+  --model openrouter/z-ai/glm-5.2 \
+  --allow-env OPENROUTER_API_KEY \
+  --out target/cerberus/openrouter-policy-denied-artifact.json \
+  > target/cerberus/openrouter-policy-denied.stdout \
+  2> target/cerberus/openrouter-policy-denied.stderr; then
+  echo "expected an OpenRouter model without a reviewed exception to be denied" >&2
+  exit 1
+fi
+grep -q 'denied by the subscription-first trusted review policy' target/cerberus/openrouter-policy-denied.stderr
+grep -q -- '--openrouter-exception-file' target/cerberus/openrouter-policy-denied.stderr
+
+if cargo run --locked -- review \
+  --request fixtures/requests/diff-only.json \
+  --harness omp \
+  --omp-binary "$PWD/fixtures/bin/fake-omp" \
+  --model openrouter/z-ai/glm-5.2 \
+  --allow-env OPENROUTER_API_KEY \
+  --out target/cerberus/openrouter-policy-omp-denied-artifact.json \
+  > target/cerberus/openrouter-policy-omp-denied.stdout \
+  2> target/cerberus/openrouter-policy-omp-denied.stderr; then
+  echo "expected an OMP OpenRouter model without a reviewed exception to be denied" >&2
+  exit 1
+fi
+grep -q 'denied by the subscription-first trusted review policy' target/cerberus/openrouter-policy-omp-denied.stderr
+
+cargo run --locked -- review \
+  --request fixtures/requests/diff-only.json \
+  --harness opencode \
+  --opencode-binary "$PWD/fixtures/bin/fake-opencode" \
+  --model openrouter/z-ai/glm-5.2 \
+  --allow-env OPENROUTER_API_KEY \
+  --openrouter-exception-file fixtures/openrouter-exceptions/any-scope.json \
+  --out target/cerberus/openrouter-policy-admitted-artifact.json \
+  --execution-plan target/cerberus/openrouter-policy-admitted-execution_plan.json \
+  --transcript target/cerberus/openrouter-policy-admitted-transcript.txt \
+  > target/cerberus/openrouter-policy-admitted.stdout \
+  2> target/cerberus/openrouter-policy-admitted.stderr
+test -s target/cerberus/openrouter-policy-admitted-artifact.json
+
+cargo run --locked -- review \
+  --request fixtures/requests/diff-only.json \
+  --harness opencode \
+  --opencode-binary "$PWD/fixtures/bin/fake-opencode" \
+  --model openrouter/z-ai/glm-5.2 \
+  --allow-env OPENROUTER_API_KEY \
+  --openrouter-exception-file fixtures/openrouter-exceptions/opencode-fallback.json \
+  --out target/cerberus/openrouter-policy-fallback-scoped-artifact.json \
+  > target/cerberus/openrouter-policy-fallback-scoped.stdout \
+  2> target/cerberus/openrouter-policy-fallback-scoped.stderr
+test -s target/cerberus/openrouter-policy-fallback-scoped-artifact.json
+
+# The opencode-fallback-scoped exception must not leak into covering OMP.
+if cargo run --locked -- review \
+  --request fixtures/requests/diff-only.json \
+  --harness omp \
+  --omp-binary "$PWD/fixtures/bin/fake-omp" \
+  --model openrouter/z-ai/glm-5.2 \
+  --allow-env OPENROUTER_API_KEY \
+  --openrouter-exception-file fixtures/openrouter-exceptions/opencode-fallback.json \
+  --out target/cerberus/openrouter-policy-omp-narrow-exception-artifact.json \
+  > target/cerberus/openrouter-policy-omp-narrow-exception.stdout \
+  2> target/cerberus/openrouter-policy-omp-narrow-exception.stderr; then
+  echo "expected an OpenCode-fallback-scoped exception to not cover OMP" >&2
+  exit 1
+fi
+grep -q 'does not cover' target/cerberus/openrouter-policy-omp-narrow-exception.stderr
+
+# A hand-edited exception (scope widened without recomputing the digest)
+# must be refused before it ever reaches substrate resolution.
+if cargo run --locked -- review \
+  --request fixtures/requests/diff-only.json \
+  --harness fixture \
+  --fixture-output fixtures/harness/valid-review.txt \
+  --openrouter-exception-file fixtures/openrouter-exceptions/tampered.json \
+  --out target/cerberus/openrouter-policy-tampered-artifact.json \
+  > target/cerberus/openrouter-policy-tampered.stdout \
+  2> target/cerberus/openrouter-policy-tampered.stderr; then
+  echo "expected a hand-edited OpenRouter exception file to be refused" >&2
+  exit 1
+fi
+grep -q 'digest mismatch' target/cerberus/openrouter-policy-tampered.stderr
 
 printf 'stale receipt should be removed before a failed run\n' \
   > target/cerberus/receipts/stale-before-failed-review.json

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod harness;
 pub mod kernel;
 pub mod mcp;
 pub mod openrouter_keys;
+pub mod openrouter_policy;
 pub mod orchestration;
 pub mod post;
 pub mod producer;
@@ -30,6 +31,9 @@ pub use openrouter_keys::{
     mint_review_key, scoped_key_name, sweep_orphaned_keys, KeyRecord, MintedKey,
     ProvisioningClient, ScopedKeyGuard, DEFAULT_BASE_URL as OPENROUTER_PROVISIONING_BASE_URL,
     REVIEW_KEY_NAME_PREFIX,
+};
+pub use openrouter_policy::{
+    require_openrouter_policy_for_substrate, OpenRouterException, OpenRouterExceptionScope,
 };
 pub use orchestration::{
     build_reviewer_plan, launch_planned_child_lanes, synthesize_lane_receipts_into_artifact,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use cerberus::harness::{
 };
 use cerberus::kernel::{ReviewKernel, ReviewRun, ReviewSubstrate, RunPolicy};
 use cerberus::openrouter_keys::{mint_review_key, ProvisioningClient, ScopedKeyGuard};
+use cerberus::openrouter_policy::{require_openrouter_policy_for_substrate, OpenRouterException};
 use cerberus::post::{build_post_plan, trusted_lifecycle, GithubClient, SummaryTarget};
 use cerberus::producer::{build_crucible_producer_manifest, CrucibleProducerManifestInput};
 use cerberus::receipt::{build_review_receipt_bundle, ReceiptBundleInput};
@@ -298,6 +299,21 @@ struct ScopedKeyArgs {
     openrouter_orphan_sweep_seconds: u64,
 }
 
+/// Explicit-source-only admission for the subscription-first, OpenRouter-
+/// denied-by-default trusted review policy (cerberus-051). No ambient flag
+/// or boolean escape hatch: an OpenRouter-routed model is admitted only when
+/// this names a file holding a reviewed, digested exception record whose
+/// scope covers the call site. See `cerberus::openrouter_policy`.
+#[derive(Debug, Args)]
+struct OpenRouterPolicyArgs {
+    /// Path to a reviewed, digested OpenRouter exception record (JSON;
+    /// `cerberus::openrouter_policy::OpenRouterException`) permitting this
+    /// review to route its resolved model through OpenRouter despite the
+    /// deny-by-default policy. Omit to run under the default deny.
+    #[arg(long)]
+    openrouter_exception_file: Option<PathBuf>,
+}
+
 /// Run a review from an existing `ReviewRequest.v1` file (built by `request`
 /// or `review-diff`, or hand-authored) and write a `ReviewArtifact.v1`.
 #[derive(Debug, Args)]
@@ -315,6 +331,8 @@ struct ReviewArgs {
     substrate: SubstrateArgs,
     #[command(flatten)]
     scoped_key: ScopedKeyArgs,
+    #[command(flatten)]
+    openrouter_policy: OpenRouterPolicyArgs,
     /// Wall-clock budget for the review, in seconds. Defaults to the
     /// request's own `policy.timeout_ms`.
     #[arg(long)]
@@ -428,6 +446,8 @@ struct ReviewPrArgs {
     substrate: SubstrateArgs,
     #[command(flatten)]
     scoped_key: ScopedKeyArgs,
+    #[command(flatten)]
+    openrouter_policy: OpenRouterPolicyArgs,
     /// Write a redacted ReviewReceiptBundle.v1 here instead of the default
     /// `<out-dir>/receipt-bundle.json`.
     #[arg(long)]
@@ -499,6 +519,8 @@ struct ReviewDiffArgs {
     substrate: SubstrateArgs,
     #[command(flatten)]
     scoped_key: ScopedKeyArgs,
+    #[command(flatten)]
+    openrouter_policy: OpenRouterPolicyArgs,
     /// Map the verdict to the process exit code: `none` (default) never
     /// blocks, `warn` blocks on WARN or FAIL, `fail` blocks only on FAIL. A
     /// blocking verdict exits 1; a Cerberus error (no valid artifact) always
@@ -664,6 +686,7 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
         markdown,
         substrate,
         scoped_key,
+        openrouter_policy,
         timeout_seconds,
         execution_plan,
         transcript,
@@ -698,7 +721,8 @@ fn review(args: ReviewArgs) -> Result<ExitCode> {
         .map(Duration::from_secs)
         .unwrap_or_else(|| Duration::from_millis(request.policy.timeout_ms));
     let substrate = review_substrate(substrate)?;
-    require_child_env_for_substrate(&request, &substrate)?;
+    let openrouter_exception = resolve_openrouter_exception(&openrouter_policy)?;
+    require_openrouter_policy_for_substrate(&request, &substrate, openrouter_exception.as_ref())?;
     for warning in credential_shaped_env_warnings(&request) {
         eprintln!("warning: {warning}");
     }
@@ -770,30 +794,17 @@ fn extend_review_allowed_env(request: &mut ReviewRequest, allowed_env: Vec<Strin
     }
 }
 
-fn require_child_env_for_substrate(
-    request: &ReviewRequest,
-    substrate: &ReviewSubstrate,
-) -> Result<()> {
-    let ReviewSubstrate::Opencode(config) = substrate else {
-        return Ok(());
-    };
-    let Some(model) = config.model.as_deref() else {
-        return Ok(());
-    };
-    if config.attach.is_some() || !model.starts_with("openrouter/") {
-        return Ok(());
-    }
-    if request
-        .policy
-        .allowed_env
-        .iter()
-        .any(|key| key == "OPENROUTER_API_KEY")
-    {
-        return Ok(());
-    }
-    Err(anyhow!(
-        "opencode OpenRouter model {model:?} requires OPENROUTER_API_KEY in Cerberus's scrubbed child environment; pass --allow-env OPENROUTER_API_KEY or include it in request.policy.allowed_env"
-    ))
+/// Resolve the CLI-level OpenRouter policy exception: `None` when
+/// `--openrouter-exception-file` was not passed (the default deny-by-default
+/// state), `Some` when the named file loads and self-verifies. See
+/// `cerberus::openrouter_policy::OpenRouterException::load`.
+fn resolve_openrouter_exception(
+    args: &OpenRouterPolicyArgs,
+) -> Result<Option<OpenRouterException>> {
+    args.openrouter_exception_file
+        .as_deref()
+        .map(OpenRouterException::load)
+        .transpose()
 }
 
 /// Backlog 013 M1: build the provisioning client when `--openrouter-scoped-key`
@@ -908,7 +919,8 @@ fn review_diff(args: ReviewDiffArgs) -> Result<ExitCode> {
         mint_scoped_openrouter_key(scoped_key_client.as_ref(), &mut request, &args.scoped_key)?;
     validate_request(&request)?;
     let substrate = review_substrate(args.substrate)?;
-    require_child_env_for_substrate(&request, &substrate)?;
+    let openrouter_exception = resolve_openrouter_exception(&args.openrouter_policy)?;
+    require_openrouter_policy_for_substrate(&request, &substrate, openrouter_exception.as_ref())?;
     for warning in credential_shaped_env_warnings(&request) {
         eprintln!("warning: {warning}");
     }
@@ -1000,7 +1012,8 @@ fn review_pr(args: ReviewPrArgs) -> Result<()> {
     ensure_pr_head_unchanged(number, &repo, &gh_binary, Some(&github_token), &head_sha)?;
 
     let substrate = review_substrate(args.substrate)?;
-    require_child_env_for_substrate(&request, &substrate)?;
+    let openrouter_exception = resolve_openrouter_exception(&args.openrouter_policy)?;
+    require_openrouter_policy_for_substrate(&request, &substrate, openrouter_exception.as_ref())?;
     for warning in credential_shaped_env_warnings(&request) {
         eprintln!("warning: {warning}");
     }
@@ -1430,6 +1443,7 @@ fn _assert_plan_is_serializable(plan: &ExecutionPlan) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cerberus::openrouter_policy::OpenRouterExceptionScope;
 
     const ALL_VERDICTS: [Verdict; 4] = [Verdict::Pass, Verdict::Warn, Verdict::Fail, Verdict::Skip];
 
@@ -1494,15 +1508,19 @@ mod tests {
             model: Some("openrouter/z-ai/glm-5.2".to_string()),
         });
 
-        let err = require_child_env_for_substrate(&request, &substrate).unwrap_err();
+        let err = require_openrouter_policy_for_substrate(&request, &substrate, None).unwrap_err();
         assert!(
             err.to_string().contains("--allow-env OPENROUTER_API_KEY"),
             "error should name the concrete fix: {err}"
         );
     }
 
+    // cerberus-051: the allowlisted credential alone used to be sufficient to
+    // run an OpenRouter model. The subscription-first deny-by-default policy
+    // now requires a covering exception on top of it -- this is the exact
+    // permissive gap cerberus-051 closes; see cerberus::openrouter_policy.
     #[test]
-    fn openrouter_model_with_allowed_key_passes_preflight() {
+    fn openrouter_model_with_allowed_key_is_still_denied_without_an_exception() {
         let request_path =
             Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/requests/diff-only.json");
         let mut request: ReviewRequest = read_json(&request_path).expect("fixture request loads");
@@ -1514,7 +1532,67 @@ mod tests {
             model: Some("openrouter/z-ai/glm-5.2".to_string()),
         });
 
-        require_child_env_for_substrate(&request, &substrate).unwrap();
+        let err = require_openrouter_policy_for_substrate(&request, &substrate, None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("denied by the subscription-first trusted review policy"),
+            "an allowlisted credential must not bypass the deny-by-default policy: {err}"
+        );
+    }
+
+    fn default_openrouter_policy_args() -> OpenRouterPolicyArgs {
+        OpenRouterPolicyArgs {
+            openrouter_exception_file: None,
+        }
+    }
+
+    #[test]
+    fn resolve_openrouter_exception_is_none_when_flag_is_absent() {
+        let resolved =
+            resolve_openrouter_exception(&default_openrouter_policy_args()).expect("resolves");
+        assert!(
+            resolved.is_none(),
+            "no exception should be loaded unless --openrouter-exception-file is passed"
+        );
+    }
+
+    #[test]
+    fn resolve_openrouter_exception_loads_and_admits_the_checked_in_any_scope_fixture() {
+        let exception_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("fixtures/openrouter-exceptions/any-scope.json");
+        let args = OpenRouterPolicyArgs {
+            openrouter_exception_file: Some(exception_path),
+        };
+        let exception = resolve_openrouter_exception(&args)
+            .expect("fixture exception resolves")
+            .expect("flag was set, so an exception must load");
+        assert_eq!(exception.scope, OpenRouterExceptionScope::Any);
+
+        let request_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/requests/diff-only.json");
+        let mut request: ReviewRequest = read_json(&request_path).expect("fixture request loads");
+        extend_review_allowed_env(&mut request, vec!["OPENROUTER_API_KEY".to_string()]);
+        let substrate = ReviewSubstrate::Omp(OmpSubstrateConfig {
+            binary: "omp".to_string(),
+            model: Some("openrouter/z-ai/glm-5.2".to_string()),
+        });
+
+        require_openrouter_policy_for_substrate(&request, &substrate, Some(&exception)).unwrap();
+    }
+
+    #[test]
+    fn resolve_openrouter_exception_rejects_a_tampered_checked_in_fixture() {
+        let exception_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("fixtures/openrouter-exceptions/tampered.json");
+        let args = OpenRouterPolicyArgs {
+            openrouter_exception_file: Some(exception_path),
+        };
+        let err = resolve_openrouter_exception(&args).unwrap_err();
+        assert!(
+            err.chain()
+                .any(|cause| cause.to_string().contains("digest mismatch")),
+            "a hand-edited exception file must be refused: {err:#}"
+        );
     }
 
     // The ExitCode mapping (blocking -> 1, clean -> 0, error -> 2) is proven

--- a/src/openrouter_policy.rs
+++ b/src/openrouter_policy.rs
@@ -204,7 +204,10 @@ pub fn require_openrouter_policy_for_substrate(
     let Some((context, model, required_scope)) = openrouter_admission_target(substrate) else {
         return Ok(());
     };
-    if !model.starts_with("openrouter/") {
+    // Case-insensitive: a substrate/model resolver that accepts
+    // "OpenRouter/..." or "OPENROUTER/..." must not bypass the deny-by-
+    // default policy just because Rust's own comparison was case-sensitive.
+    if !model.to_ascii_lowercase().starts_with("openrouter/") {
         return Ok(());
     }
     if !request
@@ -395,6 +398,23 @@ mod tests {
     }
 
     // --- non-OpenRouter models and attach substrates are unaffected -------
+
+    #[test]
+    fn openrouter_model_with_mixed_case_prefix_is_still_gated() {
+        let request = openrouter_request(vec!["OPENROUTER_API_KEY".to_string()]);
+        let substrate = ReviewSubstrate::Opencode(OpenCodeSubstrateConfig {
+            binary: "opencode".to_string(),
+            attach: None,
+            agent: Some("build".to_string()),
+            model: Some("OpenRouter/z-ai/glm-5.2".to_string()),
+        });
+        let err = require_openrouter_policy_for_substrate(&request, &substrate, None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("denied by the subscription-first trusted review policy"),
+            "a case-varied OpenRouter prefix must not bypass the deny-by-default policy: {err}"
+        );
+    }
 
     #[test]
     fn non_openrouter_model_is_never_gated() {

--- a/src/openrouter_policy.rs
+++ b/src/openrouter_policy.rs
@@ -1,0 +1,480 @@
+//! Subscription-first / OpenRouter-denied-by-default trusted review policy
+//! (Phase 1, cerberus-051; see docs/plans/productization-2026-07-17.md).
+//!
+//! Cerberus's trusted (non-container) review path forwarded any OpenRouter
+//! model as long as the credential was allowlisted -- no policy ever asked
+//! whether OpenRouter should be reachable at all for a given call site. This
+//! module closes that gap with a deny-by-default admission check: a resolved
+//! model that routes through OpenRouter (`openrouter/...`) is rejected unless
+//! an explicit, reviewed, tamper-evident exception record names a scope wide
+//! enough to cover the call site.
+//!
+//! Per ADR 0003 ("the deterministic waist vs. model judgment"), this is
+//! exactly the kind of check Rust may own: "does a covering exception exist
+//! and self-verify" is a non-AI oracle with a certain yes/no answer. *Which*
+//! models or providers deserve an exception is never Cerberus's call --
+//! that judgment belongs entirely to whoever authors and reviews the
+//! exception file out of band. Rust never hardcodes a model or provider
+//! allowlist here.
+
+use std::fmt;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::digest::sha256_digest;
+use crate::kernel::ReviewSubstrate;
+use crate::schema::ReviewRequest;
+
+/// What an `OpenRouterException` authorizes. A closed, explicit enum so a
+/// narrow carve-out can never silently widen into a blanket exception just
+/// because an operator reused a file for a different call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenRouterExceptionScope {
+    /// Permits OpenRouter routing for any substrate/call site this policy
+    /// gates.
+    Any,
+    /// Permits OpenRouter routing only for the OpenCode substrate. OpenCode
+    /// is the substrate docs/plans/productization-2026-07-17.md Phase 1
+    /// calls "the fallback lane": subscription-backed live smoke is
+    /// preferred, and this narrower scope is the alternative proof gate when
+    /// that isn't available. It never satisfies a check raised for a
+    /// different substrate (e.g. OMP).
+    OpencodeFallback,
+}
+
+impl OpenRouterExceptionScope {
+    /// Does a grant of `self` satisfy a check that requires `required`?
+    /// `Any` covers everything; every other scope covers only itself.
+    fn covers(self, required: OpenRouterExceptionScope) -> bool {
+        self == OpenRouterExceptionScope::Any || self == required
+    }
+}
+
+impl fmt::Display for OpenRouterExceptionScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            OpenRouterExceptionScope::Any => "any",
+            OpenRouterExceptionScope::OpencodeFallback => "opencode_fallback",
+        };
+        f.write_str(label)
+    }
+}
+
+/// The fields an exception's content digest is computed over. Kept as its
+/// own type (rather than reusing `OpenRouterException` and skipping
+/// `digest`) so the payload shape used to compute and to verify the digest
+/// can never drift apart.
+#[derive(Serialize)]
+struct OpenRouterExceptionPayload<'a> {
+    scope: OpenRouterExceptionScope,
+    reason: &'a str,
+    approved_by: &'a str,
+}
+
+/// A reviewed, digested exception to the OpenRouter deny-by-default policy.
+///
+/// This is a schema-checked admission artifact, not a place to encode which
+/// models or providers are judged acceptable. An operator authors and
+/// reviews this file out of band (typically checked into the repo, or
+/// supplied via an explicit path for a one-off exception); Cerberus only
+/// checks that it exists, parses, is scoped widely enough for the call site,
+/// and has not been hand-edited since its digest was computed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpenRouterException {
+    pub scope: OpenRouterExceptionScope,
+    /// Free-text justification recorded when the exception was approved.
+    /// Never consulted for correctness -- pure provenance.
+    pub reason: String,
+    /// Who reviewed and approved this exception (name, handle, or similar).
+    pub approved_by: String,
+    /// sha256 hex digest (see [`crate::digest::sha256_digest`]) over the
+    /// canonical JSON of `{scope, reason, approved_by}`, computed by whoever
+    /// authored this record and re-verified on every load. Editing `scope`,
+    /// `reason`, or `approved_by` without recomputing this digest makes the
+    /// record self-evidently tampered, so Cerberus can refuse it
+    /// deterministically instead of trusting arbitrary JSON on disk.
+    pub digest: String,
+}
+
+impl OpenRouterException {
+    /// Compute the content digest for the given fields. Used both to author
+    /// a new exception record and to verify one on load.
+    pub fn compute_digest(
+        scope: OpenRouterExceptionScope,
+        reason: &str,
+        approved_by: &str,
+    ) -> Result<String> {
+        let payload = OpenRouterExceptionPayload {
+            scope,
+            reason,
+            approved_by,
+        };
+        let bytes = serde_json::to_vec(&payload)
+            .context("serialize OpenRouter exception payload for digesting")?;
+        Ok(sha256_digest(bytes))
+    }
+
+    fn verify_digest(&self) -> Result<()> {
+        let expected = Self::compute_digest(self.scope, &self.reason, &self.approved_by)?;
+        if expected != self.digest {
+            return Err(anyhow!(
+                "OpenRouter exception content digest mismatch: expected {expected}, got {}; \
+                 the record was edited without recomputing its digest over \
+                 {{scope, reason, approved_by}} -- recompute via \
+                 OpenRouterException::compute_digest and update the file",
+                self.digest
+            ));
+        }
+        Ok(())
+    }
+
+    /// Load and self-verify an exception record from an explicit file path.
+    /// No ambient or default path is ever consulted -- callers must name the
+    /// file explicitly, matching the house `--gh-token-file`-style pattern
+    /// of explicit-source-only trust.
+    pub fn load(path: &Path) -> Result<Self> {
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("read OpenRouter exception file {}", path.display()))?;
+        let record: OpenRouterException = serde_json::from_str(&raw)
+            .with_context(|| format!("parse OpenRouter exception file {}", path.display()))?;
+        record
+            .verify_digest()
+            .with_context(|| format!("verify OpenRouter exception file {}", path.display()))?;
+        Ok(record)
+    }
+
+    fn covers(&self, required: OpenRouterExceptionScope) -> bool {
+        self.scope.covers(required)
+    }
+}
+
+/// Which [`OpenRouterExceptionScope`] a substrate call site requires, and
+/// the model it resolved (if the substrate is configured to run at all).
+/// `None` means this substrate/config combination never launches a
+/// Cerberus-controlled model call, so no policy check applies.
+fn openrouter_admission_target(
+    substrate: &ReviewSubstrate,
+) -> Option<(&'static str, &str, OpenRouterExceptionScope)> {
+    match substrate {
+        ReviewSubstrate::Opencode(config) => {
+            // Attaching to an existing session never launches a new model
+            // call under Cerberus's own credential threading; nothing to
+            // gate here.
+            if config.attach.is_some() {
+                return None;
+            }
+            let model = config.model.as_deref()?;
+            Some((
+                "opencode",
+                model,
+                OpenRouterExceptionScope::OpencodeFallback,
+            ))
+        }
+        ReviewSubstrate::Omp(config) => {
+            let model = config.model.as_deref()?;
+            Some(("omp", model, OpenRouterExceptionScope::Any))
+        }
+        // Fixture never calls a model. ContainerOpencode is the untrusted-PR
+        // sandbox path with its own scoped-key credential model (backlog
+        // 013 M1, src/openrouter_keys.rs) and is out of scope for this
+        // trusted-path policy.
+        ReviewSubstrate::Fixture(_) | ReviewSubstrate::ContainerOpencode(_) => None,
+    }
+}
+
+/// Deny-by-default admission check plus the pre-existing credential-hygiene
+/// check, for both the OpenCode and OMP substrates.
+///
+/// Order matters: the credential check runs first and is unchanged from the
+/// pre-cerberus-051 behavior, so a request missing `OPENROUTER_API_KEY` from
+/// its allowed-env list still gets that exact, actionable error regardless
+/// of exception state. Only once the credential is present does the new
+/// policy check run: an OpenRouter-routed model is rejected unless
+/// `exception` is `Some` and its scope covers the call site's required
+/// scope.
+pub fn require_openrouter_policy_for_substrate(
+    request: &ReviewRequest,
+    substrate: &ReviewSubstrate,
+    exception: Option<&OpenRouterException>,
+) -> Result<()> {
+    let Some((context, model, required_scope)) = openrouter_admission_target(substrate) else {
+        return Ok(());
+    };
+    if !model.starts_with("openrouter/") {
+        return Ok(());
+    }
+    if !request
+        .policy
+        .allowed_env
+        .iter()
+        .any(|key| key == "OPENROUTER_API_KEY")
+    {
+        return Err(anyhow!(
+            "{context} OpenRouter model {model:?} requires OPENROUTER_API_KEY in Cerberus's \
+             scrubbed child environment; pass --allow-env OPENROUTER_API_KEY or include it in \
+             request.policy.allowed_env"
+        ));
+    }
+    match exception {
+        Some(exception) if exception.covers(required_scope) => Ok(()),
+        Some(exception) => Err(anyhow!(
+            "{context} OpenRouter model {model:?} is denied by the subscription-first trusted \
+             review policy: the supplied --openrouter-exception-file is scoped to \
+             {}, which does not cover the {context} call site's required scope {required_scope}",
+            exception.scope
+        )),
+        None => Err(anyhow!(
+            "{context} OpenRouter model {model:?} is denied by the subscription-first trusted \
+             review policy (docs/plans/productization-2026-07-17.md Phase 1); pass \
+             --openrouter-exception-file <path> naming a reviewed, digested exception record \
+             scoped to {required_scope} or wider"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness::{OmpSubstrateConfig, OpenCodeSubstrateConfig};
+    use crate::schema::ReviewPolicy;
+    use std::path::PathBuf;
+
+    fn openrouter_request(allowed_env: Vec<String>) -> ReviewRequest {
+        let request_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/requests/diff-only.json");
+        let mut request: ReviewRequest = serde_json::from_str(
+            &fs::read_to_string(&request_path).expect("fixture request reads"),
+        )
+        .expect("fixture request parses");
+        request.policy = ReviewPolicy {
+            allowed_env,
+            ..ReviewPolicy::default()
+        };
+        request
+    }
+
+    fn opencode_openrouter_substrate() -> ReviewSubstrate {
+        ReviewSubstrate::Opencode(OpenCodeSubstrateConfig {
+            binary: "opencode".to_string(),
+            attach: None,
+            agent: Some("build".to_string()),
+            model: Some("openrouter/z-ai/glm-5.2".to_string()),
+        })
+    }
+
+    fn omp_openrouter_substrate() -> ReviewSubstrate {
+        ReviewSubstrate::Omp(OmpSubstrateConfig {
+            binary: "omp".to_string(),
+            model: Some("openrouter/z-ai/glm-5.2".to_string()),
+        })
+    }
+
+    fn scoped_exception(scope: OpenRouterExceptionScope) -> OpenRouterException {
+        let reason = "test fixture exception";
+        let approved_by = "test-suite";
+        let digest = OpenRouterException::compute_digest(scope, reason, approved_by)
+            .expect("digest computes");
+        OpenRouterException {
+            scope,
+            reason: reason.to_string(),
+            approved_by: approved_by.to_string(),
+            digest,
+        }
+    }
+
+    // --- deny-by-default: no exception, either substrate -----------------
+
+    #[test]
+    fn opencode_openrouter_model_is_denied_without_an_exception() {
+        let request = openrouter_request(vec!["OPENROUTER_API_KEY".to_string()]);
+        let err = require_openrouter_policy_for_substrate(
+            &request,
+            &opencode_openrouter_substrate(),
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("denied by the subscription-first trusted review policy"),
+            "error should name the policy that blocked it: {err}"
+        );
+        assert!(
+            err.to_string().contains("--openrouter-exception-file"),
+            "error should name the concrete fix: {err}"
+        );
+    }
+
+    #[test]
+    fn omp_openrouter_model_is_denied_without_an_exception() {
+        let request = openrouter_request(vec!["OPENROUTER_API_KEY".to_string()]);
+        let err =
+            require_openrouter_policy_for_substrate(&request, &omp_openrouter_substrate(), None)
+                .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("denied by the subscription-first trusted review policy"),
+            "OMP must be gated the same as OpenCode, not silently exempt: {err}"
+        );
+    }
+
+    // --- existing credential-hygiene check stays authoritative first -----
+
+    #[test]
+    fn openrouter_model_without_allowed_key_is_a_clear_preflight_error_before_policy() {
+        let request = openrouter_request(Vec::new());
+        let err = require_openrouter_policy_for_substrate(
+            &request,
+            &opencode_openrouter_substrate(),
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("--allow-env OPENROUTER_API_KEY"),
+            "missing credential should still fail with the original, policy-independent fix: {err}"
+        );
+    }
+
+    // --- explicit-exception path: a covering exception is admitted -------
+
+    #[test]
+    fn opencode_openrouter_model_passes_with_an_any_scoped_exception() {
+        let request = openrouter_request(vec!["OPENROUTER_API_KEY".to_string()]);
+        let exception = scoped_exception(OpenRouterExceptionScope::Any);
+        require_openrouter_policy_for_substrate(
+            &request,
+            &opencode_openrouter_substrate(),
+            Some(&exception),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn omp_openrouter_model_passes_with_an_any_scoped_exception() {
+        let request = openrouter_request(vec!["OPENROUTER_API_KEY".to_string()]);
+        let exception = scoped_exception(OpenRouterExceptionScope::Any);
+        require_openrouter_policy_for_substrate(
+            &request,
+            &omp_openrouter_substrate(),
+            Some(&exception),
+        )
+        .unwrap();
+    }
+
+    // --- OpenCode-fallback-scoped exception: narrow, substrate-specific --
+
+    #[test]
+    fn opencode_openrouter_model_passes_with_an_opencode_fallback_scoped_exception() {
+        let request = openrouter_request(vec!["OPENROUTER_API_KEY".to_string()]);
+        let exception = scoped_exception(OpenRouterExceptionScope::OpencodeFallback);
+        require_openrouter_policy_for_substrate(
+            &request,
+            &opencode_openrouter_substrate(),
+            Some(&exception),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn omp_openrouter_model_is_still_denied_by_an_opencode_fallback_scoped_exception() {
+        let request = openrouter_request(vec!["OPENROUTER_API_KEY".to_string()]);
+        let exception = scoped_exception(OpenRouterExceptionScope::OpencodeFallback);
+        let err = require_openrouter_policy_for_substrate(
+            &request,
+            &omp_openrouter_substrate(),
+            Some(&exception),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("does not cover"),
+            "a fallback-scoped exception must not leak into covering OMP: {err}"
+        );
+    }
+
+    // --- non-OpenRouter models and attach substrates are unaffected -------
+
+    #[test]
+    fn non_openrouter_model_is_never_gated() {
+        let request = openrouter_request(Vec::new());
+        let substrate = ReviewSubstrate::Opencode(OpenCodeSubstrateConfig {
+            binary: "opencode".to_string(),
+            attach: None,
+            agent: Some("build".to_string()),
+            model: Some("anthropic/claude-sonnet".to_string()),
+        });
+        require_openrouter_policy_for_substrate(&request, &substrate, None).unwrap();
+    }
+
+    #[test]
+    fn attaching_to_an_existing_opencode_session_is_never_gated() {
+        let request = openrouter_request(Vec::new());
+        let substrate = ReviewSubstrate::Opencode(OpenCodeSubstrateConfig {
+            binary: "opencode".to_string(),
+            attach: Some("existing-session".to_string()),
+            agent: Some("build".to_string()),
+            model: Some("openrouter/z-ai/glm-5.2".to_string()),
+        });
+        require_openrouter_policy_for_substrate(&request, &substrate, None).unwrap();
+    }
+
+    // --- exception record loading and digest verification ----------------
+
+    #[test]
+    fn exception_load_rejects_a_tampered_scope() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let digest = OpenRouterException::compute_digest(
+            OpenRouterExceptionScope::OpencodeFallback,
+            "r",
+            "a",
+        )
+        .unwrap();
+        let tampered = serde_json::json!({
+            "scope": "any",
+            "reason": "r",
+            "approved_by": "a",
+            "digest": digest,
+        });
+        let path: PathBuf = dir.path().join("tampered.json");
+        fs::write(&path, serde_json::to_string(&tampered).unwrap()).unwrap();
+
+        let err = OpenRouterException::load(&path).unwrap_err();
+        assert!(
+            err.chain()
+                .any(|cause| cause.to_string().contains("digest mismatch")),
+            "widening scope without recomputing the digest must be rejected: {err:#}"
+        );
+    }
+
+    #[test]
+    fn exception_load_accepts_a_correctly_digested_record() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let digest = OpenRouterException::compute_digest(
+            OpenRouterExceptionScope::Any,
+            "reason",
+            "reviewer",
+        )
+        .unwrap();
+        let record = OpenRouterException {
+            scope: OpenRouterExceptionScope::Any,
+            reason: "reason".to_string(),
+            approved_by: "reviewer".to_string(),
+            digest,
+        };
+        let path: PathBuf = dir.path().join("valid.json");
+        fs::write(&path, serde_json::to_string(&record).unwrap()).unwrap();
+
+        let loaded = OpenRouterException::load(&path).expect("valid record loads");
+        assert_eq!(loaded, record);
+    }
+
+    #[test]
+    fn exception_load_rejects_a_missing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("does-not-exist.json");
+        let err = OpenRouterException::load(&path).unwrap_err();
+        assert!(err.to_string().contains("read OpenRouter exception file"));
+    }
+}


### PR DESCRIPTION
## Outcome

Trusted (non-container) reviews now deny any model routed through OpenRouter (`openrouter/...`) by default, for both the OpenCode and OMP substrates. An OpenRouter model only runs when an operator supplies `--openrouter-exception-file` naming a reviewed, digest-verified exception record — never a bare boolean flag. Closes the exact gap the productization plan names: "Existing OpenRouter-first/scoped-key paths conflict with subscription-first spend policy... trusted model policy denies OpenRouter by default. Any OpenRouter use needs an explicit reviewed per-exception allowlist" (docs/plans/productization-2026-07-17.md Phase 1).

## Change

- New `src/openrouter_policy.rs` module:
  - `OpenRouterExceptionScope`: closed enum (`Any` | `OpencodeFallback`) — a narrow OpenCode-fallback-scoped exception can never leak into covering OMP.
  - `OpenRouterException`: a reviewed exception record (`scope`, `reason`, `approved_by`, sha256 content `digest`). `digest` is recomputed and checked on every `load`, so a hand-edited record is rejected deterministically.
  - `require_openrouter_policy_for_substrate`: runs the pre-existing `OPENROUTER_API_KEY`-allowlist credential check first (unchanged behavior/error text), then the new deny-by-default policy check, for both `ReviewSubstrate::Opencode` and `ReviewSubstrate::Omp`. Fixture and ContainerOpencode substrates are untouched (out of scope — container path has its own scoped-key credential model in `src/openrouter_keys.rs`, not touched by this PR).
- `src/main.rs`: replaces the old `require_child_env_for_substrate` (Opencode-only, credential-hygiene-only) with the new gate at all three call sites (`review`, `review-diff`, `review-pr`). New `--openrouter-exception-file <path>` flag (explicit-source-only, no ambient fallback — matches the house `--gh-token-file` pattern), flattened into all three subcommands via `OpenRouterPolicyArgs`.
- Checked-in fixtures (`fixtures/openrouter-exceptions/`): `any-scope.json`, `opencode-fallback.json`, and a deliberately `tampered.json` (scope widened without recomputing the digest) proving self-verification.
- `scripts/verify.sh`: help-text pins for the new flag, plus black-box CLI scenarios proving deny-by-default (both substrates), the any-scope and opencode-fallback-scope admit paths, scope non-leakage into OMP, and tampered-record rejection — all firing before any substrate binary is invoked.
- Hardening (post-review): `model.starts_with("openrouter/")` is now case-insensitive, closing a bypass a fresh-context review found (`OpenRouter/...` previously slipped past the gate).

Rust's role stays purely admission: it checks for the OpenRouter routing prefix and whether a covering, digest-verified exception exists. It never hardcodes which models or providers are exempt — that judgment belongs entirely to whoever authors and reviews the exception file (ADR 0003).

## Verification

- `./scripts/verify.sh` — full green (fmt, clippy `-D warnings`, full `cargo test` suite incl. the docker-gated container red-team block, gitleaks secret scan) after every change, including the post-review hardening commit.
- Fresh cross-model adversarial review: GLM 5.2 (via Main, after `agent='cerberus'` hit a Grok credit outage affecting the whole fleet) — **verdict PASS, safe_to_open_pr: true**. Findings: (1) `src/mcp.rs`'s `review_git_range` entrypoint never called the old gate either — pre-existing gap, confirmed not a regression, tracked as a separate follow-up card, not fixed here; (2) case-sensitive prefix match — fixed in this PR (see Hardening above); (3) sha256 digest is tamper-evident, not cryptographically unforgeable, and the checked-in "any-scope" fixture is an intentionally broad test-only fixture — both correctly match the stated review-based trust model.
- Unit tests: 12 in `openrouter_policy.rs` (deny-by-default for both substrates, any-scope admit, opencode-fallback-scope admit + non-leakage into OMP, non-OpenRouter/attach bypass paths, digest tamper rejection, mixed-case hardening) + 7 CLI-level tests in `main.rs` (credential-check-first ordering preserved, `--openrouter-exception-file` resolution against checked-in fixtures). All green.

## Boundaries

No merge or deploy. Out of scope, not touched: `src/orchestration.rs`, `src/kernel.rs` lane-planning (seat policy — `cerberus-049`, parallel worktree); semaphore/concurrency/retry logic in `main.rs` beyond the specific gate functions (`cerberus-052`, parallel worktree); `src/openrouter_keys.rs` container-path scoped-key minting (pre-existing, unrelated); `src/mcp.rs`'s pre-existing gap (flagged by review, tracked separately by Main, not this PR's responsibility).
