### PR TITLE
Phase 1a: declarative seat-policy schema + Tier 0/1 admission

### DIFF
--- a/config/seat_policy.json
+++ b/config/seat_policy.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "cerberus.seat_policy.v1",
+  "tier1_floor": {
+    "seat_count": 4,
+    "seats": [
+      { "role": "behavioral-correctness", "dimension": "model_judgment" },
+      { "role": "security-and-trust-boundary", "dimension": "model_judgment" },
+      { "role": "architecture-and-maintainability", "dimension": "model_judgment" },
+      { "role": "deterministic-verification", "dimension": "heuristic_tool" }
+    ]
+  }
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1043,8 +1043,20 @@ import json
 with open("target/cerberus/reviewer_plan.json", encoding="utf-8") as fh:
     plan = json.load(fh)
 assert plan["schema_version"] == "cerberus.reviewer_plan.v1"
-assert plan["lane_decision"]["mode"] == "single_master"
-assert len(plan["child_lanes"]) == 0
+# fixtures/requests/diff-only.json is a meaningful (Tier 1) diff, so the
+# seat-policy floor (ADR 0004) applies: the plan names one lane per
+# required floor seat, carries only its role label, and never assigns a
+# model -- the master reviewer decides prompt/scope/model per lane at
+# launch time (still disabled until the reviewer-lane substrate lands).
+assert plan["lane_decision"]["mode"] == "planned_child_lanes"
+assert len(plan["child_lanes"]) == 4
+assert all(lane.get("model") is None for lane in plan["child_lanes"])
+assert {lane["role"] for lane in plan["child_lanes"]} == {
+    "behavioral-correctness",
+    "security-and-trust-boundary",
+    "architecture-and-maintainability",
+    "deterministic-verification",
+}
 assert plan["master_lane"]["expected_output"] == "ReviewArtifact.v1"
 assert plan["diff_understanding"]["changed_surfaces"][0]["path"] == "src/ratio.rs"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod receipt;
 pub mod render;
 pub mod request;
 pub mod schema;
+pub mod seat_policy;
 mod secrets;
 mod telemetry;
 #[cfg(test)]
@@ -48,5 +49,9 @@ pub use receipt::{
 pub use render::render_markdown;
 pub use schema::{
     ContextCapabilities, ReviewArtifact, ReviewRequest, ReviewTelemetry, REVIEW_ARTIFACT_SCHEMA,
+};
+pub use seat_policy::{
+    admit_seat_plan, classify_diff_tier, load_seat_policy, DiffTier, RequiredSeat,
+    SeatAdmissionVerdict, SeatDimension, SeatPolicy, Tier1Floor, SEAT_POLICY_SCHEMA,
 };
 pub use validation::{validate_artifact_for_request, validate_request};

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -8,6 +8,10 @@ use crate::schema::{
     ChangedFile, ContextCapabilities, FileStatus, LifecycleState, Receipt, ReceiptRole,
     ReceiptStatus, ReviewArtifact, ReviewRequest, ReviewTelemetry, RunError,
 };
+use crate::seat_policy::{
+    admit_seat_plan, classify_diff_tier, load_seat_policy, DiffTier, SeatAdmissionVerdict,
+    SeatPolicy, SEAT_POLICY_SCHEMA,
+};
 
 pub const REVIEWER_PLAN_SCHEMA: &str = "cerberus.reviewer_plan.v1";
 pub const REVIEWER_LANE_RECEIPT_SCHEMA: &str = "cerberus.reviewer_lane_receipt.v1";
@@ -201,6 +205,16 @@ pub fn build_reviewer_plan(
             .collect()
     };
 
+    let seat_policy = load_seat_policy()?;
+    let diff_tier = classify_diff_tier(&request.change.files);
+    let (lane_decision, child_lanes) = plan_seat_admitted_lanes(
+        diff_tier,
+        &seat_policy,
+        &scope,
+        &context_tier,
+        &execution_plan.harness,
+    )?;
+
     Ok(ReviewerPlanReceipt {
         schema_version: REVIEWER_PLAN_SCHEMA.to_string(),
         request_id: request.request_id.clone(),
@@ -212,35 +226,136 @@ pub fn build_reviewer_plan(
             skipped_context: skipped_context(&available_context),
             available_context,
         },
-        lane_decision: LaneDecision {
-            mode: LaneDecisionMode::SingleMaster,
-            reason: "The current orchestrator slice records the existing single-master path; child lane launch is disabled until the reviewer-lane substrate lands.".to_string(),
-            stop_condition: "Emit exactly one ReviewArtifact.v1 candidate and pass validate_artifact_for_request, or fail closed.".to_string(),
-            cost_budget_usd: None,
-        },
+        lane_decision,
         master_lane: ReviewerLanePlan {
             id: "lane-master".to_string(),
             role: "master".to_string(),
-            objective: "Review the change using the declared context and synthesize the final artifact.".to_string(),
+            objective:
+                "Review the change using the declared context and synthesize the final artifact."
+                    .to_string(),
             scope,
             allowed_context_tier: context_tier,
             substrate: execution_plan.harness.clone(),
             model: telemetry.model.clone(),
             cost_budget_usd: None,
-            stop_condition: "Stop after a validated ReviewArtifact.v1 is emitted or the substrate fails.".to_string(),
+            stop_condition:
+                "Stop after a validated ReviewArtifact.v1 is emitted or the substrate fails."
+                    .to_string(),
             expected_output: "ReviewArtifact.v1".to_string(),
         },
-        child_lanes: Vec::new(),
-        synthesis: SynthesisPlan {
+        child_lanes,
+        synthesis: synthesis_plan_for_tier(diff_tier),
+    })
+}
+
+/// Build a tier-accurate `SynthesisPlan`. Tier 0 keeps the pre-existing
+/// single-master notes; Tier 1 says what actually happened at this point in
+/// the pipeline -- floor-satisfying lanes were *planned and admitted*, not
+/// launched -- rather than reusing the Tier 0 "no child lanes" language,
+/// which reads as contradicting a populated `child_lanes` list.
+fn synthesis_plan_for_tier(tier: DiffTier) -> SynthesisPlan {
+    match tier {
+        DiffTier::Tier0 => SynthesisPlan {
             strategy: "single_master_synthesis".to_string(),
             artifact_contract: "ReviewArtifact.v1".to_string(),
             validation_gate: "validate_artifact_for_request".to_string(),
             notes: vec![
-                "No child lanes were launched in this run.".to_string(),
+                "Tier 0 diff: the seat-policy floor is empty, so no child lanes were planned or launched in this run.".to_string(),
                 "Future child-lane evidence must be captured as ReviewerLaneReceipt.v1, synthesized into the same artifact receipts, and cannot bypass validation.".to_string(),
             ],
         },
-    })
+        DiffTier::Tier1 => SynthesisPlan {
+            strategy: "seat_policy_admitted_planned_lanes".to_string(),
+            artifact_contract: "ReviewArtifact.v1".to_string(),
+            validation_gate: "validate_artifact_for_request".to_string(),
+            notes: vec![
+                "Tier 1 diff: seat-policy-floor-satisfying child lanes were planned and admitted (see child_lanes and lane_decision), but launch remains disabled until the reviewer-lane substrate lands (see launch_planned_child_lanes).".to_string(),
+                "Future child-lane evidence must be captured as ReviewerLaneReceipt.v1, synthesized into the same artifact receipts, and cannot bypass validation.".to_string(),
+            ],
+        },
+    }
+}
+
+/// Build the declared lane decision + child-lane set for one review, and
+/// admit it against the seat-policy floor (ADR 0004). On Tier 0 the floor
+/// is empty and the run stays single-master. On Tier 1, this constructs one
+/// planned (not yet launched -- see \`launch_planned_child_lanes\`) lane per
+/// required floor seat, naming only the seat's role label; it never fills
+/// in a model (\`model: None\`), matching the ADR's "the master decides the
+/// model" rule.
+///
+/// Admission is re-checked here as a defense-in-depth self-check: this
+/// function is currently the only "master" that declares lanes (the
+/// reviewer-lane substrate that would let an external master submit its
+/// own plan has not landed yet), so a rejection here means a bug in this
+/// function itself, not an external caller -- fail closed rather than
+/// silently emit a floor-violating plan.
+fn plan_seat_admitted_lanes(
+    tier: DiffTier,
+    seat_policy: &SeatPolicy,
+    scope: &[String],
+    context_tier: &str,
+    harness: &str,
+) -> Result<(LaneDecision, Vec<ReviewerLanePlan>)> {
+    match tier {
+        DiffTier::Tier0 => Ok((
+            LaneDecision {
+                mode: LaneDecisionMode::SingleMaster,
+                reason: "Tier 0 diff (no meaningful content change; see seat_policy::classify_diff_tier): the seat-policy floor is empty, so only the master lane runs.".to_string(),
+                stop_condition: "Emit exactly one ReviewArtifact.v1 candidate and pass validate_artifact_for_request, or fail closed.".to_string(),
+                cost_budget_usd: None,
+            },
+            Vec::new(),
+        )),
+        DiffTier::Tier1 => {
+            let planned: Vec<ReviewerLanePlan> = seat_policy
+                .tier1_floor
+                .seats
+                .iter()
+                .map(|seat| ReviewerLanePlan {
+                    id: format!("lane-{}", sanitize_lane_id(&seat.role)),
+                    role: seat.role.clone(),
+                    objective: "Planned to satisfy the Tier 1 seat-policy floor; the master reviewer authors this lane's actual prompt, scope, and model at launch time.".to_string(),
+                    scope: scope.to_vec(),
+                    allowed_context_tier: context_tier.to_string(),
+                    substrate: harness.to_string(),
+                    model: None,
+                    cost_budget_usd: None,
+                    stop_condition: "Return one ReviewerLaneReceipt.v1 with evidence or a fail-closed error status.".to_string(),
+                    expected_output: "ReviewerLaneReceipt.v1".to_string(),
+                })
+                .collect();
+
+            match admit_seat_plan(tier, &seat_policy.tier1_floor, &planned) {
+                SeatAdmissionVerdict::Accepted => {}
+                SeatAdmissionVerdict::Rejected { missing_roles } => bail!(
+                    "seat policy admission rejected the planned Tier 1 lane set: missing required role(s) {}",
+                    missing_roles.join(", ")
+                ),
+            }
+
+            Ok((
+                LaneDecision {
+                    mode: LaneDecisionMode::PlannedChildLanes,
+                    reason: format!(
+                        "Tier 1 diff admitted against the seat-policy floor ({} required seat(s), {SEAT_POLICY_SCHEMA}); child lane launch remains disabled until the reviewer-lane substrate lands (see launch_planned_child_lanes).",
+                        seat_policy.tier1_floor.seat_count
+                    ),
+                    stop_condition: "Emit exactly one ReviewArtifact.v1 candidate and pass validate_artifact_for_request, or fail closed.".to_string(),
+                    cost_budget_usd: None,
+                },
+                planned,
+            ))
+        }
+    }
+}
+
+/// Delegates to `crate::request::sanitize_id` (the same lane/request id
+/// normalization already used for request ids) rather than reimplementing
+/// the same "replace anything non-alphanumeric/dash/underscore with a
+/// dash" rule a second time.
+fn sanitize_lane_id(role: &str) -> String {
+    crate::request::sanitize_id(role)
 }
 
 fn changed_surfaces(files: &[ChangedFile]) -> Vec<ChangedSurface> {
@@ -329,7 +444,7 @@ mod tests {
     use crate::validation::validate_artifact_for_request;
 
     #[test]
-    fn reviewer_plan_records_single_master_diff_understanding() {
+    fn reviewer_plan_plans_seat_policy_floor_lanes_for_tier1_diff() {
         let request = ReviewRequest {
             schema_version: crate::schema::REVIEW_REQUEST_SCHEMA.to_string(),
             request_id: "req-1".to_string(),
@@ -387,9 +502,28 @@ mod tests {
         )
         .unwrap();
 
+        let seat_policy = crate::seat_policy::load_seat_policy().unwrap();
+
         assert_eq!(plan.schema_version, REVIEWER_PLAN_SCHEMA);
-        assert_eq!(plan.lane_decision.mode, LaneDecisionMode::SingleMaster);
-        assert!(plan.child_lanes.is_empty());
+        // A Modified file is a meaningful (Tier 1) diff: the seat-policy
+        // floor applies, so the plan names one lane per required role.
+        assert_eq!(plan.lane_decision.mode, LaneDecisionMode::PlannedChildLanes);
+        assert_eq!(plan.child_lanes.len(), seat_policy.tier1_floor.seat_count);
+        let declared_roles: std::collections::HashSet<&str> = plan
+            .child_lanes
+            .iter()
+            .map(|lane| lane.role.as_str())
+            .collect();
+        let floor_roles: std::collections::HashSet<&str> = seat_policy
+            .tier1_floor
+            .seats
+            .iter()
+            .map(|seat| seat.role.as_str())
+            .collect();
+        assert_eq!(declared_roles, floor_roles);
+        // Rust never picks a model for a planned lane -- the master decides
+        // at launch time.
+        assert!(plan.child_lanes.iter().all(|lane| lane.model.is_none()));
         assert_eq!(plan.master_lane.model.as_deref(), Some("fixture-model"));
         assert_eq!(plan.master_lane.allowed_context_tier, "diff_only");
         assert_eq!(
@@ -407,12 +541,76 @@ mod tests {
     }
 
     #[test]
+    fn reviewer_plan_stays_single_master_for_tier0_diff() {
+        let request = ReviewRequest {
+            schema_version: crate::schema::REVIEW_REQUEST_SCHEMA.to_string(),
+            request_id: "req-tier0".to_string(),
+            source: Source {
+                kind: SourceKind::Fixture,
+                external_id: None,
+                repo: None,
+                uri: None,
+                metadata: serde_json::json!({}),
+            },
+            change: Change {
+                title: "rename only".to_string(),
+                description: None,
+                base_ref: None,
+                head_ref: None,
+                head_sha: None,
+                diff: Diff {
+                    format: "unified".to_string(),
+                    body: "diff --git a/src/old.rs b/src/new.rs\nsimilarity index 100%\nrename from src/old.rs\nrename to src/new.rs\n".to_string(),
+                    digest: None,
+                },
+                files: vec![ChangedFile {
+                    path: "src/new.rs".to_string(),
+                    status: FileStatus::Renamed,
+                    old_path: Some("src/old.rs".to_string()),
+                    additions: Some(0),
+                    deletions: Some(0),
+                }],
+            },
+            context: Default::default(),
+            policy: ReviewPolicy {
+                external_research: ExternalResearchPolicy::Forbid,
+                ..ReviewPolicy::default()
+            },
+        };
+        let plan = build_reviewer_plan(
+            &request,
+            &ExecutionPlan {
+                harness: "fixture".to_string(),
+                command: "fixture".to_string(),
+                args: Vec::new(),
+                cwd: ".".to_string(),
+                timeout_ms: 1000,
+                env_allowlist: Vec::new(),
+                context_capabilities: ContextCapabilities::from_request(&request),
+                prompt_transport: "fixture".to_string(),
+                private_material_in_argv: false,
+                workspace_mode: "diff_packet".to_string(),
+                runtime_transcripts: Vec::new(),
+            },
+            &ReviewTelemetry::default(),
+        )
+        .unwrap();
+
+        assert_eq!(plan.lane_decision.mode, LaneDecisionMode::SingleMaster);
+        assert!(plan.child_lanes.is_empty());
+    }
+
+    #[test]
     fn lane_substrate_launches_arbitrary_planned_roles() {
         let request = request();
         let mut plan =
             build_reviewer_plan(&request, &execution_plan(&request), &Default::default()).unwrap();
         plan.lane_decision.mode = LaneDecisionMode::PlannedChildLanes;
-        plan.child_lanes.push(ReviewerLanePlan {
+        // Replace (not append to) the seat-policy floor's default planned
+        // lanes: this test proves the substrate can launch an arbitrary
+        // master-declared role, not just the floor's four -- no static
+        // roster in Rust (AGENTS.md red line 1).
+        plan.child_lanes = vec![ReviewerLanePlan {
             id: "lane-model-boundary".to_string(),
             role: "model-boundary-risk".to_string(),
             objective: "Look for deterministic heuristics where model judgment belongs."
@@ -424,7 +622,7 @@ mod tests {
             cost_budget_usd: Some("0.01".to_string()),
             stop_condition: "Return one receipt with evidence or skipped status.".to_string(),
             expected_output: "ReviewerLaneReceipt.v1".to_string(),
-        });
+        }];
 
         let receipts =
             launch_planned_child_lanes(&RecordingLaneSubstrate, &request, &plan).unwrap();

--- a/src/request.rs
+++ b/src/request.rs
@@ -533,7 +533,7 @@ fn apply_numstat(files: &mut [ChangedFile], stats: &BTreeMap<String, (Option<u32
     }
 }
 
-fn sanitize_id(value: &str) -> String {
+pub(crate) fn sanitize_id(value: &str) -> String {
     value
         .chars()
         .map(|ch| {

--- a/src/seat_policy.rs
+++ b/src/seat_policy.rs
@@ -1,0 +1,413 @@
+//! Declarative seat-policy admission
+//! (`docs/adr/0004-declarative-seat-policy-not-static-roster.md`).
+//!
+//! This module enforces *coverage*, never *content*: whether the master
+//! reviewer's declared lane set names the required roles, and whether the
+//! mandatory Factory model-vs-heuristic dimension is present, is a
+//! decidable oracle question (ADR 0003: "can a non-AI oracle decide
+//! pass/fail with certainty?"). What each lane's system prompt says, which
+//! model it uses, and how good its findings are stays model judgment --
+//! this module never authors a persona, a prompt, or a fixed model choice.
+//! See ADR 0004's residual-risk paragraph: policy data may name required
+//! roles/dimensions and a count, and nothing else.
+
+use std::collections::HashSet;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::orchestration::ReviewerLanePlan;
+use crate::schema::{ChangedFile, FileStatus};
+
+pub const SEAT_POLICY_SCHEMA: &str = "cerberus.seat_policy.v1";
+
+/// Trusted, versioned, repo-owned seat-policy data (ADR 0004 decision 2),
+/// embedded at compile time from a real, diffable, reviewable JSON file --
+/// the same trusted-data spirit as `config/omp-version.json`'s runtime-read
+/// pin, without adding a new runtime file-I/O failure mode to every
+/// review's admission path (this policy has no "bump without a rebuild"
+/// requirement the way a substrate version pin does).
+const SEAT_POLICY_JSON: &str = include_str!("../config/seat_policy.json");
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SeatPolicy {
+    pub schema_version: String,
+    pub tier1_floor: Tier1Floor,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Tier1Floor {
+    pub seat_count: usize,
+    pub seats: Vec<RequiredSeat>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RequiredSeat {
+    /// A coverage-area label (e.g. "security-and-trust-boundary"). Data
+    /// only -- never a persona identity or system prompt. The master
+    /// reviewer still authors the actual lane prompt/scope/model for this
+    /// role at launch time; Rust only checks that a declared lane carries
+    /// this role label.
+    pub role: String,
+    pub dimension: SeatDimension,
+}
+
+/// The Factory model-vs-heuristic dimension (VISION.md's "named dimensions
+/// guide the master; they do not become hardcoded personas... including
+/// the mandatory Factory dimension"): whether a seat is another model call
+/// or a deterministic tool/heuristic. ADR 0004 requires at least one
+/// mandatory Tier 1 seat carry `HeuristicTool`.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SeatDimension {
+    ModelJudgment,
+    HeuristicTool,
+}
+
+/// Parse and sanity-check the embedded seat policy. Fails closed rather
+/// than silently dropping the floor if the embedded data is malformed,
+/// internally inconsistent, or missing the mandatory Factory dimension --
+/// all build-time bugs, not runtime conditions, but surfacing them as a
+/// `Result` keeps this on the same fail-closed path as
+/// `build_reviewer_plan`'s other fallible steps instead of panicking.
+pub fn load_seat_policy() -> Result<SeatPolicy> {
+    let policy: SeatPolicy = serde_json::from_str(SEAT_POLICY_JSON)
+        .context("parse embedded seat policy (config/seat_policy.json)")?;
+    validate_seat_policy(policy)
+}
+
+/// Sanity-check a parsed seat policy: schema version, internal
+/// seat_count/seats.len() consistency, role-label uniqueness (a duplicated
+/// role would let seat_count overstate real coverage without tripping any
+/// other check), and presence of the mandatory Factory dimension. Split out
+/// from `load_seat_policy` so it can be unit-tested directly against
+/// hand-built `SeatPolicy` values, not only the one embedded config.
+fn validate_seat_policy(policy: SeatPolicy) -> Result<SeatPolicy> {
+    if policy.schema_version != SEAT_POLICY_SCHEMA {
+        bail!(
+            "unsupported seat policy schema_version {} (expected {SEAT_POLICY_SCHEMA})",
+            policy.schema_version
+        );
+    }
+    if policy.tier1_floor.seats.len() != policy.tier1_floor.seat_count {
+        bail!(
+            "seat policy tier1_floor.seat_count ({}) does not match tier1_floor.seats.len() ({})",
+            policy.tier1_floor.seat_count,
+            policy.tier1_floor.seats.len()
+        );
+    }
+    let mut seen_roles: HashSet<&str> = HashSet::new();
+    for seat in &policy.tier1_floor.seats {
+        if !seen_roles.insert(seat.role.as_str()) {
+            bail!(
+                "seat policy tier1_floor.seats contains a duplicate role {:?}; each required seat must name a distinct role",
+                seat.role
+            );
+        }
+    }
+    if !policy
+        .tier1_floor
+        .seats
+        .iter()
+        .any(|seat| seat.dimension == SeatDimension::HeuristicTool)
+    {
+        bail!(
+            "seat policy tier1_floor is missing the mandatory Factory model-vs-heuristic \
+             dimension (no seat is tagged heuristic_tool); see ADR 0004"
+        );
+    }
+    Ok(policy)
+}
+
+/// Deterministic Tier 0 / Tier 1 diff classification (ADR 0004 decision 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffTier {
+    /// No meaningful diff: no seats required.
+    Tier0,
+    /// A meaningful diff: the Tier 1 seat-policy floor applies.
+    Tier1,
+}
+
+/// Classify a changed-file set as Tier 0 or Tier 1. This is an oracle
+/// question (ADR 0003): the diff either changed reviewable content or it
+/// did not, decidable purely from `ChangedFile` shape, never a model call.
+///
+/// Tier 0 iff the change touches zero files, or every changed file is a
+/// pure rename/copy with zero content delta (`FileStatus::Renamed` or
+/// `FileStatus::Copied` with `additions == Some(0)` and
+/// `deletions == Some(0)`) -- i.e. a path moved or was duplicated without a
+/// single line of content changing. Any `Added`/`Modified`/`Removed` file,
+/// or a `Renamed`/`Copied` file with nonzero or unknown (`None`) line
+/// counts, makes the whole request Tier 1.
+///
+/// This deliberately does not attempt whitespace-only content
+/// classification: `ChangedFile` carries aggregate line counts, not diff
+/// content, and inferring "whitespace-only" from `+N/-N` alone is
+/// unreliable (a single-character edit inside a line still reports
+/// `+1/-1`, identical in shape to a real one-line content change). A
+/// future risk classifier that *adds* seats above the floor may reach for
+/// richer signals (e.g. the raw diff body); this floor classifier stays
+/// conservative and exact so it never wrongly waves through a real change
+/// as Tier 0.
+pub fn classify_diff_tier(files: &[ChangedFile]) -> DiffTier {
+    if files.is_empty() || files.iter().all(is_content_free_rename) {
+        DiffTier::Tier0
+    } else {
+        DiffTier::Tier1
+    }
+}
+
+fn is_content_free_rename(file: &ChangedFile) -> bool {
+    matches!(file.status, FileStatus::Renamed | FileStatus::Copied)
+        && file.additions == Some(0)
+        && file.deletions == Some(0)
+}
+
+/// Deterministic admission verdict (ADR 0004 decision 4): the master may
+/// add lanes beyond the floor; it may never declare fewer required roles
+/// than the floor on a Tier 1 diff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SeatAdmissionVerdict {
+    Accepted,
+    Rejected { missing_roles: Vec<String> },
+}
+
+/// Check the master's *declared* child-lane role set against the policy
+/// floor. Tier 0 has an empty floor and always accepts. Tier 1 requires
+/// the declared roles (by label, matching `ReviewerLanePlan::role`) to be a
+/// superset of `floor.seats`'s roles -- a set-superset comparison, which is
+/// an oracle question (ADR 0004 decision 4), not a quality judgment. This
+/// function never inspects a lane's prompt, scope, or model -- only its
+/// declared role label, which the master itself writes at runtime.
+pub fn admit_seat_plan(
+    tier: DiffTier,
+    floor: &Tier1Floor,
+    declared_child_lanes: &[ReviewerLanePlan],
+) -> SeatAdmissionVerdict {
+    if tier == DiffTier::Tier0 {
+        return SeatAdmissionVerdict::Accepted;
+    }
+    let declared_roles: HashSet<&str> = declared_child_lanes
+        .iter()
+        .map(|lane| lane.role.as_str())
+        .collect();
+    let missing_roles: Vec<String> = floor
+        .seats
+        .iter()
+        .filter(|seat| !declared_roles.contains(seat.role.as_str()))
+        .map(|seat| seat.role.clone())
+        .collect();
+    if missing_roles.is_empty() {
+        SeatAdmissionVerdict::Accepted
+    } else {
+        SeatAdmissionVerdict::Rejected { missing_roles }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn changed(
+        path: &str,
+        status: FileStatus,
+        additions: Option<u32>,
+        deletions: Option<u32>,
+    ) -> ChangedFile {
+        ChangedFile {
+            path: path.to_string(),
+            status,
+            old_path: None,
+            additions,
+            deletions,
+        }
+    }
+
+    fn lane(role: &str) -> ReviewerLanePlan {
+        ReviewerLanePlan {
+            id: format!("lane-{role}"),
+            role: role.to_string(),
+            objective: "test".to_string(),
+            scope: Vec::new(),
+            allowed_context_tier: "diff_only".to_string(),
+            substrate: "fixture".to_string(),
+            model: None,
+            cost_budget_usd: None,
+            stop_condition: "test".to_string(),
+            expected_output: "ReviewerLaneReceipt.v1".to_string(),
+        }
+    }
+
+    #[test]
+    fn embedded_seat_policy_loads_and_carries_the_mandatory_heuristic_dimension() {
+        let policy = load_seat_policy().unwrap();
+        assert_eq!(policy.schema_version, SEAT_POLICY_SCHEMA);
+        assert_eq!(policy.tier1_floor.seat_count, 4);
+        assert_eq!(policy.tier1_floor.seats.len(), 4);
+        assert!(policy
+            .tier1_floor
+            .seats
+            .iter()
+            .any(|seat| seat.dimension == SeatDimension::HeuristicTool));
+    }
+
+    #[test]
+    fn validate_seat_policy_rejects_duplicate_roles() {
+        let policy = SeatPolicy {
+            schema_version: SEAT_POLICY_SCHEMA.to_string(),
+            tier1_floor: Tier1Floor {
+                seat_count: 2,
+                seats: vec![
+                    RequiredSeat {
+                        role: "duplicate-role".to_string(),
+                        dimension: SeatDimension::ModelJudgment,
+                    },
+                    RequiredSeat {
+                        role: "duplicate-role".to_string(),
+                        dimension: SeatDimension::HeuristicTool,
+                    },
+                ],
+            },
+        };
+        let error = validate_seat_policy(policy).unwrap_err();
+        assert!(error.to_string().contains("duplicate role"));
+    }
+
+    #[test]
+    fn validate_seat_policy_rejects_missing_heuristic_dimension() {
+        let policy = SeatPolicy {
+            schema_version: SEAT_POLICY_SCHEMA.to_string(),
+            tier1_floor: Tier1Floor {
+                seat_count: 1,
+                seats: vec![RequiredSeat {
+                    role: "only-model-seat".to_string(),
+                    dimension: SeatDimension::ModelJudgment,
+                }],
+            },
+        };
+        let error = validate_seat_policy(policy).unwrap_err();
+        assert!(error.to_string().contains("heuristic_tool"));
+    }
+
+    #[test]
+    fn validate_seat_policy_rejects_seat_count_mismatch() {
+        let policy = SeatPolicy {
+            schema_version: SEAT_POLICY_SCHEMA.to_string(),
+            tier1_floor: Tier1Floor {
+                seat_count: 2,
+                seats: vec![RequiredSeat {
+                    role: "only-one-seat".to_string(),
+                    dimension: SeatDimension::HeuristicTool,
+                }],
+            },
+        };
+        let error = validate_seat_policy(policy).unwrap_err();
+        assert!(error.to_string().contains("seat_count"));
+    }
+
+    #[test]
+    fn empty_changeset_classifies_as_tier0() {
+        assert_eq!(classify_diff_tier(&[]), DiffTier::Tier0);
+    }
+
+    #[test]
+    fn pure_rename_with_zero_delta_classifies_as_tier0() {
+        let files = vec![changed("b.rs", FileStatus::Renamed, Some(0), Some(0))];
+        assert_eq!(classify_diff_tier(&files), DiffTier::Tier0);
+    }
+
+    #[test]
+    fn pure_copy_with_zero_delta_classifies_as_tier0() {
+        let files = vec![changed("b.rs", FileStatus::Copied, Some(0), Some(0))];
+        assert_eq!(classify_diff_tier(&files), DiffTier::Tier0);
+    }
+
+    #[test]
+    fn modified_file_classifies_as_tier1() {
+        let files = vec![changed("a.rs", FileStatus::Modified, Some(3), Some(1))];
+        assert_eq!(classify_diff_tier(&files), DiffTier::Tier1);
+    }
+
+    #[test]
+    fn rename_with_nonzero_delta_classifies_as_tier1() {
+        let files = vec![changed("b.rs", FileStatus::Renamed, Some(1), Some(0))];
+        assert_eq!(classify_diff_tier(&files), DiffTier::Tier1);
+    }
+
+    #[test]
+    fn rename_with_unknown_delta_classifies_as_tier1() {
+        let files = vec![changed("b.rs", FileStatus::Renamed, None, None)];
+        assert_eq!(classify_diff_tier(&files), DiffTier::Tier1);
+    }
+
+    #[test]
+    fn mixed_changeset_with_one_real_edit_classifies_as_tier1() {
+        let files = vec![
+            changed("b.rs", FileStatus::Renamed, Some(0), Some(0)),
+            changed("a.rs", FileStatus::Added, Some(10), Some(0)),
+        ];
+        assert_eq!(classify_diff_tier(&files), DiffTier::Tier1);
+    }
+
+    #[test]
+    fn tier0_admission_accepts_with_no_declared_lanes() {
+        let policy = load_seat_policy().unwrap();
+        let verdict = admit_seat_plan(DiffTier::Tier0, &policy.tier1_floor, &[]);
+        assert_eq!(verdict, SeatAdmissionVerdict::Accepted);
+    }
+
+    #[test]
+    fn tier1_admission_accepts_declared_superset_of_floor() {
+        let policy = load_seat_policy().unwrap();
+        let mut declared: Vec<ReviewerLanePlan> = policy
+            .tier1_floor
+            .seats
+            .iter()
+            .map(|seat| lane(&seat.role))
+            .collect();
+        // The master may add lanes beyond the floor.
+        declared.push(lane("extra-risk-triggered-lane"));
+        let verdict = admit_seat_plan(DiffTier::Tier1, &policy.tier1_floor, &declared);
+        assert_eq!(verdict, SeatAdmissionVerdict::Accepted);
+    }
+
+    #[test]
+    fn tier1_admission_rejects_when_declared_lanes_undershoot_the_floor() {
+        let policy = load_seat_policy().unwrap();
+        // Drop the last required role.
+        let declared: Vec<ReviewerLanePlan> = policy
+            .tier1_floor
+            .seats
+            .iter()
+            .take(policy.tier1_floor.seats.len() - 1)
+            .map(|seat| lane(&seat.role))
+            .collect();
+        let verdict = admit_seat_plan(DiffTier::Tier1, &policy.tier1_floor, &declared);
+        match verdict {
+            SeatAdmissionVerdict::Rejected { missing_roles } => {
+                assert_eq!(missing_roles.len(), 1);
+                assert_eq!(
+                    missing_roles[0],
+                    policy.tier1_floor.seats.last().unwrap().role
+                );
+            }
+            SeatAdmissionVerdict::Accepted => {
+                panic!("expected rejection for an undershot lane set")
+            }
+        }
+    }
+
+    #[test]
+    fn tier1_admission_rejects_empty_declared_lanes() {
+        let policy = load_seat_policy().unwrap();
+        let verdict = admit_seat_plan(DiffTier::Tier1, &policy.tier1_floor, &[]);
+        match verdict {
+            SeatAdmissionVerdict::Rejected { missing_roles } => {
+                assert_eq!(missing_roles.len(), policy.tier1_floor.seats.len());
+            }
+            SeatAdmissionVerdict::Accepted => {
+                panic!("expected rejection for zero declared lanes on Tier 1")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Outcome

Implements Powder `cerberus-049` / ADR 0004 decisions 1, 2, and 4. Stacked on #527 (seat-policy-reconciliation ADRs) -> #526 (harness extraction) -> #525 (Phase 0), all open and unmerged.

## Change

- `src/seat_policy.rs` (new): a deterministic Tier 0 (no meaningful diff)/Tier 1 (meaningful diff) classifier over `ChangedFile` shape (renames/copies with zero content delta are Tier 0; anything else -- including unknown line counts -- is conservatively Tier 1); a trusted, versioned, compile-time-embedded seat-policy data file (`config/seat_policy.json`, schema `cerberus.seat_policy.v1`) naming exactly four mandatory Tier 1 seat roles including the mandatory Factory `HeuristicTool` dimension; and `admit_seat_plan`, a pure set-superset admission check between a declared child-lane role set and the policy floor.
- `src/orchestration.rs`: `build_reviewer_plan` now classifies the diff and calls a new `plan_seat_admitted_lanes` helper -- Tier 0 stays `LaneDecisionMode::SingleMaster` with an empty `child_lanes`; Tier 1 constructs one planned (not launched) `ReviewerLanePlan` per floor seat, naming only the role label (`model: None` -- the master decides the model at launch time, never Rust), admits it against the floor, and fails closed on a bug. `SynthesisPlan` is now tier-aware via a new `synthesis_plan_for_tier` helper, replacing a stale note that unconditionally said "No child lanes were launched" even when 4 lanes were just planned.
- `sanitize_lane_id` deduped to delegate to the existing (now `pub(crate)`) `request::sanitize_id` instead of reimplementing the same normalization.
- `scripts/verify.sh`: new black-box scenario asserting a Tier 1 fixture request's `reviewer_plan.json` carries the 4 floor lanes and `PlannedChildLanes` mode.

Seat-policy data names role/dimension labels and a count only -- never a persona system prompt or a fixed provider/model string, per ADR 0004's residual-risk paragraph (verified explicitly by the adversarial review below).

## Non-goals (explicit, tracked separately)

- No live multi-model lane launch (`launch_planned_child_lanes` stays unwired) -- that's `cerberus-054`, gated on `cerberus-049`+`050`+`051`+`052` all landing.
- No seat receipt identity/family validation -- that's `cerberus-050`, blocked on this card.
- No risk classifier that adds seats above the floor beyond the superset-accepting admission check -- explicitly deferred per the module's own doc comments; the floor is the whole of this card's scope.

## Verification

- `./scripts/verify.sh`: full green (fmt, clippy -D warnings, full test suite -- 157 lib tests including 9 new seat-policy/tier-classification/admission tests, 13 main tests, 4 schema tests, 1 kernel integration test -- Docker-backed container red-team block, gitleaks, black-box CLI scenarios).
- Fresh adversarial review (GLM 5.2, cross-model; Grok/agent='cerberus' was down fleet-wide with real 403 spend-limit/429 rate-limit errors across every attempt this session -- I ran the review directly): verdict **WARN**, `safe_to_open_pr: true`. One "important" finding: this branch (built off the harness-extraction branch) didn't yet include the ADR 0004 doc it cites throughout -- resolved by rebasing onto #527's branch (which carries that ADR) before opening this PR, with zero code changes (clean patch reapply, unchanged diff content, re-verified green after rebase). Remaining findings were advisory only: the admission gate's only live caller can't currently exercise the `Rejected` branch (self-check, documented, proven separately by direct unit tests of `admit_seat_plan`); `verify.sh` hardcodes the 4-seat floor's literal role strings rather than deriving them from `config/seat_policy.json` (low-impact coupling); no risk classifier exists yet (explicitly out of scope, see Non-goals).

## Boundaries

No merge or deploy. This PR only adds deterministic admission machinery -- it does not launch a single real model call.